### PR TITLE
Feature/unify no explicit calls to mangrove

### DIFF
--- a/src/periphery/MangroveOrder.sol
+++ b/src/periphery/MangroveOrder.sol
@@ -198,15 +198,15 @@ contract MangroveOrder is Forwarder, IOrderLogic {
     uint fund
   ) internal returns (uint refund) {
     res.offerId = _newOffer(
-      NewOfferArgs({
+      OfferArgs({
         outbound_tkn: outbound_tkn,
         inbound_tkn: inbound_tkn,
         wants: tko.makerWants - (res.takerGot + res.fee), // tko.makerWants is before slippage
         gives: tko.makerGives - res.takerGave,
         gasreq: offerGasreq() + additionalGasreq, // using default gasreq of the strat + potential admin defined increase
+        gasprice: 0, // ignored
         pivotId: tko.pivotId,
         fund: fund,
-        caller: msg.sender,
         noRevert: true // returns 0 when MGV reverts
       })
     );

--- a/src/strategies/interfaces/IOfferLogic.sol
+++ b/src/strategies/interfaces/IOfferLogic.sol
@@ -101,6 +101,27 @@ interface IOfferLogic is IMaker {
   ///@dev Since a call is made to the `receiver`, this function is subject to reentrancy.
   function withdrawFromMangrove(uint amount, address payable receiver) external;
 
+  ///@notice Memory allocation for `_new/updateOffer`'s arguments.
+  ///@param outbound_tkn outbound token of the offer list.
+  ///@param inbound_tkn inbound token of the offer list.
+  ///@param wants the amount of inbound tokens the maker wants for a complete fill.
+  ///@param gives the amount of outbound tokens the maker gives for a complete fill.
+  ///@param gasreq gas required for trade execution.
+  ///@param pivotId a best pivot estimate for cheap offer insertion in the offer list.
+  ///@param fund WEIs in `this` contract's balance that are used to provision the offer.
+  ///@param noRevert is set to true if calling function does not wish `_newOffer` to revert on error.
+  struct OfferArgs {
+    IERC20 outbound_tkn;
+    IERC20 inbound_tkn;
+    uint wants;
+    uint gives;
+    uint gasreq;
+    uint gasprice;
+    uint pivotId;
+    uint fund;
+    bool noRevert;
+  }
+
   ///@notice updates an offer existing on Mangrove (not necessarily live).
   ///@param outbound_tkn the outbound token of the offer list of the offer
   ///@param inbound_tkn the outbound token of the offer list of the offer

--- a/src/strategies/offer_forwarder/OfferForwarder.sol
+++ b/src/strategies/offer_forwarder/OfferForwarder.sol
@@ -36,7 +36,7 @@ contract OfferForwarder is IMakerLogic, Forwarder {
     uint gasreq,
     uint gasprice, // keeping gasprice here in order to expose the same interface as `OfferMaker` contracts.
     uint pivotId
-  ) external payable returns (uint offerId) {
+  ) public payable returns (uint offerId) {
     gasprice; // ignoring gasprice that will be derived based on msg.value.
     offerId = _newOffer(
       OfferArgs({

--- a/src/strategies/offer_forwarder/OfferForwarder.sol
+++ b/src/strategies/offer_forwarder/OfferForwarder.sol
@@ -51,6 +51,5 @@ contract OfferForwarder is IMakerLogic, Forwarder {
         noRevert: false // propagates Mangrove's revert data in case of newOffer failure
       })
     );
-    require(offerId != 0, "OfferForwarder/newOfferFailed");
   }
 }

--- a/src/strategies/offer_forwarder/OfferForwarder.sol
+++ b/src/strategies/offer_forwarder/OfferForwarder.sol
@@ -39,14 +39,14 @@ contract OfferForwarder is IMakerLogic, Forwarder {
   ) external payable returns (uint offerId) {
     gasprice; // ignoring gasprice that will be derived based on msg.value.
     offerId = _newOffer(
-      NewOfferArgs({
+      OfferArgs({
         outbound_tkn: outbound_tkn,
         inbound_tkn: inbound_tkn,
         wants: wants,
         gives: gives,
         gasreq: gasreq,
+        gasprice: 0,
         pivotId: pivotId,
-        caller: msg.sender,
         fund: msg.value,
         noRevert: false // propagates Mangrove's revert data in case of newOffer failure
       })

--- a/src/strategies/offer_maker/OfferMaker.sol
+++ b/src/strategies/offer_maker/OfferMaker.sol
@@ -44,14 +44,18 @@ contract OfferMaker is IMakerLogic, Direct {
     uint gasprice,
     uint pivotId
   ) external payable override onlyAdmin returns (uint offerId) {
-    offerId = MGV.newOffer{value: msg.value}(
-      address(outbound_tkn),
-      address(inbound_tkn),
-      wants,
-      gives,
-      gasreq >= type(uint24).max ? offerGasreq() : gasreq,
-      gasprice,
-      pivotId
+    offerId = _newOffer(
+      OfferArgs({
+        outbound_tkn: outbound_tkn,
+        inbound_tkn: inbound_tkn,
+        wants: wants,
+        gives: gives,
+        gasreq: gasreq,
+        gasprice: gasprice,
+        pivotId: pivotId,
+        fund: msg.value,
+        noRevert: false
+      })
     );
   }
 }

--- a/src/strategies/offer_maker/OfferMaker.sol
+++ b/src/strategies/offer_maker/OfferMaker.sol
@@ -43,7 +43,7 @@ contract OfferMaker is IMakerLogic, Direct {
     uint gasreq,
     uint gasprice,
     uint pivotId
-  ) external payable override onlyAdmin returns (uint offerId) {
+  ) public payable override mgvOrAdmin returns (uint offerId) {
     offerId = _newOffer(
       OfferArgs({
         outbound_tkn: outbound_tkn,

--- a/test/strategies/unit/MakerPermissions.t.sol
+++ b/test/strategies/unit/MakerPermissions.t.sol
@@ -51,7 +51,7 @@ contract MakerPermissionTest is MangroveTest {
   }
 
   function testCannot_PostNewOffer() public {
-    vm.expectRevert("AccessControlled/Invalid");
+    vm.expectRevert("mgvOffer/unauthorized");
     makerContract.newOffer{value: 0.1 ether}({
       outbound_tkn: weth,
       inbound_tkn: usdc,


### PR DESCRIPTION
In this PR both `Forwarder` and `Direct` strats now have a similar scheme to write offers:
* an internal `_update/_newOffer` function that performs the call to `MGV` (and maintain logic if necessary)
* a public `updateOffer` function that calls the internal variant with additional guards.
* for deployable strats a public `newOffer` function that also calls the internal variant.

The public versions always reverts if mangrove reverts. When writing an offer in a hook one can use the internal variant and set `noRevert` to `false` in order to avoid throwing (internal calls to public functions cannot be encapsulated in a `try` `catch`).
