### PR TITLE
feat: use remoteEns when available

### DIFF
--- a/script/lib/Deployer.sol
+++ b/script/lib/Deployer.sol
@@ -38,8 +38,9 @@ abstract contract Deployer is Script2 {
     vm.label(address(fork), "Deployer:Fork");
     vm.label(address(remoteEns), "Remote ENS");
 
-    // depending on which fork the script is running on, choose whether to write the addresses to a file, get the right fork contract, and name the current network.
+    // detect if we've already created a fork -- the singleton method works as an inter-contract storage used for communication
     if (singleton("Deployer:Fork") == address(0)) {
+      // depending on which fork the script is running on, choose whether to write the addresses to a file, get the right fork contract, and name the current network.
       if (block.chainid == 80001) {
         fork = new MumbaiFork();
       } else if (block.chainid == 127) {

--- a/test/lib/forks/Generic.sol
+++ b/test/lib/forks/Generic.sol
@@ -12,8 +12,7 @@ struct Record {
 
 /* 
 Note: when you add a *Fork contract, to have it available in deployment scripts,
-remember to add it to the initialized forks in Deployer.sol.
-*/
+remember to add it to the initialized forks in Deployer.sol.*/
 contract GenericFork is Script {
   uint public INTERNAL_FORK_ID;
   uint public CHAIN_ID;
@@ -134,6 +133,15 @@ contract GenericFork is Script {
     records = readAddresses("deployed");
     for (uint i = 0; i < records.length; i++) {
       set(records[i].name, records[i].addr);
+    }
+
+    // If a remote ToyENS is found, import its records.
+    ToyENS remoteEns = ToyENS(address(bytes20(hex"decaf0")));
+    if (address(remoteEns).code.length > 0) {
+      (string[] memory names, address[] memory addrs) = remoteEns.all();
+      for (uint i = 0; i < names.length; i++) {
+        set(names[i], addrs[i]);
+      }
     }
 
     // if already forked, ignore BLOCK_NUMBER & don't re-fork


### PR DESCRIPTION
If a `forge script` is about to deploy to a node that has a ToyENS deployed at the canonical address, it will use its addresses (and they will supersede whatever it found in JSON files).