### PR TITLE
feat: add market order simulation to mgvreader

### DIFF
--- a/test/lib/Test2.sol
+++ b/test/lib/Test2.sol
@@ -155,12 +155,12 @@ contract Test2 is Test, Script2 {
     return gasDelta;
   }
 
-  function gas_(string memory msg) internal virtual returns (uint) {
+  function gas_(string memory gasLabel) internal virtual returns (uint) {
     uint checkpointGasLeft2 = gasleft();
 
     uint gasDelta = checkpointGasLeft - checkpointGasLeft2;
 
-    console2.log("Gas used in: %s: %s", msg, gasDelta);
+    console2.log("Gas used in: %s: %s", gasLabel, gasDelta);
     // emit log_named_uint(string.concat("Gas used in: ",msg), gasDelta);
     return gasDelta;
   }

--- a/test/lib/Test2.sol
+++ b/test/lib/Test2.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.13;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, console2} from "forge-std/Test.sol";
 import {Script2} from "./Script2.sol";
 
 /* Some ease-of-life additions to forge-std/Test.sol */
@@ -137,23 +137,31 @@ contract Test2 is Test, Script2 {
 
   /* *** Gas Metering *** */
 
-  uint private checkpointGasLeft = 1; // Start the slot non0.
-  string checkpointLabel;
-
+  uint private checkpointGasLeft;
   /* start measuring gas */
-  function _gas() internal virtual {
-    // checkpointLabel = label;
 
+  function _gas() internal virtual {
     checkpointGasLeft = gasleft();
   }
 
   /* stop measuring gas and report */
-  function gas_() internal virtual {
+  function gas_() internal virtual returns (uint) {
     uint checkpointGasLeft2 = gasleft();
 
-    // Subtract 100 to account for the warm SLOAD in startMeasuringGas.
-    uint gasDelta = checkpointGasLeft - checkpointGasLeft2 - 100;
+    uint gasDelta = checkpointGasLeft - checkpointGasLeft2;
 
-    emit log_named_uint("Gas used", gasDelta);
+    // emit log_named_uint("Gas used", gasDelta);
+    console2.log("Gas used: %s", gasDelta);
+    return gasDelta;
+  }
+
+  function gas_(string memory msg) internal virtual returns (uint) {
+    uint checkpointGasLeft2 = gasleft();
+
+    uint gasDelta = checkpointGasLeft - checkpointGasLeft2;
+
+    console2.log("Gas used in: %s: %s", msg, gasDelta);
+    // emit log_named_uint(string.concat("Gas used in: ",msg), gasDelta);
+    return gasDelta;
   }
 }

--- a/test/periphery/MgvReader.t.sol
+++ b/test/periphery/MgvReader.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.10;
 
 import "mgv_test/lib/MangroveTest.sol";
 
-import {MgvReader} from "src/periphery/MgvReader.sol";
+import {MgvReader, VolumeData} from "src/periphery/MgvReader.sol";
 import {MgvStructs} from "src/MgvLib.sol";
 
 // In these tests, the testing contract is the market maker.
@@ -152,4 +152,103 @@ contract MgvReaderTest is MangroveTest {
     mgv.setUseOracle(true);
     try_provision();
   }
+
+  function test_marketOrder_0() public {
+    VolumeData[] memory vd = reader.marketOrder($(base), $(quote), 1 ether, 1 ether, true);
+
+    assertEq(vd.length, 0);
+  }
+
+  function test_marketOrder_no_match() public {
+    mkr.newOffer(1.1 ether, 1 ether, 0, 0);
+    VolumeData[] memory vd = reader.marketOrder($(base), $(quote), 1 ether, 1 ether, true);
+
+    assertEq(vd.length, 0);
+  }
+
+  function test_marketOrder_partial_fillWants() public {
+    mkr.newOffer(1 ether, 1 ether, 0, 0);
+    VolumeData[] memory vd = reader.marketOrder($(base), $(quote), 0.8 ether, 0.9 ether, true);
+    assertEq(vd.length, 1, "bad vd length");
+    assertEq(vd[0].totalGot, 0.8 ether, "bad totalGot");
+    assertEq(vd[0].totalGave, 0.8 ether, "bad totalGave");
+  }
+
+  function test_marketOrder_partial_noFillWants() public {
+    mkr.newOffer(1 ether, 1 ether, 0, 0);
+    VolumeData[] memory vd = reader.marketOrder($(base), $(quote), 0.3 ether, 0.9 ether, false);
+    assertEq(vd.length, 1, "bad vd length");
+    assertEq(vd[0].totalGot, 0.9 ether, "bad totalGot");
+    assertEq(vd[0].totalGave, 0.9 ether, "bad totalGave");
+  }
+
+  function test_marketOrder_full_fillWants() public {
+    mkr.newOffer(1 ether, 1 ether, 0, 0);
+    VolumeData[] memory vd = reader.marketOrder($(base), $(quote), 1 ether, 1 ether, true);
+    assertEq(vd.length, 1, "bad vd length");
+    assertEq(vd[0].totalGot, 1 ether, "bad totalGot");
+    assertEq(vd[0].totalGave, 1 ether, "bad totalGave");
+  }
+
+  function test_marketOrder_full_noFillWants() public {
+    mkr.newOffer(1 ether, 1.1 ether, 0, 0);
+    VolumeData[] memory vd = reader.marketOrder($(base), $(quote), 0.5 ether, 1 ether, false);
+    assertEq(vd.length, 1, "bad vd length");
+    assertEq(vd[0].totalGot, 1.1 ether, "bad totalGot");
+    assertEq(vd[0].totalGave, 1 ether, "bad totalGave");
+  }
+
+  function test_marketOrder_partial_due_to_price_fillWants() public {
+    mkr.newOffer(1 ether, 1 ether, 0, 0);
+    mkr.newOffer(1 ether, 0.8 ether, 0, 0);
+    VolumeData[] memory vd = reader.marketOrder($(base), $(quote), 1.4 ether, 1.5 ether, true);
+    assertEq(vd.length, 2, "bad vd length");
+    assertEq(vd[0].totalGot, 1 ether, "bad totalGot[0]");
+    assertEq(vd[0].totalGave, 1 ether, "bad totalGave[0]");
+    assertEq(vd[1].totalGot, 1.4 ether, "bad totalGot[1]");
+    assertEq(vd[1].totalGave, 1.5 ether, "bad totalGave[1]");
+  }
+
+  function test_marketOrder_gas() public {
+    mkr.newOffer(1 ether, 1 ether, 214_000, 0);
+    mkr.newOffer(1 ether, 1 ether, 216_000, 0);
+    VolumeData[] memory vd = reader.marketOrder($(base), $(quote), 1.4 ether, 1.5 ether, true);
+    assertEq(vd.length, 2, "bad vd length");
+    assertEq(vd[0].totalGasreq, 214_000, "bad totalGasreq[0]");
+    assertEq(vd[1].totalGasreq, 214_000 + 216_000, "bad totalGasreq[1]");
+  }
+
+  function test_marketOrder_fee(uint8 fee) public {
+    vm.assume(fee <= 500);
+    mgv.setFee($(base), $(quote), fee);
+    mkr.newOffer(0.3 ether, 0.3 ether, 0, 0);
+    VolumeData[] memory vd = reader.marketOrder($(base), $(quote), 0.3 ether, 0.3 ether, true);
+    assertEq(vd.length, 1, "bad vd length");
+    assertEq(vd[0].totalGot, minusFee($(base), $(quote), 0.3 ether), "bad totalGot");
+    assertEq(vd[0].totalGave, 0.3 ether, "bad totalGave");
+  }
+
+  function test_marketOrder_volumeData_length(uint8 numOffers) public {
+    vm.assume(numOffers < 12);
+    for (uint i = 0; i < numOffers; i++) {
+      mkr.newOffer(0.1 ether, 0.1 ether, 0, 0);
+    }
+    VolumeData[] memory vd = reader.marketOrder($(base), $(quote), numOffers * 0.1 ether, numOffers * 0.1 ether, true);
+    assertEq(vd.length, numOffers, "bad vd length");
+    for (uint i = 0; i < numOffers; i++) {
+      assertEq(vd[i].totalGot, (i + 1) * 0.1 ether, string.concat("bad totalGot ", vm.toString(i)));
+      assertEq(vd[i].totalGave, (i + 1) * 0.1 ether, string.concat("bad totalGave", vm.toString(i)));
+    }
+  }
+}
+
+function printVolumeData(VolumeData[] memory vd) view {
+  console.log("====================");
+  console.log("Volume Data size: %s", vd.length);
+  for (uint i = 0; i < vd.length; i++) {
+    console.log("got %s", vd[i].totalGot);
+    console.log("gave %s", vd[i].totalGave);
+    console.log("___________");
+  }
+  console.log("====================");
 }

--- a/test/periphery/MgvReader.t.sol
+++ b/test/periphery/MgvReader.t.sol
@@ -255,7 +255,7 @@ contract MgvReaderTest is MangroveTest {
     uint volume = prepareOffers(numOffers);
     if (doSim) {
       _gas();
-      VolumeData[] memory vd = reader.marketOrder($(base), $(quote), volume, volume, true);
+      reader.marketOrder($(base), $(quote), volume, volume, true);
       sumGas += gas_("simulation");
     }
     _gas();


### PR DESCRIPTION
fixes #25
todo: add tests that measure the gas difference between running a vanilla marketOrder and one after the simulation