### PR TITLE
fix(package): Fix imports

### DIFF
--- a/script/ActivateMarket.s.sol
+++ b/script/ActivateMarket.s.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.13;
 
 import {Deployer} from "mgv_script/lib/Deployer.sol";
-import {MgvOracle} from "src/periphery/MgvOracle.sol";
-import "src/Mangrove.sol";
+import {MgvOracle} from "mgv_src/periphery/MgvOracle.sol";
+import "mgv_src/Mangrove.sol";
 import {ERC20} from "../test/lib/tokens/ERC20.sol";
 
 import {ActivateSemibook} from "./ActivateSemibook.s.sol";
@@ -13,8 +13,7 @@ import {ActivateSemibook} from "./ActivateSemibook.s.sol";
  TKN1_IN_GWEI=$(cast tun 7.5ether gwei) \
  TKN2_IN_GWEI=$(cast tun 7.1 eth gwei) \
  FEE=30 \
- forge script --fork-url mumbai ActivateMarket
-*/
+ forge script --fork-url mumbai ActivateMarket*/
 
 contract ActivateMarket is Deployer {
   function run() public {

--- a/script/ActivateMarket.s.sol
+++ b/script/ActivateMarket.s.sol
@@ -13,7 +13,8 @@ import {ActivateSemibook} from "./ActivateSemibook.s.sol";
  TKN1_IN_GWEI=$(cast tun 7.5ether gwei) \
  TKN2_IN_GWEI=$(cast tun 7.1 eth gwei) \
  FEE=30 \
- forge script --fork-url mumbai ActivateMarket*/
+ forge script --fork-url mumbai ActivateMarket
+*/
 
 contract ActivateMarket is Deployer {
   function run() public {

--- a/script/ActivateSemibook.s.sol
+++ b/script/ActivateSemibook.s.sol
@@ -19,7 +19,8 @@ uint constant COVER_FACTOR = 100;
   outbound_in_gwei should be obtained like this:
   1. Get the price of one outbound token display unit in ETH
   2. Multiply by 10^9
-  3. Round to nearest integer*/
+  3. Round to nearest integer
+*/
 
 contract ActivateSemibook is Test2, Deployer {
   function run() public {

--- a/script/ActivateSemibook.s.sol
+++ b/script/ActivateSemibook.s.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.13;
 
 import {Deployer} from "mgv_script/lib/Deployer.sol";
 import "mgv_test/lib/Test2.sol";
-import "src/Mangrove.sol";
+import "mgv_src/Mangrove.sol";
 import {ERC20} from "mgv_test/lib/tokens/ERC20.sol";
-import {MgvStructs} from "src/MgvLib.sol";
+import {MgvStructs} from "mgv_src/MgvLib.sol";
 
 uint constant COVER_FACTOR = 100;
 
@@ -19,8 +19,7 @@ uint constant COVER_FACTOR = 100;
   outbound_in_gwei should be obtained like this:
   1. Get the price of one outbound token display unit in ETH
   2. Multiply by 10^9
-  3. Round to nearest integer
-*/
+  3. Round to nearest integer*/
 
 contract ActivateSemibook is Test2, Deployer {
   function run() public {

--- a/script/lib/MangroveDeployer.sol
+++ b/script/lib/MangroveDeployer.sol
@@ -3,12 +3,12 @@ pragma solidity ^0.8.13;
 
 import {Script} from "forge-std/Script.sol";
 
-import "src/Mangrove.sol";
-import "src/periphery/MgvReader.sol";
-import {MangroveOrderEnriched} from "src/periphery/MangroveOrderEnriched.sol";
-import {MgvCleaner} from "src/periphery/MgvCleaner.sol";
-import {MgvOracle} from "src/periphery/MgvOracle.sol";
-import {IMangrove} from "src/IMangrove.sol";
+import "mgv_src/Mangrove.sol";
+import "mgv_src/periphery/MgvReader.sol";
+import {MangroveOrderEnriched} from "mgv_src/periphery/MangroveOrderEnriched.sol";
+import {MgvCleaner} from "mgv_src/periphery/MgvCleaner.sol";
+import {MgvOracle} from "mgv_src/periphery/MgvOracle.sol";
+import {IMangrove} from "mgv_src/IMangrove.sol";
 import {Deployer} from "./Deployer.sol";
 
 contract MangroveDeployer is Deployer {

--- a/script/periphery/ActivateMangroveOrder.s.sol
+++ b/script/periphery/ActivateMangroveOrder.s.sol
@@ -15,7 +15,9 @@ import {Deployer} from "mgv_script/lib/Deployer.sol";
     The TKNS env variable should be given as a comma-separated list of names (known by ens).
     For instance:
 
-  TKNS="DAI,USDC,WETH,DAI_AAVE,USDC_AAVE,WETH_AAVE" forge script --fork-url mumbai ActivateMangroveOrder*/
+  TKNS="DAI,USDC,WETH,DAI_AAVE,USDC_AAVE,WETH_AAVE" forge script --fork-url mumbai ActivateMangroveOrder
+
+*/
 
 contract ActivateMangroveOrder is Deployer {
   function run() public {

--- a/script/periphery/ActivateMangroveOrder.s.sol
+++ b/script/periphery/ActivateMangroveOrder.s.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.13;
 
 import {console} from "forge-std/console.sol";
 import {Script2} from "mgv_test/lib/Script2.sol";
-import {MangroveOrder} from "src/periphery/MangroveOrder.sol";
-import {IERC20} from "src/MgvLib.sol";
+import {MangroveOrder} from "mgv_src/periphery/MangroveOrder.sol";
+import {IERC20} from "mgv_src/MgvLib.sol";
 import {Deployer} from "mgv_script/lib/Deployer.sol";
 
 /*  Allows MangroveOrder to trade on the tokens given in argument.
@@ -15,9 +15,7 @@ import {Deployer} from "mgv_script/lib/Deployer.sol";
     The TKNS env variable should be given as a comma-separated list of names (known by ens).
     For instance:
 
-  TKNS="DAI,USDC,WETH,DAI_AAVE,USDC_AAVE,WETH_AAVE" forge script --fork-url mumbai ActivateMangroveOrder
-
-*/
+  TKNS="DAI,USDC,WETH,DAI_AAVE,USDC_AAVE,WETH_AAVE" forge script --fork-url mumbai ActivateMangroveOrder*/
 
 contract ActivateMangroveOrder is Deployer {
   function run() public {

--- a/script/periphery/ConfigureMgvOracle.s.sol
+++ b/script/periphery/ConfigureMgvOracle.s.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.13;
 
 import {Deployer} from "mgv_script/lib/Deployer.sol";
-import {MgvOracle} from "src/periphery/MgvOracle.sol";
-import {Mangrove} from "src/Mangrove.sol";
+import {MgvOracle} from "mgv_src/periphery/MgvOracle.sol";
+import {Mangrove} from "mgv_src/Mangrove.sol";
 
 contract ConfigureMgvOracle is Deployer {
   function run() public {

--- a/script/periphery/MangroveOrderDeployer.s.sol
+++ b/script/periphery/MangroveOrderDeployer.s.sol
@@ -10,7 +10,8 @@ import {Deployer} from "mgv_script/lib/Deployer.sol";
  forge script --fork-url mumbai MangroveOrderDeployer -vvv 
     Then broadcast and verify:
  WRITE_DEPLOY=true forge script --fork-url mumbai MangroveOrderDeployer -vvv --broadcast --verify
-    Remember to activate it using ActivateMangroveOrder*/
+    Remember to activate it using ActivateMangroveOrder
+*/
 contract MangroveOrderDeployer is Deployer {
   function run() public {
     innerRun({admin: fork.get("Deployer")});

--- a/script/periphery/MangroveOrderDeployer.s.sol
+++ b/script/periphery/MangroveOrderDeployer.s.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {Script, console} from "forge-std/Script.sol";
-import {MangroveOrderEnriched, IERC20, IMangrove} from "src/periphery/MangroveOrderEnriched.sol";
+import {MangroveOrderEnriched, IERC20, IMangrove} from "mgv_src/periphery/MangroveOrderEnriched.sol";
 import {Deployer} from "mgv_script/lib/Deployer.sol";
 
 /*  Deploys a MangroveOrder instance
@@ -10,8 +10,7 @@ import {Deployer} from "mgv_script/lib/Deployer.sol";
  forge script --fork-url mumbai MangroveOrderDeployer -vvv 
     Then broadcast and verify:
  WRITE_DEPLOY=true forge script --fork-url mumbai MangroveOrderDeployer -vvv --broadcast --verify
-    Remember to activate it using ActivateMangroveOrder
-*/
+    Remember to activate it using ActivateMangroveOrder*/
 contract MangroveOrderDeployer is Deployer {
   function run() public {
     innerRun({admin: fork.get("Deployer")});

--- a/script/periphery/MgvReaderDeployer.sol
+++ b/script/periphery/MgvReaderDeployer.sol
@@ -9,7 +9,8 @@ import {Deployer} from "mgv_script/lib/Deployer.sol";
     First test:
  ADMIN=$MUMBAI_PRIVATE_ADDRESS forge script --fork-url mumbai MgvReaderDeployer -vvv 
     Then broadcast and verify:
- WRITE_DEPLOY=true forge script --fork-url mumbai MgvReaderDeployer -vvv --broadcast --verify*/
+ WRITE_DEPLOY=true forge script --fork-url mumbai MgvReaderDeployer -vvv --broadcast --verify
+*/
 contract MgvReaderDeployer is Deployer {
   function run() public {
     address payable mgv = fork.get("Mangrove");

--- a/script/periphery/MgvReaderDeployer.sol
+++ b/script/periphery/MgvReaderDeployer.sol
@@ -2,15 +2,14 @@
 pragma solidity ^0.8.13;
 
 import {Script, console} from "forge-std/Script.sol";
-import {MgvReader, IMangrove} from "src/periphery/MgvReader.sol";
+import {MgvReader, IMangrove} from "mgv_src/periphery/MgvReader.sol";
 import {Deployer} from "mgv_script/lib/Deployer.sol";
 
 /*  Deploys a MangroveOrder instance
     First test:
  ADMIN=$MUMBAI_PRIVATE_ADDRESS forge script --fork-url mumbai MgvReaderDeployer -vvv 
     Then broadcast and verify:
- WRITE_DEPLOY=true forge script --fork-url mumbai MgvReaderDeployer -vvv --broadcast --verify
-*/
+ WRITE_DEPLOY=true forge script --fork-url mumbai MgvReaderDeployer -vvv --broadcast --verify*/
 contract MgvReaderDeployer is Deployer {
   function run() public {
     address payable mgv = fork.get("Mangrove");

--- a/script/strategies/InitMango.s.sol
+++ b/script/strategies/InitMango.s.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.13;
 
 import {Script, console} from "forge-std/Script.sol";
 import {Deployer} from "mgv_script/lib/Deployer.sol";
-import {Mango, IERC20, IMangrove} from "src/strategies/offer_maker/market_making/mango/Mango.sol";
+import {Mango, IERC20, IMangrove} from "mgv_src/strategies/offer_maker/market_making/mango/Mango.sol";
 
 /**
  * @notice Initialize Mango offers on a given market

--- a/script/strategies/MangoDeployer.s.sol
+++ b/script/strategies/MangoDeployer.s.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {Script, console} from "forge-std/Script.sol";
-import {Mango, IERC20, IMangrove} from "src/strategies/offer_maker/market_making/mango/Mango.sol";
+import {Mango, IERC20, IMangrove} from "mgv_src/strategies/offer_maker/market_making/mango/Mango.sol";
 import {Deployer} from "../lib/Deployer.sol";
 
 /**

--- a/script/strategies/ShiftMango.s.sol
+++ b/script/strategies/ShiftMango.s.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {Script, console} from "forge-std/Script.sol";
-import {Mango, IERC20, IMangrove} from "src/strategies/offer_maker/market_making/mango/Mango.sol";
+import {Mango, IERC20, IMangrove} from "mgv_src/strategies/offer_maker/market_making/mango/Mango.sol";
 import {Deployer} from "mgv_script/lib/Deployer.sol";
 
 /**

--- a/script/strategies/StopMango.s.sol
+++ b/script/strategies/StopMango.s.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {Script, console} from "forge-std/Script.sol";
-import {Mango, IERC20, IMangrove} from "src/strategies/offer_maker/market_making/mango/Mango.sol";
+import {Mango, IERC20, IMangrove} from "mgv_src/strategies/offer_maker/market_making/mango/Mango.sol";
 import {Deployer} from "mgv_script/lib/Deployer.sol";
 
 /**

--- a/script/toy/MangroveJs.s.sol
+++ b/script/toy/MangroveJs.s.sol
@@ -3,12 +3,12 @@ pragma solidity ^0.8.13;
 
 import {MangroveDeployer} from "mgv_script/lib/MangroveDeployer.sol";
 
-import {AbstractMangrove} from "src/AbstractMangrove.sol";
-import {IERC20} from "src/MgvLib.sol";
+import {AbstractMangrove} from "mgv_src/AbstractMangrove.sol";
+import {IERC20} from "mgv_src/MgvLib.sol";
 import {TestToken} from "mgv_test/lib/tokens/TestToken.sol";
-import {MangroveOrder} from "src/periphery/MangroveOrderEnriched.sol";
+import {MangroveOrder} from "mgv_src/periphery/MangroveOrderEnriched.sol";
 import {SimpleTestMaker} from "mgv_test/lib/agents/TestMaker.sol";
-import {IMangrove} from "src/IMangrove.sol";
+import {IMangrove} from "mgv_src/IMangrove.sol";
 import {Deployer} from "mgv_script/lib/Deployer.sol";
 
 /* 
@@ -17,9 +17,7 @@ This script prepares a local server for testing by mangrove.js.
 In the future it should a) Use mostly the normal deploy file, so there is as
 little discrepancy between real deploys and deploys that mangrove.js tests
 interact with.  b) For any additional deployments needed, those files should be
-hosted in mangrove.js.
-
-*/
+hosted in mangrove.js.*/
 
 contract MangroveJsDeploy is Deployer {
   IERC20 tokenA;

--- a/script/toy/MangroveJs.s.sol
+++ b/script/toy/MangroveJs.s.sol
@@ -17,7 +17,9 @@ This script prepares a local server for testing by mangrove.js.
 In the future it should a) Use mostly the normal deploy file, so there is as
 little discrepancy between real deploys and deploys that mangrove.js tests
 interact with.  b) For any additional deployments needed, those files should be
-hosted in mangrove.js.*/
+hosted in mangrove.js.
+
+*/
 
 contract MangroveJsDeploy is Deployer {
   IERC20 tokenA;

--- a/src/periphery/MangroveOrder.sol
+++ b/src/periphery/MangroveOrder.sol
@@ -13,12 +13,12 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import {IMangrove} from "src/IMangrove.sol";
-import {Forwarder, MangroveOffer} from "src/strategies/offer_forwarder/abstract/Forwarder.sol";
-import {IOrderLogic} from "src/strategies/interfaces/IOrderLogic.sol";
-import {SimpleRouter} from "src/strategies/routers/SimpleRouter.sol";
-import {TransferLib} from "src/strategies/utils/TransferLib.sol";
-import {MgvLib, IERC20} from "src/MgvLib.sol";
+import {IMangrove} from "mgv_src/IMangrove.sol";
+import {Forwarder, MangroveOffer} from "mgv_src/strategies/offer_forwarder/abstract/Forwarder.sol";
+import {IOrderLogic} from "mgv_src/strategies/interfaces/IOrderLogic.sol";
+import {SimpleRouter} from "mgv_src/strategies/routers/SimpleRouter.sol";
+import {TransferLib} from "mgv_src/strategies/utils/TransferLib.sol";
+import {MgvLib, IERC20} from "mgv_src/MgvLib.sol";
 
 ///@title MangroveOrder. A periphery contract to Mangrove protocol that implements "Good till cancelled" (GTC) orders as well as "Fill or kill" (FOK) orders.
 ///@notice A GTC order is a market buy (sell) order complemented by a bid (ask) order, called a resting order, that occurs when the buy (sell) order was partially filled.

--- a/src/periphery/MangroveOrderEnriched.sol
+++ b/src/periphery/MangroveOrderEnriched.sol
@@ -13,9 +13,9 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import {MangroveOrder} from "src/periphery/MangroveOrder.sol";
-import {IERC20} from "src/MgvLib.sol";
-import {IMangrove} from "src/IMangrove.sol";
+import {MangroveOrder} from "mgv_src/periphery/MangroveOrder.sol";
+import {IERC20} from "mgv_src/MgvLib.sol";
+import {IMangrove} from "mgv_src/IMangrove.sol";
 
 /**
  * @title This contract is a `MangroveOrder` enriched with the ability to retrieve all offers for each owner.

--- a/src/periphery/MgvCleaner.sol
+++ b/src/periphery/MgvCleaner.sol
@@ -34,7 +34,8 @@ import {IMangrove} from "mgv_src/IMangrove.sol";
    You can adjust takerWants/takerGives and gasreq as needed.
 
    Note: in the current version you do not need to set MgvCleaner's allowance in Mangrove.
-   TODO: add `collectWith` with an additional `taker` argument.*/
+   TODO: add `collectWith` with an additional `taker` argument.
+*/
 contract MgvCleaner {
   IMangrove immutable MGV;
 

--- a/src/periphery/MgvCleaner.sol
+++ b/src/periphery/MgvCleaner.sol
@@ -21,7 +21,7 @@ pragma solidity ^0.8.10;
 pragma abicoder v2;
 
 import {MgvLib, MgvStructs} from "../MgvLib.sol";
-import {IMangrove} from "src/IMangrove.sol";
+import {IMangrove} from "mgv_src/IMangrove.sol";
 
 /* The purpose of the Cleaner contract is to execute failing offers and collect
  * their associated bounty. It takes an array of offers with same definition as
@@ -34,8 +34,7 @@ import {IMangrove} from "src/IMangrove.sol";
    You can adjust takerWants/takerGives and gasreq as needed.
 
    Note: in the current version you do not need to set MgvCleaner's allowance in Mangrove.
-   TODO: add `collectWith` with an additional `taker` argument.
-*/
+   TODO: add `collectWith` with an additional `taker` argument.*/
 contract MgvCleaner {
   IMangrove immutable MGV;
 

--- a/src/periphery/MgvOracle.sol
+++ b/src/periphery/MgvOracle.sol
@@ -20,7 +20,7 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import "src/MgvLib.sol";
+import "mgv_src/MgvLib.sol";
 
 /* The purpose of the Oracle contract is to act as a gas price and density
  * oracle for the Mangrove. It bridges to an external oracle, and allows

--- a/src/periphery/MgvReader.sol
+++ b/src/periphery/MgvReader.sol
@@ -20,8 +20,8 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import {MgvLib, MgvStructs} from "src/MgvLib.sol";
-import {IMangrove} from "src/IMangrove.sol";
+import {MgvLib, MgvStructs} from "mgv_src/MgvLib.sol";
+import {IMangrove} from "mgv_src/IMangrove.sol";
 
 struct VolumeData {
   uint totalGot;

--- a/src/strategies/MangroveOffer.sol
+++ b/src/strategies/MangroveOffer.sol
@@ -13,12 +13,12 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import {AccessControlled} from "src/strategies/utils/AccessControlled.sol";
+import {AccessControlled} from "mgv_src/strategies/utils/AccessControlled.sol";
 import {MangroveOfferStorage as MOS} from "./MangroveOfferStorage.sol";
-import {IOfferLogic} from "src/strategies/interfaces/IOfferLogic.sol";
-import {MgvLib, IERC20, MgvStructs} from "src/MgvLib.sol";
-import {IMangrove} from "src/IMangrove.sol";
-import {AbstractRouter} from "src/strategies/routers/AbstractRouter.sol";
+import {IOfferLogic} from "mgv_src/strategies/interfaces/IOfferLogic.sol";
+import {MgvLib, IERC20, MgvStructs} from "mgv_src/MgvLib.sol";
+import {IMangrove} from "mgv_src/IMangrove.sol";
+import {AbstractRouter} from "mgv_src/strategies/routers/AbstractRouter.sol";
 
 /// @title This contract is the basic building block for Mangrove strats.
 /// @notice It contains the mandatory interface expected by Mangrove (`IOfferLogic` is `IMaker`) and enforces additional functions implementations (via `IOfferLogic`).

--- a/src/strategies/MangroveOfferStorage.sol
+++ b/src/strategies/MangroveOfferStorage.sol
@@ -13,7 +13,7 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import "src/strategies/interfaces/IOfferLogic.sol";
+import "mgv_src/strategies/interfaces/IOfferLogic.sol";
 
 /// @title This is the storage part of a diamond storage scheme for `MangroveOffer` to reduce size of contracts.
 library MangroveOfferStorage {

--- a/src/strategies/integrations/AaveModuleImplementation.sol
+++ b/src/strategies/integrations/AaveModuleImplementation.sol
@@ -24,8 +24,8 @@ import {
   DataTypes,
   RC
 } from "./AaveModuleStorage.sol";
-import {IERC20} from "src/MgvLib.sol";
-import "src/strategies/utils/TransferLib.sol";
+import {IERC20} from "mgv_src/MgvLib.sol";
+import "mgv_src/strategies/utils/TransferLib.sol";
 
 contract AaveV3ModuleImplementation {
   IPool public immutable POOL;

--- a/src/strategies/integrations/AaveModuleStorage.sol
+++ b/src/strategies/integrations/AaveModuleStorage.sol
@@ -22,7 +22,7 @@ import {ICreditDelegationToken} from "../vendor/aave/v3/ICreditDelegationToken.s
 import "../vendor/aave/v3/IPriceOracleGetter.sol";
 import {ReserveConfiguration as RC} from "../vendor/aave/v3/ReserveConfiguration.sol";
 
-import "src/IMangrove.sol";
+import "mgv_src/IMangrove.sol";
 
 library AaveV3ModuleStorage {
   // address of the lendingPool

--- a/src/strategies/integrations/AaveV2Module.sol
+++ b/src/strategies/integrations/AaveV2Module.sol
@@ -14,12 +14,12 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import "src/strategies/vendor/aave/v2/ILendingPool.sol";
-import "src/strategies/vendor/aave/v2/ILendingPoolAddressesProvider.sol";
-import "src/strategies/vendor/aave/v2/IPriceOracleGetter.sol";
-import "src/strategies/vendor/compound/Exponential.sol";
-import "src/IMangrove.sol";
-import {IERC20, MgvLib} from "src/MgvLib.sol";
+import "mgv_src/strategies/vendor/aave/v2/ILendingPool.sol";
+import "mgv_src/strategies/vendor/aave/v2/ILendingPoolAddressesProvider.sol";
+import "mgv_src/strategies/vendor/aave/v2/IPriceOracleGetter.sol";
+import "mgv_src/strategies/vendor/compound/Exponential.sol";
+import "mgv_src/IMangrove.sol";
+import {IERC20, MgvLib} from "mgv_src/MgvLib.sol";
 
 contract AaveModule is Exponential {
   event ErrorOnRedeem(

--- a/src/strategies/integrations/CompoundModule.sol
+++ b/src/strategies/integrations/CompoundModule.sol
@@ -13,10 +13,10 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import "src/strategies/vendor/compound/ICompound.sol";
-import "src/strategies/vendor/compound/Exponential.sol";
-import "src/IMangrove.sol";
-import {IERC20, MgvLib} from "src/MgvLib.sol";
+import "mgv_src/strategies/vendor/compound/ICompound.sol";
+import "mgv_src/strategies/vendor/compound/Exponential.sol";
+import "mgv_src/IMangrove.sol";
+import {IERC20, MgvLib} from "mgv_src/MgvLib.sol";
 
 interface WETH is IERC20 {
   function deposit() external payable;

--- a/src/strategies/interfaces/IForwarder.sol
+++ b/src/strategies/interfaces/IForwarder.sol
@@ -14,8 +14,8 @@ pragma solidity >=0.7.0;
 
 pragma abicoder v2;
 
-import {IMangrove} from "src/IMangrove.sol";
-import {IERC20} from "src/MgvLib.sol";
+import {IMangrove} from "mgv_src/IMangrove.sol";
+import {IERC20} from "mgv_src/MgvLib.sol";
 
 ///@title IForwarder
 ///@notice Interface for contracts that manage liquidity on Mangrove on behalf of multiple offer makers

--- a/src/strategies/interfaces/IOfferLogic.sol
+++ b/src/strategies/interfaces/IOfferLogic.sol
@@ -14,9 +14,9 @@ pragma solidity >=0.8.0;
 
 pragma abicoder v2;
 
-import {IMangrove} from "src/IMangrove.sol";
-import {IERC20, IMaker} from "src/MgvLib.sol";
-import {AbstractRouter} from "src/strategies/routers/AbstractRouter.sol";
+import {IMangrove} from "mgv_src/IMangrove.sol";
+import {IERC20, IMaker} from "mgv_src/MgvLib.sol";
+import {AbstractRouter} from "mgv_src/strategies/routers/AbstractRouter.sol";
 
 ///@title IOfferLogic interface for offer management
 ///@notice It is an IMaker for Mangrove.

--- a/src/strategies/interfaces/IOrderLogic.sol
+++ b/src/strategies/interfaces/IOrderLogic.sol
@@ -14,8 +14,8 @@ pragma solidity >=0.8.0;
 
 pragma abicoder v2;
 
-import {IMangrove} from "src/IMangrove.sol";
-import {IERC20} from "src/MgvLib.sol";
+import {IMangrove} from "mgv_src/IMangrove.sol";
+import {IERC20} from "mgv_src/MgvLib.sol";
 
 ///@title Interface for resting orders functionality.
 interface IOrderLogic {

--- a/src/strategies/offer_forwarder/OfferForwarder.sol
+++ b/src/strategies/offer_forwarder/OfferForwarder.sol
@@ -13,9 +13,9 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import {Forwarder, IMangrove, IERC20} from "src/strategies/offer_forwarder/abstract/Forwarder.sol";
-import {IMakerLogic} from "src/strategies/interfaces/IMakerLogic.sol";
-import {SimpleRouter, AbstractRouter} from "src/strategies/routers/SimpleRouter.sol";
+import {Forwarder, IMangrove, IERC20} from "mgv_src/strategies/offer_forwarder/abstract/Forwarder.sol";
+import {IMakerLogic} from "mgv_src/strategies/interfaces/IMakerLogic.sol";
+import {SimpleRouter, AbstractRouter} from "mgv_src/strategies/routers/SimpleRouter.sol";
 
 contract OfferForwarder is IMakerLogic, Forwarder {
   constructor(IMangrove mgv, address deployer) Forwarder(mgv, new SimpleRouter(), 30_000) {

--- a/src/strategies/offer_forwarder/abstract/Forwarder.sol
+++ b/src/strategies/offer_forwarder/abstract/Forwarder.sol
@@ -13,12 +13,12 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import {MangroveOffer, MOS} from "src/strategies/MangroveOffer.sol";
-import {IForwarder} from "src/strategies/interfaces/IForwarder.sol";
-import {AbstractRouter} from "src/strategies/routers/AbstractRouter.sol";
-import {IOfferLogic} from "src/strategies/interfaces/IOfferLogic.sol";
-import {MgvLib, IERC20, MgvStructs} from "src/MgvLib.sol";
-import {IMangrove} from "src/IMangrove.sol";
+import {MangroveOffer, MOS} from "mgv_src/strategies/MangroveOffer.sol";
+import {IForwarder} from "mgv_src/strategies/interfaces/IForwarder.sol";
+import {AbstractRouter} from "mgv_src/strategies/routers/AbstractRouter.sol";
+import {IOfferLogic} from "mgv_src/strategies/interfaces/IOfferLogic.sol";
+import {MgvLib, IERC20, MgvStructs} from "mgv_src/MgvLib.sol";
+import {IMangrove} from "mgv_src/IMangrove.sol";
 
 ///@title Class for maker contracts that forward offer makers instructions to Mangrove in a permissionless fashion.
 ///@notice Each offer posted via this contract are managed by their offer maker, not by this contract's admin.

--- a/src/strategies/offer_maker/OfferMaker.sol
+++ b/src/strategies/offer_maker/OfferMaker.sol
@@ -13,8 +13,8 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import {Direct, AbstractRouter, IMangrove, IERC20} from "src/strategies/offer_maker/abstract/Direct.sol";
-import {IMakerLogic} from "src/strategies/interfaces/IMakerLogic.sol";
+import {Direct, AbstractRouter, IMangrove, IERC20} from "mgv_src/strategies/offer_maker/abstract/Direct.sol";
+import {IMakerLogic} from "mgv_src/strategies/interfaces/IMakerLogic.sol";
 
 contract OfferMaker is IMakerLogic, Direct {
   // router_ needs to bind to this contract

--- a/src/strategies/offer_maker/abstract/Direct.sol
+++ b/src/strategies/offer_maker/abstract/Direct.sol
@@ -13,13 +13,13 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import {MangroveOffer} from "src/strategies/MangroveOffer.sol";
-import {MgvLib, IERC20, MgvStructs} from "src/MgvLib.sol";
-import {MangroveOfferStorage as MOS} from "src/strategies/MangroveOfferStorage.sol";
-import {TransferLib} from "src/strategies/utils/TransferLib.sol";
-import {IMangrove} from "src/IMangrove.sol";
-import {AbstractRouter} from "src/strategies/routers/AbstractRouter.sol";
-import {IOfferLogic} from "src/strategies/interfaces/IOfferLogic.sol";
+import {MangroveOffer} from "mgv_src/strategies/MangroveOffer.sol";
+import {MgvLib, IERC20, MgvStructs} from "mgv_src/MgvLib.sol";
+import {MangroveOfferStorage as MOS} from "mgv_src/strategies/MangroveOfferStorage.sol";
+import {TransferLib} from "mgv_src/strategies/utils/TransferLib.sol";
+import {IMangrove} from "mgv_src/IMangrove.sol";
+import {AbstractRouter} from "mgv_src/strategies/routers/AbstractRouter.sol";
+import {IOfferLogic} from "mgv_src/strategies/interfaces/IOfferLogic.sol";
 
 /// `Direct` strats is an extension of MangroveOffer that allows contract's admin to manage offers on Mangrove.
 abstract contract Direct is MangroveOffer {

--- a/src/strategies/offer_maker/market_making/mango/Mango.sol
+++ b/src/strategies/offer_maker/market_making/mango/Mango.sol
@@ -18,7 +18,7 @@ import "./MangoImplementation.sol";
 import "../../abstract/Direct.sol";
 import "../../../routers/AbstractRouter.sol";
 import "../../../routers/SimpleRouter.sol";
-import {MgvLib} from "src/MgvLib.sol";
+import {MgvLib} from "mgv_src/MgvLib.sol";
 
 /**
  * Discrete automated market making strat

--- a/src/strategies/offer_maker/market_making/mango/MangoImplementation.sol
+++ b/src/strategies/offer_maker/market_making/mango/MangoImplementation.sol
@@ -13,10 +13,10 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import "src/IMangrove.sol";
+import "mgv_src/IMangrove.sol";
 import "./MangoStorage.sol";
-import "src/strategies/utils/TransferLib.sol";
-import {MgvLib, MgvStructs} from "src/MgvLib.sol";
+import "mgv_src/strategies/utils/TransferLib.sol";
+import {MgvLib, MgvStructs} from "mgv_src/MgvLib.sol";
 
 //import "../routers/AbstractRouter.sol";
 

--- a/src/strategies/offer_maker/market_making/mango/MangoStorage.sol
+++ b/src/strategies/offer_maker/market_making/mango/MangoStorage.sol
@@ -13,7 +13,7 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import "src/strategies/routers/AbstractRouter.sol";
+import "mgv_src/strategies/routers/AbstractRouter.sol";
 
 library MangoStorage {
   /**

--- a/src/strategies/routers/AaveRouter.sol
+++ b/src/strategies/routers/AaveRouter.sol
@@ -14,9 +14,9 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import "src/strategies/integrations/AaveV3Module.sol";
-import "src/strategies/utils/AccessControlled.sol";
-import "src/strategies/utils/TransferLib.sol";
+import "mgv_src/strategies/integrations/AaveV3Module.sol";
+import "mgv_src/strategies/utils/AccessControlled.sol";
+import "mgv_src/strategies/utils/TransferLib.sol";
 import "./AbstractRouter.sol";
 
 // Underlying on AAVE

--- a/src/strategies/routers/AbstractRouter.sol
+++ b/src/strategies/routers/AbstractRouter.sol
@@ -14,9 +14,9 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import {AccessControlled} from "src/strategies/utils/AccessControlled.sol";
+import {AccessControlled} from "mgv_src/strategies/utils/AccessControlled.sol";
 import {AbstractRouterStorage as ARSt} from "./AbstractRouterStorage.sol";
-import {IERC20} from "src/MgvLib.sol";
+import {IERC20} from "mgv_src/MgvLib.sol";
 
 /// @title AbstractRouter
 /// @notice Partial implementation and requirements for liquidity routers.

--- a/src/strategies/routers/SimpleRouter.sol
+++ b/src/strategies/routers/SimpleRouter.sol
@@ -14,8 +14,8 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import {IERC20} from "src/MgvLib.sol";
-import {TransferLib} from "src/strategies/utils/TransferLib.sol";
+import {IERC20} from "mgv_src/MgvLib.sol";
+import {TransferLib} from "mgv_src/strategies/utils/TransferLib.sol";
 import {AbstractRouter} from "./AbstractRouter.sol";
 
 ///@notice `SimpleRouter` instances pull (push) liquidity directly from (to) the reserve

--- a/src/strategies/utils/TransferLib.sol
+++ b/src/strategies/utils/TransferLib.sol
@@ -13,7 +13,7 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import {IERC20} from "src/MgvLib.sol";
+import {IERC20} from "mgv_src/MgvLib.sol";
 
 ///@title This library helps with safely interacting with ERC20 tokens
 ///@notice Transferring 0 or to self will be skipped.

--- a/src/strategies/vendor/compound/ICompound.sol
+++ b/src/strategies/vendor/compound/ICompound.sol
@@ -15,7 +15,7 @@
 pragma solidity ^0.8.10;
 pragma abicoder v2;
 
-import {IERC20} from "src/MgvLib.sol";
+import {IERC20} from "mgv_src/MgvLib.sol";
 
 interface ICompoundPriceOracle {
   function getUnderlyingPrice(IcERC20 cToken) external view returns (uint);

--- a/src/toy_strategies/offer_forwarder/OasisLike.sol
+++ b/src/toy_strategies/offer_forwarder/OasisLike.sol
@@ -13,8 +13,8 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import "src/strategies/offer_forwarder/OfferForwarder.sol";
-import "src/strategies/routers/SimpleRouter.sol";
+import "mgv_src/strategies/offer_forwarder/OfferForwarder.sol";
+import "mgv_src/strategies/routers/SimpleRouter.sol";
 
 contract OasisLike is OfferForwarder {
   bytes32 public constant NAME = "OasisLike";

--- a/src/toy_strategies/offer_forwarder/OfferProxy.sol
+++ b/src/toy_strategies/offer_forwarder/OfferProxy.sol
@@ -13,8 +13,8 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import "src/strategies/offer_forwarder/OfferForwarder.sol";
-import "src/strategies/routers/AaveDeepRouter.sol";
+import "mgv_src/strategies/offer_forwarder/OfferForwarder.sol";
+import "mgv_src/strategies/routers/AaveDeepRouter.sol";
 
 contract OfferProxy is OfferForwarder {
   bytes32 public constant NAME = "OfferProxy";

--- a/src/toy_strategies/offer_maker/Ghost.sol
+++ b/src/toy_strategies/offer_maker/Ghost.sol
@@ -13,9 +13,9 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import "src/strategies/offer_maker/abstract/Direct.sol";
-import "src/strategies/routers/SimpleRouter.sol";
-import {MgvLib, MgvStructs} from "src/MgvLib.sol";
+import "mgv_src/strategies/offer_maker/abstract/Direct.sol";
+import "mgv_src/strategies/routers/SimpleRouter.sol";
+import {MgvLib, MgvStructs} from "mgv_src/MgvLib.sol";
 
 contract Ghost is Direct {
   IERC20 public immutable BASE;

--- a/src/toy_strategies/offer_maker/cash_management/AdvancedAaveRetail.sol
+++ b/src/toy_strategies/offer_maker/cash_management/AdvancedAaveRetail.sol
@@ -13,9 +13,9 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import "src/strategies/offer_maker/OfferMaker.sol";
-import "src/strategies/routers/AaveDeepRouter.sol";
-import {MgvLib} from "src/MgvLib.sol";
+import "mgv_src/strategies/offer_maker/OfferMaker.sol";
+import "mgv_src/strategies/routers/AaveDeepRouter.sol";
+import {MgvLib} from "mgv_src/MgvLib.sol";
 
 contract AdvancedAaveRetail is OfferMaker {
   bytes32 public constant NAME = "AdvancedAaveRetail";

--- a/src/toy_strategies/offer_maker/cash_management/SimpleAaveRetail.sol
+++ b/src/toy_strategies/offer_maker/cash_management/SimpleAaveRetail.sol
@@ -13,8 +13,8 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import "src/strategies/offer_maker/OfferMaker.sol";
-import "src/strategies/routers/AaveRouter.sol";
+import "mgv_src/strategies/offer_maker/OfferMaker.sol";
+import "mgv_src/strategies/routers/AaveRouter.sol";
 
 contract SimpleAaveRetail is OfferMaker {
   bytes32 public constant NAME = "SimpleAaveRetail";

--- a/src/toy_strategies/utils/SimpleOracle.sol
+++ b/src/toy_strategies/utils/SimpleOracle.sol
@@ -14,7 +14,7 @@ pragma solidity ^0.8.10;
 pragma abicoder v2;
 
 import "../interfaces/IOracle.sol";
-import "src/strategies/utils/AccessControlled.sol";
+import "mgv_src/strategies/utils/AccessControlled.sol";
 import {IERC20} from "../../MgvLib.sol";
 
 contract SimpleOracle is IOracle, AccessControlled {

--- a/test/core/Gatekeeping.t.sol
+++ b/test/core/Gatekeeping.t.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.10;
 pragma abicoder v2;
 
 import "mgv_test/lib/MangroveTest.sol";
-import {MgvStructs} from "src/MgvLib.sol";
+import {MgvStructs} from "mgv_src/MgvLib.sol";
 
 // In these tests, the testing contract is the market maker.
 contract GatekeepingTest is IMaker, MangroveTest {

--- a/test/core/MakerOperations.t.sol
+++ b/test/core/MakerOperations.t.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.10;
 pragma abicoder v2;
 
 import "mgv_test/lib/MangroveTest.sol";
-import {MgvStructs} from "src/MgvLib.sol";
+import {MgvStructs} from "mgv_src/MgvLib.sol";
 
 contract MakerOperationsTest is MangroveTest, IMaker {
   TestMaker mkr;

--- a/test/core/MakerPosthook.t.sol
+++ b/test/core/MakerPosthook.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.10;
 
 import "mgv_test/lib/MangroveTest.sol";
-import {MgvStructs} from "src/MgvLib.sol";
+import {MgvStructs} from "mgv_src/MgvLib.sol";
 
 contract MakerPosthookTest is MangroveTest, IMaker {
   TestTaker tkr;

--- a/test/core/Monitor.t.sol
+++ b/test/core/Monitor.t.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.10;
 
 import "mgv_test/lib/MangroveTest.sol";
-import {MgvLib, MgvStructs} from "src/MgvLib.sol";
+import {MgvLib, MgvStructs} from "mgv_src/MgvLib.sol";
 
 contract MonitorTest is MangroveTest {
   TestMaker mkr;

--- a/test/core/Permit.t.sol
+++ b/test/core/Permit.t.sol
@@ -39,15 +39,13 @@ pragma solidity ^0.8.10;
     deadline: deadline,
   };
 
-  owner._signTypedData(domain, types, data);
-
-*/
+  owner._signTypedData(domain, types, data);*/
 
 import {MangroveTest} from "mgv_test/lib/MangroveTest.sol";
 import {TrivialTestMaker, TestMaker} from "mgv_test/lib/agents/TestMaker.sol";
 import {Vm} from "forge-std/Vm.sol";
 import {StdStorage, stdStorage} from "forge-std/Test.sol";
-import {AbstractMangrove} from "src/AbstractMangrove.sol";
+import {AbstractMangrove} from "mgv_src/AbstractMangrove.sol";
 
 contract PermitTest is MangroveTest, TrivialTestMaker {
   using stdStorage for StdStorage;

--- a/test/core/Permit.t.sol
+++ b/test/core/Permit.t.sol
@@ -39,7 +39,9 @@ pragma solidity ^0.8.10;
     deadline: deadline,
   };
 
-  owner._signTypedData(domain, types, data);*/
+  owner._signTypedData(domain, types, data);
+
+*/
 
 import {MangroveTest} from "mgv_test/lib/MangroveTest.sol";
 import {TrivialTestMaker, TestMaker} from "mgv_test/lib/agents/TestMaker.sol";

--- a/test/core/Scenarii.t.sol
+++ b/test/core/Scenarii.t.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.10;
 
 import "mgv_test/lib/MangroveTest.sol";
-import {MgvStructs} from "src/MgvLib.sol";
+import {MgvStructs} from "mgv_src/MgvLib.sol";
 
 contract ScenariiTest is MangroveTest {
   TestTaker taker;

--- a/test/lib/MangroveTest.sol
+++ b/test/lib/MangroveTest.sol
@@ -10,15 +10,15 @@ import {MakerDeployer} from "mgv_test/lib/agents/MakerDeployer.sol";
 import {TestMoriartyMaker} from "mgv_test/lib/agents/TestMoriartyMaker.sol";
 import {TestToken} from "mgv_test/lib/tokens/TestToken.sol";
 
-import {AbstractMangrove} from "src/AbstractMangrove.sol";
-import {Mangrove} from "src/Mangrove.sol";
-import {MgvReader} from "src/periphery/MgvReader.sol";
-import {InvertedMangrove} from "src/InvertedMangrove.sol";
-import {IERC20, MgvLib, HasMgvEvents, IMaker, ITaker, IMgvMonitor, MgvStructs} from "src/MgvLib.sol";
+import {AbstractMangrove} from "mgv_src/AbstractMangrove.sol";
+import {Mangrove} from "mgv_src/Mangrove.sol";
+import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
+import {InvertedMangrove} from "mgv_src/InvertedMangrove.sol";
+import {IERC20, MgvLib, HasMgvEvents, IMaker, ITaker, IMgvMonitor, MgvStructs} from "mgv_src/MgvLib.sol";
 import {console2 as csl} from "forge-std/console2.sol";
 
 // below imports are for the \$( function)
-import {AccessControlled} from "src/strategies/utils/AccessControlled.sol";
+import {AccessControlled} from "mgv_src/strategies/utils/AccessControlled.sol";
 
 /* *************************************************************** 
    import this file and inherit MangroveTest to get up and running 

--- a/test/lib/Script2.sol
+++ b/test/lib/Script2.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.13;
 
 import {console2 as console} from "forge-std/console2.sol";
 import {Script} from "forge-std/Script.sol";
-import {IERC20} from "src/MgvLib.sol";
+import {IERC20} from "mgv_src/MgvLib.sol";
 import {ToyENS} from "mgv_script/lib/ToyENS.sol";
 
 /* Some general utility methods.

--- a/test/lib/agents/MakerDeployer.sol
+++ b/test/lib/agents/MakerDeployer.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.10;
 
-import "src/Mangrove.sol";
+import "mgv_src/Mangrove.sol";
 import "./TestMaker.sol";
 import "mgv_test/lib/tokens/TestToken.sol";
 

--- a/test/lib/agents/TestMaker.sol
+++ b/test/lib/agents/TestMaker.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.13;
 
 pragma abicoder v2;
 
-import "src/AbstractMangrove.sol";
-import {IERC20, MgvLib, IMaker} from "src/MgvLib.sol";
+import "mgv_src/AbstractMangrove.sol";
+import {IERC20, MgvLib, IMaker} from "mgv_src/MgvLib.sol";
 import {Test} from "forge-std/Test.sol";
 
 contract TrivialTestMaker is IMaker {

--- a/test/lib/agents/TestMoriartyMaker.sol
+++ b/test/lib/agents/TestMoriartyMaker.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.10;
 
-import "src/AbstractMangrove.sol";
-import {IERC20, MgvLib, IMaker} from "src/MgvLib.sol";
-import {MgvStructs} from "src/MgvLib.sol";
+import "mgv_src/AbstractMangrove.sol";
+import {IERC20, MgvLib, IMaker} from "mgv_src/MgvLib.sol";
+import {MgvStructs} from "mgv_src/MgvLib.sol";
 
 contract TestMoriartyMaker is IMaker {
   AbstractMangrove mgv;

--- a/test/lib/agents/TestTaker.sol
+++ b/test/lib/agents/TestTaker.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.10;
 
 pragma abicoder v2;
 
-import {AbstractMangrove} from "src/AbstractMangrove.sol";
-import {IERC20, ITaker} from "src/MgvLib.sol";
+import {AbstractMangrove} from "mgv_src/AbstractMangrove.sol";
+import {IERC20, ITaker} from "mgv_src/MgvLib.sol";
 import {Script2} from "mgv_test/lib/Script2.sol";
 
 contract TestTaker is ITaker, Script2 {

--- a/test/lib/tokens/ERC20.sol
+++ b/test/lib/tokens/ERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.8.0;
 
-import {IERC20} from "src/MgvLib.sol";
+import {IERC20} from "mgv_src/MgvLib.sol";
 import "./ERC20Lib.sol";
 
 /**

--- a/test/periphery/MgvCleaner.t.sol
+++ b/test/periphery/MgvCleaner.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.10;
 import "mgv_test/lib/MangroveTest.sol";
 // pragma experimental ABIEncoderV2;
 
-import {MgvCleaner} from "src/periphery/MgvCleaner.sol";
+import {MgvCleaner} from "mgv_src/periphery/MgvCleaner.sol";
 
 // In these tests, the testing contract is the market maker.
 contract MgvCleanerTest is MangroveTest {

--- a/test/periphery/MgvOracle.t.sol
+++ b/test/periphery/MgvOracle.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.10;
 // pragma experimental ABIEncoderV2;
 
 import {MangroveTest} from "mgv_test/lib/MangroveTest.sol";
-import {MgvOracle} from "src/periphery/MgvOracle.sol";
+import {MgvOracle} from "mgv_src/periphery/MgvOracle.sol";
 
 import {Test2} from "mgv_test/lib/Test2.sol";
 

--- a/test/periphery/MgvOrder.t.sol
+++ b/test/periphery/MgvOrder.t.sol
@@ -4,10 +4,10 @@ pragma solidity ^0.8.10;
 pragma abicoder v2;
 
 import {MangroveTest, TestMaker, TestTaker, TestSender} from "mgv_test/lib/MangroveTest.sol";
-import {IMangrove} from "src/IMangrove.sol";
-import {MangroveOrderEnriched as MgvOrder} from "src/periphery/MangroveOrderEnriched.sol";
-import {IOrderLogic} from "src/strategies/interfaces/IOrderLogic.sol";
-import {MgvStructs, MgvLib, IERC20} from "src/MgvLib.sol";
+import {IMangrove} from "mgv_src/IMangrove.sol";
+import {MangroveOrderEnriched as MgvOrder} from "mgv_src/periphery/MangroveOrderEnriched.sol";
+import {IOrderLogic} from "mgv_src/strategies/interfaces/IOrderLogic.sol";
+import {MgvStructs, MgvLib, IERC20} from "mgv_src/MgvLib.sol";
 
 contract MangroveOrder_Test is MangroveTest {
   // to check ERC20 logging

--- a/test/periphery/MgvReader.t.sol
+++ b/test/periphery/MgvReader.t.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.10;
 
 import "mgv_test/lib/MangroveTest.sol";
 
-import {MgvReader, VolumeData} from "src/periphery/MgvReader.sol";
-import {MgvStructs} from "src/MgvLib.sol";
+import {MgvReader, VolumeData} from "mgv_src/periphery/MgvReader.sol";
+import {MgvStructs} from "mgv_src/MgvLib.sol";
 
 // In these tests, the testing contract is the market maker.
 contract MgvReaderTest is MangroveTest {

--- a/test/script/lib/MangroveDeployer.t.sol
+++ b/test/script/lib/MangroveDeployer.t.sol
@@ -6,14 +6,14 @@ import {MangroveDeployer} from "mgv_script/lib/MangroveDeployer.sol";
 
 import {Test2, Test} from "mgv_test/lib/Test2.sol";
 
-import {MgvStructs} from "src/MgvLib.sol";
-import {Mangrove} from "src/Mangrove.sol";
-import {MgvReader} from "src/periphery/MgvReader.sol";
-import {MangroveOrderEnriched} from "src/periphery/MangroveOrderEnriched.sol";
-import {MgvCleaner} from "src/periphery/MgvCleaner.sol";
-import {MgvOracle} from "src/periphery/MgvOracle.sol";
-import {IMangrove} from "src/IMangrove.sol";
-import {AbstractRouter} from "src/strategies/routers/AbstractRouter.sol";
+import {MgvStructs} from "mgv_src/MgvLib.sol";
+import {Mangrove} from "mgv_src/Mangrove.sol";
+import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
+import {MangroveOrderEnriched} from "mgv_src/periphery/MangroveOrderEnriched.sol";
+import {MgvCleaner} from "mgv_src/periphery/MgvCleaner.sol";
+import {MgvOracle} from "mgv_src/periphery/MgvOracle.sol";
+import {IMangrove} from "mgv_src/IMangrove.sol";
+import {AbstractRouter} from "mgv_src/strategies/routers/AbstractRouter.sol";
 
 contract MangroveDeployerTest is Deployer, Test2 {
   MangroveDeployer mgvDeployer;

--- a/test/strategies/Guaave.t.sol
+++ b/test/strategies/Guaave.t.sol
@@ -19,7 +19,9 @@ import "mgv_test/lib/forks/Polygon.sol";
       constructor() {
         fork = new MumbaiFork();
       }
-    }*/
+    }
+
+*/
 
 abstract contract GuaaveAbstractTest is MangroveTest {
   uint constant BASE0 = 0.34 ether;

--- a/test/strategies/Guaave.t.sol
+++ b/test/strategies/Guaave.t.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.14;
 
 import "mgv_test/lib/MangroveTest.sol";
-import "src/strategies/offer_maker/market_making/mango/Mango.sol";
-import "src/strategies/routers/AaveRouter.sol";
+import "mgv_src/strategies/offer_maker/market_making/mango/Mango.sol";
+import "mgv_src/strategies/routers/AaveRouter.sol";
 import "mgv_test/lib/forks/Polygon.sol";
 
 /* This test works as an example of how to run the same test on multiple forks. 
@@ -19,9 +19,7 @@ import "mgv_test/lib/forks/Polygon.sol";
       constructor() {
         fork = new MumbaiFork();
       }
-    }
-
-*/
+    }*/
 
 abstract contract GuaaveAbstractTest is MangroveTest {
   uint constant BASE0 = 0.34 ether;

--- a/test/strategies/Mango.t.sol
+++ b/test/strategies/Mango.t.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.10;
 
 import "mgv_test/lib/MangroveTest.sol";
-import "src/strategies/offer_maker/market_making/mango/Mango.sol";
-import "src/strategies/routers/SimpleRouter.sol";
-import {MgvStructs} from "src/MgvLib.sol";
+import "mgv_src/strategies/offer_maker/market_making/mango/Mango.sol";
+import "mgv_src/strategies/routers/SimpleRouter.sol";
+import {MgvStructs} from "mgv_src/MgvLib.sol";
 
 contract MangoTest is MangroveTest {
   struct Book {

--- a/test/strategies/unit/AaveRouter.t.sol
+++ b/test/strategies/unit/AaveRouter.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.10;
 
 import "./OfferLogic.t.sol";
-import "src/strategies/routers/AaveRouter.sol";
+import "mgv_src/strategies/routers/AaveRouter.sol";
 import {PinnedPolygonFork} from "mgv_test/lib/forks/Polygon.sol";
 
 contract AaveRouterForkedTest is OfferLogicTest {

--- a/test/strategies/unit/AccessControl.t.sol
+++ b/test/strategies/unit/AccessControl.t.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.10;
 import "mgv_test/lib/MangroveTest.sol";
 // import "mgv_test/lib/Fork.sol";
 
-import "src/strategies/offer_maker/OfferMaker.sol";
-import "src/strategies/routers/AbstractRouter.sol";
+import "mgv_src/strategies/offer_maker/OfferMaker.sol";
+import "mgv_src/strategies/routers/AbstractRouter.sol";
 
 contract AccessControlTest is MangroveTest {
   TestToken weth;

--- a/test/strategies/unit/MangroveOffer.t.sol
+++ b/test/strategies/unit/MangroveOffer.t.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.10;
 
 import "mgv_test/lib/MangroveTest.sol";
-import "src/strategies/offer_maker/OfferMaker.sol";
-import "src/strategies/routers/SimpleRouter.sol";
-import {t_of_struct as packOffer} from "src/preprocessed/MgvOffer.post.sol";
+import "mgv_src/strategies/offer_maker/OfferMaker.sol";
+import "mgv_src/strategies/routers/SimpleRouter.sol";
+import {t_of_struct as packOffer} from "mgv_src/preprocessed/MgvOffer.post.sol";
 
 contract MangroveOfferTest is MangroveTest {
   TestToken weth;

--- a/test/strategies/unit/OfferForwarder.t.sol
+++ b/test/strategies/unit/OfferForwarder.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.10;
 
-import {SimpleRouter} from "src/strategies/routers/SimpleRouter.sol";
+import {SimpleRouter} from "mgv_src/strategies/routers/SimpleRouter.sol";
 import {OfferLogicTest, console} from "mgv_test/strategies/unit/OfferLogic.t.sol";
-import {OfferForwarder, IMakerLogic} from "src/strategies/offer_forwarder/OfferForwarder.sol";
-import {IForwarder, IMangrove, IERC20} from "src/strategies/offer_forwarder/abstract/Forwarder.sol";
-import {MgvStructs, MgvLib} from "src/MgvLib.sol";
+import {OfferForwarder, IMakerLogic} from "mgv_src/strategies/offer_forwarder/OfferForwarder.sol";
+import {IForwarder, IMangrove, IERC20} from "mgv_src/strategies/offer_forwarder/abstract/Forwarder.sol";
+import {MgvStructs, MgvLib} from "mgv_src/MgvLib.sol";
 
 contract OfferForwarderTest is OfferLogicTest {
   IForwarder forwarder;

--- a/test/strategies/unit/OfferLogic.t.sol
+++ b/test/strategies/unit/OfferLogic.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.10;
 
 import "mgv_test/lib/MangroveTest.sol";
 import {GenericFork} from "mgv_test/lib/forks/Generic.sol";
-import "src/strategies/offer_maker/OfferMaker.sol";
+import "mgv_src/strategies/offer_maker/OfferMaker.sol";
 
 // unit tests for (single /\ multi) user strats (i.e unit tests that are non specific to either single or multi user feature
 

--- a/test/strategies/unit/SimpleEOARouter.t.sol
+++ b/test/strategies/unit/SimpleEOARouter.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.10;
 
 import "./OfferLogic.t.sol";
-import "src/strategies/routers/SimpleRouter.sol";
+import "mgv_src/strategies/routers/SimpleRouter.sol";
 
 contract SimpleEOARouterTest is OfferLogicTest {
   function setupLiquidityRouting() internal override {

--- a/test/strategies/unit/SimpleRouter.t.sol
+++ b/test/strategies/unit/SimpleRouter.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.10;
 
 import "./OfferLogic.t.sol";
-import "src/strategies/routers/SimpleRouter.sol";
+import "mgv_src/strategies/routers/SimpleRouter.sol";
 
 contract SimpleRouterTest is OfferLogicTest {
   SimpleRouter router;

--- a/test/toy_strategies/AaveLender.t.sol
+++ b/test/toy_strategies/AaveLender.t.sol
@@ -8,8 +8,8 @@ import {
   AaveV3Module,
   AaveDeepRouter
 } from "src/toy_strategies/offer_maker/cash_management/AdvancedAaveRetail.sol";
-import {IERC20} from "src/MgvLib.sol";
-import {IMangrove} from "src/IMangrove.sol";
+import {IERC20} from "mgv_src/MgvLib.sol";
+import {IMangrove} from "mgv_src/IMangrove.sol";
 import {console2} from "forge-std/Test.sol";
 import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
 

--- a/test/toy_strategies/Ghost.t.sol
+++ b/test/toy_strategies/Ghost.t.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.10;
 
 import "mgv_test/lib/MangroveTest.sol";
 import "mgv_test/lib/forks/Polygon.sol";
-import "src/toy_strategies/offer_maker/Ghost.sol";
-import {MgvStructs} from "src/MgvLib.sol";
+import "mgv_src/toy_strategies/offer_maker/Ghost.sol";
+import {MgvStructs} from "mgv_src/MgvLib.sol";
 import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
 
 import {console} from "forge-std/console.sol";


### PR DESCRIPTION
Due to
https://github.com/foundry-rs/foundry/issues/1486
https://github.com/foundry-rs/foundry/issues/1933
we use a semi-unique path for imports.
Change is simply running the following two through vscode search-replace with regex:
```
import (\{[^}]*\}) from "src\/
import $1 from "mgv_src/
```
and
```
import "src/
import "mgv_src/
```