### PR TITLE
fix: increase mangrove core coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "prepack": "pinst --disable && yarn build",
     "postpack": "pinst --enable",
     "postinstall": "husky install",
+    "corecov": "forge coverage --match-path 'test/core/*'",
     "build": "forge build && node copyArtifacts && node buildIndex",
     "clean": "forge clean; rimraf index.js dist",
     "doc": "solcco -f doc/MgvDoc.html preprocessing/structs.js src/MgvLib.sol src/MgvRoot.sol src/MgvHasOffers.sol src/MgvOfferMaking.sol src/MgvOfferTaking.sol src/MgvOfferTakingWithPermit.sol src/MgvGovernable.sol src/AbstractMangrove.sol src/Mangrove.sol src/InvertedMangrove.sol",

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -479,7 +479,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
         } else if (mgvData == "mgv/takerTransferFail") {
           revert("mgv/takerTransferFail");
         } else {
-          /* This code must be unreachable. **Danger**: if a well-crafted offer/maker pair can force a revert of `flashloan`, the Mangrove will be stuck. */
+          /* This code must be unreachable except if the call to flashloan went OOG and there is enough gas to revert here. **Danger**: if a well-crafted offer/maker pair can force a revert of `flashloan`, the Mangrove will be stuck. */
           revert("mgv/swapError");
         }
       }

--- a/test/core/MakerOperations.t.sol
+++ b/test/core/MakerOperations.t.sol
@@ -862,12 +862,6 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     bytes32 data = vm.load(address(mgv), slot);
     MgvStructs.LocalPacked local = MgvStructs.LocalPacked.wrap(uint(data));
     local = local.last(type(uint32).max);
-    unchecked {
-      console.log("last", local.last());
-      console.log("last+1", 1 + local.last());
-      uint upd = 1 + local.last();
-      console.log("last+1", uint32(upd) == upd);
-    }
     vm.store(address(mgv), slot, bytes32(MgvStructs.LocalPacked.unwrap(local)));
 
     // try new offer now that we set the last id to uint32.max

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -103,8 +103,8 @@ contract TakerOperationsTest is MangroveTest {
     (uint successes, uint got, uint gave,,) =
       mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 0.5 ether, 1 ether, 100_000]), true);
     assertTrue(successes == 1, "Snipe should not fail");
-    assertEq(got, 0.5 ether, "Taker did not get enough");
-    assertEq(gave, 0.5 ether, "Taker did not give enough");
+    assertEq(got, 0.5 ether, "Taker did not get correct amount");
+    assertEq(gave, 0.5 ether, "Taker did not give correct amount");
   }
 
   function test_multiple_snipes_fillWants() public {
@@ -131,8 +131,8 @@ contract TakerOperationsTest is MangroveTest {
 
     (uint successes, uint got, uint gave,,) = mgv.snipes($(base), $(quote), targets, true);
     assertTrue(successes == 3, "Snipes should not fail");
-    assertEq(got, 2.3 ether, "Taker did not get enough");
-    assertEq(gave, 2.3 ether, "Taker did not give enough");
+    assertEq(got, 2.3 ether, "Taker did not get correct amount");
+    assertEq(gave, 2.3 ether, "Taker did not give correct amount");
   }
 
   event Transfer(address indexed from, address indexed to, uint value);
@@ -212,8 +212,8 @@ contract TakerOperationsTest is MangroveTest {
     (uint successes, uint got, uint gave,,) =
       mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 0.5 ether, 1 ether, 100_000]), false);
     assertTrue(successes == 1, "Snipe should not fail");
-    assertEq(got, 1 ether, "Taker did not get enough");
-    assertEq(gave, 1 ether, "Taker did not get enough");
+    assertEq(got, 1 ether, "Taker did not get correct amount");
+    assertEq(gave, 1 ether, "Taker did not get correct amount");
   }
 
   function test_mo_fillWants() public {
@@ -222,8 +222,8 @@ contract TakerOperationsTest is MangroveTest {
     mkr.expect("mgv/tradeSuccess"); // trade should be OK on the maker side
     quote.approve($(mgv), 2 ether);
     (uint got, uint gave,,) = mgv.marketOrder($(base), $(quote), 1.1 ether, 2 ether, true);
-    assertEq(got, 1.1 ether, "Taker did not get enough");
-    assertEq(gave, 1.1 ether, "Taker did not get enough");
+    assertEq(got, 1.1 ether, "Taker did not get correct amount");
+    assertEq(gave, 1.1 ether, "Taker did not get correct amount");
   }
 
   function test_mo_fillGives() public {
@@ -232,8 +232,8 @@ contract TakerOperationsTest is MangroveTest {
     mkr.expect("mgv/tradeSuccess"); // trade should be OK on the maker side
     quote.approve($(mgv), 2 ether);
     (uint got, uint gave,,) = mgv.marketOrder($(base), $(quote), 1.1 ether, 2 ether, false);
-    assertEq(got, 2 ether, "Taker did not get enough");
-    assertEq(gave, 2 ether, "Taker did not get enough");
+    assertEq(got, 2 ether, "Taker did not get correct amount");
+    assertEq(gave, 2 ether, "Taker did not give correct amount");
   }
 
   function test_mo_fillGivesAll_no_approved_fails() public {
@@ -253,8 +253,8 @@ contract TakerOperationsTest is MangroveTest {
     mkr.expect("mgv/tradeSuccess"); // trade should be OK on the maker side
     quote.approve($(mgv), 3 ether);
     (uint got, uint gave,,) = mgv.marketOrder($(base), $(quote), 0 ether, 3 ether, false);
-    assertEq(got, 3 ether, "Taker did not get enough");
-    assertEq(gave, 3 ether, "Taker did not get enough");
+    assertEq(got, 3 ether, "Taker did not get correct amount");
+    assertEq(gave, 3 ether, "Taker did not get correct amount");
   }
 
   function test_taker_reimbursed_if_maker_doesnt_pay() public {

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -685,7 +685,13 @@ contract TakerOperationsTest is MangroveTest {
     assertEq(gave, 0 ether, "Taker gave too much");
   }
 
-  /* When Mangrove gets a revert from `flashloan` that doesn't match known revert cases, it returns `mgv/swapError`. This can happen if the flashloan runs out of gas, but should never happen in another case. I (adhusson) did not manage to trigger the 'flash loan is OOG' condition because flashloan itself uses very little gas. If you make it OOG, then its caller will OOG too before reaching the `revert("mgv/swapError")` statement. To trigger that error, I make a BadMangrove contract with a misbehaving `flashloan` function. */
+  /* When Mangrove gets a revert from `flashloan` that doesn't match known revert
+   * cases, it returns `mgv/swapError`. This can happen if the flashloan runs out
+   * of gas, but should never happen in another case. I (adhusson) did not manage
+   * to trigger the 'flash loan is OOG' condition because flashloan itself uses
+   * very little gas. If you make it OOG, then its caller will OOG too before
+   * reaching the `revert("mgv/swapError")` statement. To trigger that error, I
+   * make a BadMangrove contract with a misbehaving `flashloan` function. */
   function test_unreachable_swapError() public {
     BadMangrove badMgv = new BadMangrove({
       governance: $(this),


### PR DESCRIPTION
Coverage is "really" 100% but (I'm guessing) some revert conditions make `forge coverage` not mark everything as covered.

See #29.