### PR TITLE
feat: autodeploy ToyENS

### DIFF
--- a/deployRemoteToyENS.sh
+++ b/deployRemoteToyENS.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Create a ToyENS instance on the anvil/hardhat server
+# Will use endpoint ETH_RPC_URL or localhost:8545 by default
+# Forge scripts that inherit the Deployer contract will automatically deploy a ToyENS
+set -xe
+TOY_ENS_CODE=$(forge inspect ToyENS deployedBytecode)
+cast rpc anvil_setCode 0xdecaf00000000000000000000000000000000000 $TOY_ENS_CODE

--- a/foundry.toml
+++ b/foundry.toml
@@ -9,6 +9,7 @@ libs=['lib']
 cache_path='cache'
 fs_permissions = [{ access = "read-write", path = "./addresses/"}]
 solc_version="0.8.14"
+ffi=true
 # optimizer=true
 # optimizer_runs=20000
 


### PR DESCRIPTION
[EXPERIMENTAL]
When a `forge script` is run, it heuristically determines if it's talking to anvil. If yes, it attempts to deploy a remote ToyENS at the canonical address.

* The heuristic is "is there >0 ETH at the anvil default address n°1", it may be wrong
* The ToyENS code will be sent to `localhost:8545` regardless of the `--fork-url` argument. To customize that, you have to set the `ETH_RPC_URL` env var.

It may prove brittle but the result is that ou can just 
1. run `anvil`
2. run `forge script`s
3. start `mangrove.js` and you wil get all your addresses

+ in addition, a bash script to do it manually if needed. Unfortunately it recompiles contracts needlessly due to a forge issue.