### PR TITLE
Final modification for audit

### DIFF
--- a/src/strategies/MangroveOffer.sol
+++ b/src/strategies/MangroveOffer.sol
@@ -260,21 +260,6 @@ abstract contract MangroveOffer is AccessControlled, IOfferLogic {
     return order.offer.gives() - order.wants;
   }
 
-  ///@notice converts Mangrove's error message string back into its original bytes32 type
-  ///@param reason the revert reason
-  function _repostStatus(string memory reason) internal pure returns (bytes32) {
-    bytes32 reason_hsh = keccak256(bytes(reason));
-    if (reason_hsh == BELOW_DENSITY) {
-      return "mgv/writeOffer/density/tooLow"; // offer not reposted because residual is below density
-    } else {
-      if (reason_hsh == OUT_OF_FUNDS) {
-        return "mgv/insufficientProvision"; // offer not reposted for other reasons (i.e lack of provision)
-      } else {
-        return REPOST_FAILED;
-      }
-    }
-  }
-
   ///@notice Hook that defines what needs to be done to the part of an offer provision that was added to the balance of `this` on Mangrove after an offer has failed.
   ///@param order is a recal of the taker order that failed
   function __handleResidualProvision__(MgvLib.SingleOrder calldata order) internal virtual {

--- a/src/strategies/MangroveOffer.sol
+++ b/src/strategies/MangroveOffer.sol
@@ -303,6 +303,18 @@ abstract contract MangroveOffer is AccessControlled, IOfferLogic {
     }
   }
 
+  ///@notice computes the provision that can be redeemed if deprovisioning a certain offer
+  ///@param outbound_tkn the outbound token of the offer list
+  ///@param inbound_tkn the inbound otken of the offer list
+  ///@param offerId the id of the offer
+  ///@return provision the provision that can be redeemed
+  function _provisionOf(IERC20 outbound_tkn, IERC20 inbound_tkn, uint offerId) internal view returns (uint provision) {
+    MgvStructs.OfferDetailPacked offerDetail = MGV.offerDetails(address(outbound_tkn), address(inbound_tkn), offerId);
+    unchecked {
+      provision = offerDetail.gasprice() * 10 ** 9 * (offerDetail.offer_gasbase() + offerDetail.gasreq());
+    }
+  }
+
   /// @inheritdoc IOfferLogic
   function getMissingProvision(IERC20 outbound_tkn, IERC20 inbound_tkn, uint gasreq, uint gasprice, uint offerId)
     public

--- a/src/strategies/MangroveOffer.sol
+++ b/src/strategies/MangroveOffer.sol
@@ -111,6 +111,7 @@ abstract contract MangroveOffer is AccessControlled, IOfferLogic {
         );
       // calling strat specific todos in case of failure
       __posthookFallback__(order, result);
+      __handleResidualProvision__(order);
     }
   }
 
@@ -255,6 +256,12 @@ abstract contract MangroveOffer is AccessControlled, IOfferLogic {
   ///@dev default is to require the original amount of tokens minus those that have been sent to the taker during trade execution.
   function __residualGives__(MgvLib.SingleOrder calldata order) internal virtual returns (uint new_gives) {
     return order.offer.gives() - order.wants;
+  }
+
+  ///@notice Hook that defines what needs to be done to the part of an offer provision that was added to the balance of `this` on Mangrove after and offer has failed.
+  ///@param order is a recal of the taker order that failed
+  function __handleResidualProvision__(MgvLib.SingleOrder calldata order) internal virtual {
+    order; //ssh
   }
 
   ///@notice Post-hook that implements default behavior when Taker Order's execution succeeded.

--- a/src/strategies/MangroveOrder.sol
+++ b/src/strategies/MangroveOrder.sol
@@ -268,9 +268,9 @@ contract MangroveOrder is Forwarder, IOrderLogic {
         gasprice: 0, // ignored
         pivotId: tko.pivotId,
         fund: fund,
-        noRevert: true, // returns 0 when MGV reverts
-        owner: msg.sender
-      })
+        noRevert: true // returns 0 when MGV reverts
+      }),
+      msg.sender
     );
     if (res.offerId == 0) {
       // either:

--- a/src/strategies/MangroveOrder.sol
+++ b/src/strategies/MangroveOrder.sol
@@ -218,6 +218,7 @@ contract MangroveOrder is Forwarder, IOrderLogic {
       mangrove: MGV,
       outbound_tkn: tko.outbound_tkn,
       inbound_tkn: tko.inbound_tkn,
+      taker: msg.sender,
       fillOrKill: tko.fillOrKill,
       takerWants: tko.takerWants,
       takerGives: tko.takerGives,
@@ -228,8 +229,7 @@ contract MangroveOrder is Forwarder, IOrderLogic {
       takerGave: res.takerGave,
       bounty: res.bounty,
       fee: res.fee,
-      restingOrderId: res.offerId,
-      taker: msg.sender
+      restingOrderId: res.offerId
     });
   }
 

--- a/src/strategies/MangroveOrder.sol
+++ b/src/strategies/MangroveOrder.sol
@@ -211,12 +211,13 @@ contract MangroveOrder is Forwarder, IOrderLogic {
     return res;
   }
 
+  ///@notice logs `OrderSummary`
+  ///@dev this function avoids loading too many variables on the stack
   function logOrderData(TakerOrder memory tko, TakerOrderResult memory res) internal {
     emit OrderSummary({
       mangrove: MGV,
       outbound_tkn: tko.outbound_tkn,
       inbound_tkn: tko.inbound_tkn,
-      taker: msg.sender,
       fillOrKill: tko.fillOrKill,
       takerWants: tko.takerWants,
       takerGives: tko.takerGives,
@@ -227,7 +228,8 @@ contract MangroveOrder is Forwarder, IOrderLogic {
       takerGave: res.takerGave,
       bounty: res.bounty,
       fee: res.fee,
-      restingOrderId: res.offerId
+      restingOrderId: res.offerId,
+      taker: msg.sender
     });
   }
 

--- a/src/strategies/interfaces/IOfferLogic.sol
+++ b/src/strategies/interfaces/IOfferLogic.sol
@@ -105,7 +105,6 @@ interface IOfferLogic is IMaker {
     uint pivotId;
     uint fund;
     bool noRevert;
-    address owner;
   }
 
   ///@notice Retracts an offer from an Offer List of Mangrove.

--- a/src/strategies/offer_forwarder/OfferForwarder.sol
+++ b/src/strategies/offer_forwarder/OfferForwarder.sol
@@ -83,7 +83,7 @@ contract OfferForwarder is ILiquidityProvider, Forwarder {
       data == "posthook/reposted" || data == "posthook/filled",
       data == "mgv/insufficientProvision"
         ? "mgv/insufficientProvision"
-        : (data == "mgv/writeOffer/density/tooLow" ? "mgv/writeOffer/density/tooLow" : "posthookFailed")
+        : (data == "mgv/writeOffer/density/tooLow" ? "mgv/writeOffer/density/tooLow" : "posthook/failed")
     );
   }
 }

--- a/src/strategies/offer_forwarder/OfferForwarder.sol
+++ b/src/strategies/offer_forwarder/OfferForwarder.sol
@@ -41,9 +41,9 @@ contract OfferForwarder is ILiquidityProvider, Forwarder {
         gasprice: 0,
         pivotId: pivotId,
         fund: msg.value,
-        noRevert: false, // propagates Mangrove's revert data in case of newOffer failure
-        owner: msg.sender
-      })
+        noRevert: false // propagates Mangrove's revert data in case of newOffer failure
+      }),
+      msg.sender
     );
   }
 

--- a/src/strategies/offer_forwarder/abstract/Forwarder.sol
+++ b/src/strategies/offer_forwarder/abstract/Forwarder.sol
@@ -296,13 +296,7 @@ abstract contract Forwarder is IForwarder, MangroveOffer {
   /// because $~n<n$ a small amount of WEIs will accumulate on the balance of `this` on Mangrove over time.
   /// Note that these WEIs are not burnt since they can be admin retrieved using `withdrawFromMangrove`.
   /// @inheritdoc MangroveOffer
-  function __posthookFallback__(MgvLib.SingleOrder calldata order, MgvLib.OrderResult calldata result)
-    internal
-    virtual
-    override
-    returns (bytes32)
-  {
-    result; // ssh
+  function __handleResidualProvision__(MgvLib.SingleOrder calldata order) internal virtual override {
     mapping(uint => OwnerData) storage semiBookOwnerData =
       ownerData[IERC20(order.outbound_tkn)][IERC20(order.inbound_tkn)];
     // NB if several offers of `this` contract have failed during the market order, the balance of this contract on Mangrove will contain cumulated free provision
@@ -320,6 +314,5 @@ abstract contract Forwarder is IForwarder, MangroveOffer {
     // storing the portion of this contract's balance on Mangrove that should be attributed back to the failing offer's owner
     // those free WEIs can be retrieved by offer owner, by calling `retractOffer` with the `deprovision` flag.
     semiBookOwnerData[order.offerId].weiBalance += uint96(approxReturnedProvision);
-    return "";
   }
 }

--- a/src/strategies/offer_forwarder/abstract/Forwarder.sol
+++ b/src/strategies/offer_forwarder/abstract/Forwarder.sol
@@ -290,7 +290,7 @@ abstract contract Forwarder is IForwarder, MangroveOffer {
   }
 
   ///@dev if offer failed to execute, Mangrove retracts and deprovisions it after the posthook call.
-  /// As a consequence if `__posthookFallback__` is reached, `this` balance on Mangrove *will* increase, after the posthook,
+  /// As a consequence if this hook is reached, `this` balance on Mangrove *will* increase, after the posthook,
   /// of some amount $n$ of native tokens. We evaluate here an underapproximation $~n$ in order to credit the offer maker in a pull based manner:
   /// failed offer owner can retrieve $~n$ by calling `retractOffer` on the failed offer.
   /// because $~n<n$ a small amount of WEIs will accumulate on the balance of `this` on Mangrove over time.

--- a/src/strategies/offer_forwarder/abstract/Forwarder.sol
+++ b/src/strategies/offer_forwarder/abstract/Forwarder.sol
@@ -219,7 +219,7 @@ abstract contract Forwarder is IForwarder, MangroveOffer {
         return REPOST_SUCCESS;
       } catch Error(string memory reason) {
         require(args.noRevert, reason);
-        return _repostStatus(reason);
+        return bytes32(bytes(reason));
       }
     }
   }

--- a/src/strategies/offer_forwarder/abstract/Forwarder.sol
+++ b/src/strategies/offer_forwarder/abstract/Forwarder.sol
@@ -42,14 +42,14 @@ abstract contract Forwarder is IForwarder, MangroveOffer {
 
   ///@notice modifier to enforce function caller to be offer owner
   modifier onlyOwner(IERC20 outbound_tkn, IERC20 inbound_tkn, uint offerId) {
-    require(ownerData[outbound_tkn][inbound_tkn][offerId].owner == msg.sender, "Forwarder/unauthorized");
+    require(ownerData[outbound_tkn][inbound_tkn][offerId].owner == msg.sender, "AccessControlled/Invalid");
     _;
   }
 
   ///@notice modifier to enforce function caller to be offer owner or MGV (for use in the offer logic)
   modifier mgvOrOwner(IERC20 outbound_tkn, IERC20 inbound_tkn, uint offerId) {
     if (msg.sender != address(MGV)) {
-      require(ownerData[outbound_tkn][inbound_tkn][offerId].owner == msg.sender, "Forwarder/unauthorized");
+      require(ownerData[outbound_tkn][inbound_tkn][offerId].owner == msg.sender, "AccessControlled/Invalid");
     }
     _;
   }
@@ -219,12 +219,7 @@ abstract contract Forwarder is IForwarder, MangroveOffer {
         return REPOST_SUCCESS;
       } catch Error(string memory reason) {
         require(args.noRevert, reason);
-        bytes32 reason_hsh = keccak256(bytes(reason));
-        if (reason_hsh == BELOW_DENSITY) {
-          return REPOST_FAILED_DUST; // offer not reposted because residual is below density
-        } else {
-          return REPOST_FAILED; // offer not reposted for other reasons (i.e lack of provision)
-        }
+        return _repostStatus(reason);
       }
     }
   }

--- a/src/strategies/offer_maker/DirectTester.sol
+++ b/src/strategies/offer_maker/DirectTester.sol
@@ -48,7 +48,7 @@ contract DirectTester is ITesterContract, OfferMaker {
       data == "posthook/reposted" || data == "posthook/filled",
       (data == "mgv/insufficientProvision")
         ? "mgv/insufficientProvision"
-        : (data == "mgv/writeOffer/density/tooLow" ? "mgv/writeOffer/density/tooLow" : "posthookFailed")
+        : (data == "mgv/writeOffer/density/tooLow" ? "mgv/writeOffer/density/tooLow" : "posthook/failed")
     );
   }
 }

--- a/src/strategies/offer_maker/OfferMaker.sol
+++ b/src/strategies/offer_maker/OfferMaker.sol
@@ -43,8 +43,7 @@ contract OfferMaker is ILiquidityProvider, Direct {
         gasprice: 0,
         pivotId: pivotId,
         fund: msg.value,
-        noRevert: false,
-        owner: msg.sender
+        noRevert: false
       })
     );
   }
@@ -66,8 +65,7 @@ contract OfferMaker is ILiquidityProvider, Direct {
         gasprice: 0,
         pivotId: pivotId,
         fund: msg.value,
-        noRevert: false,
-        owner: msg.sender
+        noRevert: false
       }),
       offerId
     );

--- a/src/strategies/offer_maker/abstract/Direct.sol
+++ b/src/strategies/offer_maker/abstract/Direct.sol
@@ -111,7 +111,7 @@ abstract contract Direct is MangroveOffer {
       return REPOST_SUCCESS;
     } catch Error(string memory reason) {
       require(args.noRevert, reason);
-      return _repostStatus(reason);
+      return bytes32(bytes(reason));
     }
   }
 

--- a/src/strategies/offer_maker/abstract/Direct.sol
+++ b/src/strategies/offer_maker/abstract/Direct.sol
@@ -142,11 +142,7 @@ abstract contract Direct is MangroveOffer {
     override
     returns (uint provision)
   {
-    MgvStructs.OfferDetailPacked offerDetail = MGV.offerDetails(address(outbound_tkn), address(inbound_tkn), offerId);
-    (, MgvStructs.LocalPacked local) = MGV.config(address(outbound_tkn), address(inbound_tkn));
-    unchecked {
-      provision = offerDetail.gasprice() * 10 ** 9 * (local.offer_gasbase() + offerDetail.gasreq());
-    }
+    provision = _provisionOf(outbound_tkn, inbound_tkn, offerId);
   }
 
   function __put__(uint, /*amount*/ MgvLib.SingleOrder calldata) internal virtual override returns (uint missing) {

--- a/src/strategies/offer_maker/abstract/Direct.sol
+++ b/src/strategies/offer_maker/abstract/Direct.sol
@@ -111,12 +111,7 @@ abstract contract Direct is MangroveOffer {
       return REPOST_SUCCESS;
     } catch Error(string memory reason) {
       require(args.noRevert, reason);
-      bytes32 reason_hsh = keccak256(bytes(reason));
-      if (reason_hsh == BELOW_DENSITY) {
-        return REPOST_FAILED_DUST; // offer not reposted because residual is below density
-      } else {
-        return REPOST_FAILED; // offer not reposted for other reasons (i.e lack of provision)
-      }
+      return _repostStatus(reason);
     }
   }
 

--- a/src/toy_strategies/offer_forwarder/AmplifierForwarder.sol
+++ b/src/toy_strategies/offer_forwarder/AmplifierForwarder.sol
@@ -91,9 +91,9 @@ contract AmplifierForwarder is Forwarder {
         gasprice: 0, // ignored
         pivotId: pivot1,
         fund: fund1,
-        noRevert: false,
-        owner: msg.sender
-      })
+        noRevert: false
+      }),
+      msg.sender
     );
 
     offers[msg.sender].id1 = _offerId1;
@@ -109,9 +109,9 @@ contract AmplifierForwarder is Forwarder {
         gasprice: 0, // ignored
         pivotId: pivot2,
         fund: fund2,
-        noRevert: false,
-        owner: msg.sender
-      })
+        noRevert: false
+      }),
+      msg.sender
     );
     offers[msg.sender].id2 = _offerId2;
 
@@ -150,7 +150,7 @@ contract AmplifierForwarder is Forwarder {
 
       //uint prov = getMissingProvision(IERC20(order.outbound_tkn), IERC20(alt_stable), type(uint).max, 0, 0);
 
-      uint id = _updateOffer(
+      bytes32 reason = _updateOffer(
         OfferArgs({
           outbound_tkn: IERC20(order.outbound_tkn),
           inbound_tkn: IERC20(alt_stable),
@@ -160,12 +160,11 @@ contract AmplifierForwarder is Forwarder {
           gasprice: 0, // ignored
           pivotId: alt_offer.next(),
           noRevert: true,
-          fund: 0,
-          owner: owner
+          fund: 0
         }),
         alt_offerId
       );
-      if (id == 0) {
+      if (reason != "posthook/reposted") {
         // might want to Log an incident here because this should not be reachable
         return "posthook/altRepostFail";
       } else {

--- a/src/toy_strategies/offer_maker/Amplifier.sol
+++ b/src/toy_strategies/offer_maker/Amplifier.sol
@@ -87,8 +87,7 @@ contract Amplifier is Direct {
         gasprice: 0,
         pivotId: pivot1,
         fund: msg.value,
-        noRevert: false,
-        owner: msg.sender
+        noRevert: false
       })
     );
     // no need to fund this second call for provision
@@ -103,8 +102,7 @@ contract Amplifier is Direct {
         gasprice: 0,
         pivotId: pivot2,
         fund: 0,
-        noRevert: false,
-        owner: msg.sender
+        noRevert: false
       })
     );
 
@@ -144,7 +142,7 @@ contract Amplifier is Direct {
         new_alt_wants = (old_alt_wants * new_alt_gives) / old_alt_gives;
       }
       // the call below might throw
-      uint id = _updateOffer(
+      bytes32 reason = _updateOffer(
         OfferArgs({
           outbound_tkn: IERC20(order.outbound_tkn),
           inbound_tkn: IERC20(alt_stable),
@@ -153,13 +151,12 @@ contract Amplifier is Direct {
           gasreq: alt_detail.gasreq(),
           pivotId: alt_offer.next(),
           gasprice: 0,
-          owner: admin(), // ignored
           fund: 0,
           noRevert: true
         }),
         alt_offerId
       );
-      if (id == 0) {
+      if (reason != "posthook/reposted") {
         return "posthook/altOfferRepostFail";
       } else {
         return "posthook/bothOfferReposted";

--- a/src/toy_strategies/offer_maker/tutorial/OfferMakerTutorial.sol
+++ b/src/toy_strategies/offer_maker/tutorial/OfferMakerTutorial.sol
@@ -42,8 +42,7 @@ contract OfferMakerTutorial is Direct, ILiquidityProvider {
         gasprice: 0,
         pivotId: pivotId, // a best pivot estimate for cheap offer insertion in the offer list - this should be a parameter computed off-chain for cheaper insertion
         fund: msg.value, // WEIs in that are used to provision the offer.
-        noRevert: false, // we want to revert on error
-        owner: msg.sender // The sender is the owner
+        noRevert: false // we want to revert on error
       })
     );
   }
@@ -65,8 +64,7 @@ contract OfferMakerTutorial is Direct, ILiquidityProvider {
         gasprice: 0,
         pivotId: pivotId,
         fund: msg.value,
-        noRevert: false,
-        owner: msg.sender
+        noRevert: false
       }),
       offerId
     );

--- a/src/toy_strategies/offer_maker/tutorial/OfferMakerTutorialResidual.sol
+++ b/src/toy_strategies/offer_maker/tutorial/OfferMakerTutorialResidual.sol
@@ -42,8 +42,7 @@ contract OfferMakerTutorialResidual is Direct, ILiquidityProvider {
         gasprice: 0,
         pivotId: pivotId, // a best pivot estimate for cheap offer insertion in the offer list - this should be a parameter computed off-chain for cheaper insertion
         fund: msg.value, // WEIs in that are used to provision the offer.
-        noRevert: false, // we want to revert on error
-        owner: msg.sender // The sender is the owner
+        noRevert: false // we want to revert on error
       })
     );
   }
@@ -65,8 +64,7 @@ contract OfferMakerTutorialResidual is Direct, ILiquidityProvider {
         gasprice: 0,
         pivotId: pivotId,
         fund: msg.value,
-        noRevert: false,
-        owner: msg.sender
+        noRevert: false
       }),
       offerId
     );

--- a/test/core/Permit.t.sol
+++ b/test/core/Permit.t.sol
@@ -90,9 +90,9 @@ contract PermitTest is MangroveTest, TrivialTestMaker {
     mgv.newOffer($(base), $(quote), amount, amount, 100_000, 0, 0);
   }
 
-  function test_no_allowance(uint96 value) external {
+  function test_no_allowance(uint value) external {
     /* You can use 0 from someone who gave you an allowance of 0. */
-    vm.assume(value > 1_000_000); //can't create an offer below density
+    value = bound(value, reader.minVolume($(base), $(quote), 100_000), type(uint96).max); //can't create an offer below density
     deal($(base), $(this), value);
     deal($(quote), good_owner, value);
     newOffer(value);

--- a/test/core/Permit.t.sol
+++ b/test/core/Permit.t.sol
@@ -44,7 +44,7 @@ pragma solidity ^0.8.10;
 import {MangroveTest} from "mgv_test/lib/MangroveTest.sol";
 import {TrivialTestMaker, TestMaker} from "mgv_test/lib/agents/TestMaker.sol";
 import {Vm} from "forge-std/Vm.sol";
-import {StdStorage, stdStorage} from "forge-std/Test.sol";
+import {console2, StdStorage, stdStorage} from "forge-std/Test.sol";
 import {AbstractMangrove} from "mgv_src/AbstractMangrove.sol";
 
 contract PermitTest is MangroveTest, TrivialTestMaker {
@@ -92,7 +92,8 @@ contract PermitTest is MangroveTest, TrivialTestMaker {
 
   function test_no_allowance(uint96 value) external {
     /* You can use 0 from someone who gave you an allowance of 0. */
-    vm.assume(value > 0); //can't create a 0 offer
+    vm.assume(value > 10); //can't create an offer below density
+    console2.log(value);
     deal($(base), $(this), value);
     deal($(quote), good_owner, value);
     newOffer(value);

--- a/test/core/Permit.t.sol
+++ b/test/core/Permit.t.sol
@@ -92,8 +92,7 @@ contract PermitTest is MangroveTest, TrivialTestMaker {
 
   function test_no_allowance(uint96 value) external {
     /* You can use 0 from someone who gave you an allowance of 0. */
-    vm.assume(value > 10); //can't create an offer below density
-    console2.log(value);
+    vm.assume(value > 1_000_000); //can't create an offer below density
     deal($(base), $(this), value);
     deal($(quote), good_owner, value);
     newOffer(value);

--- a/test/lib/MangroveTest.sol
+++ b/test/lib/MangroveTest.sol
@@ -224,8 +224,8 @@ contract MangroveTest is Test2, HasMgvEvents {
   function setupMarket(address $a, address $b, AbstractMangrove _mgv) internal {
     assertNot0x($a);
     assertNot0x($b);
-    _mgv.activate($a, $b, options.defaultFee, 0, 20_000);
-    _mgv.activate($b, $a, options.defaultFee, 0, 20_000);
+    _mgv.activate($a, $b, options.defaultFee, 10, 20_000);
+    _mgv.activate($b, $a, options.defaultFee, 10, 20_000);
     // logging
     vm.label($a, IERC20($a).symbol());
     vm.label($b, IERC20($b).symbol());

--- a/test/lib/tokens/MintableERC20BLWithDecimals.sol
+++ b/test/lib/tokens/MintableERC20BLWithDecimals.sol
@@ -11,9 +11,9 @@ contract MintableERC20BLWithDecimals is
   mapping(address => bool) admins;
   uint public _decimals; // full uint to help forge-std's stdstore
 
-  constructor(address admin, string memory name, string memory symbol, uint8 decimals) ERC20BL(name, symbol) {
+  constructor(address admin, string memory name, string memory symbol, uint8 __decimals) ERC20BL(name, symbol) {
     admins[admin] = true;
-    _decimals = decimals;
+    _decimals = __decimals;
   }
 
   function decimals() public view virtual override returns (uint8) {

--- a/test/strategies/MgvOrder.t.sol
+++ b/test/strategies/MgvOrder.t.sol
@@ -110,7 +110,7 @@ contract MangroveOrder_Test is MangroveTest {
     });
     IOrderLogic.TakerOrderResult memory res = mgo.take{value: 0.1 ether}(buyOrder);
     assertTrue(res.offerId > 0, "Resting offer failed to be published on mangrove");
-    vm.expectRevert("Forwarder/unauthorized");
+    vm.expectRevert("AccessControlled/Invalid");
     vm.prank(freshAddress());
     mgo.updateOffer(quote, base, 1, 1, 0, res.offerId);
   }
@@ -686,7 +686,7 @@ contract MangroveOrder_Test is MangroveTest {
     });
     IOrderLogic.TakerOrderResult memory res = mgo.take{value: 0.1 ether}(buyOrder);
     assertTrue(res.offerId > 0, "resting order not posted");
-    vm.expectRevert("Forwarder/unauthorized");
+    vm.expectRevert("AccessControlled/Invalid");
     vm.prank(freshAddress());
     mgo.setExpiry(quote, base, res.offerId, block.timestamp + 70);
   }

--- a/test/strategies/MgvOrder.t.sol
+++ b/test/strategies/MgvOrder.t.sol
@@ -112,7 +112,7 @@ contract MangroveOrder_Test is MangroveTest {
     assertTrue(res.offerId > 0, "Resting offer failed to be published on mangrove");
     vm.expectRevert("AccessControlled/Invalid");
     vm.prank(freshAddress());
-    mgo.updateOffer(quote, base, 1, 1, 0, res.offerId);
+    mgo.updateOffer(quote, base, 10, 10, 0, res.offerId);
   }
 
   function test_owner_can_update_offer() public {
@@ -129,8 +129,8 @@ contract MangroveOrder_Test is MangroveTest {
     });
     IOrderLogic.TakerOrderResult memory res = mgo.take{value: 0.1 ether}(buyOrder);
     assertTrue(res.offerId > 0, "Resting offer failed to be published on mangrove");
-    mgo.updateOffer(quote, base, 1, 1, 0, res.offerId);
-    assertEq(mgv.offers($(quote), $(base), res.offerId).gives(), 1, "Offer incorrectly updated");
+    mgo.updateOffer(quote, base, 1 ether, 1 ether, 0, res.offerId);
+    assertEq(mgv.offers($(quote), $(base), res.offerId).gives(), 1 ether, "Offer incorrectly updated");
   }
 
   function test_partial_filled_buy_order_returns_residual() public {

--- a/test/strategies/unit/OfferLogic.t.sol
+++ b/test/strategies/unit/OfferLogic.t.sol
@@ -252,6 +252,27 @@ contract OfferLogicTest is MangroveTest {
     });
   }
 
+  function test_only_maker_can_updateOffer() public {
+    vm.prank(maker);
+    uint offerId = makerContract.newOffer{value: 0.1 ether}({
+      outbound_tkn: weth,
+      inbound_tkn: usdc,
+      wants: 2000 * 10 ** 6,
+      gives: 1 * 10 ** 18,
+      pivotId: 0
+    });
+    vm.expectRevert("AccessControlled/Invalid");
+    vm.prank(freshAddress());
+    makerContract.updateOffer({
+      outbound_tkn: weth,
+      inbound_tkn: usdc,
+      wants: 2000 * 10 ** 6,
+      gives: 1 * 10 ** 18,
+      pivotId: offerId,
+      offerId: offerId
+    });
+  }
+
   function test_updateOffer_fails_when_provision_is_too_low() public {
     vm.prank(maker);
     uint offerId = makerContract.newOffer{value: 0.1 ether}({

--- a/test/strategies/unit/OfferLogic.t.sol
+++ b/test/strategies/unit/OfferLogic.t.sol
@@ -158,6 +158,10 @@ contract OfferLogicTest is MangroveTest {
     });
   }
 
+  function test_provisionOf_returns_zero_if_offer_does_not_exist() public {
+    assertEq(makerContract.provisionOf(weth, usdc, 0), 0, "Invalid returned provision");
+  }
+
   function test_maker_can_deprovision_Offer() public {
     vm.prank(maker);
     uint offerId = makerContract.newOffer{value: 0.1 ether}({

--- a/test/strategies/unit/OfferLogic.t.sol
+++ b/test/strategies/unit/OfferLogic.t.sol
@@ -360,4 +360,62 @@ contract OfferLogicTest is MangroveTest {
     vm.prank($(mgv));
     makerContract.makerPosthook(order, result);
   }
+
+  function test_reposting_fails_with_expected_reason_when_underprovisioned() public {
+    vm.prank(maker);
+    uint offerId = makerContract.newOffer{value: 0.1 ether}({
+      outbound_tkn: weth,
+      inbound_tkn: usdc,
+      wants: 2000 * 10 ** 6,
+      gives: 1 * 10 ** 18,
+      pivotId: 0
+    });
+    mgv.setGasprice(1000);
+    vm.startPrank(deployer);
+    makerContract.withdrawFromMangrove(mgv.balanceOf(address(makerContract)), payable(deployer));
+    vm.stopPrank();
+
+    MgvLib.OrderResult memory result;
+    result.mgvData = "mgv/tradeSuccess";
+    MgvLib.SingleOrder memory order;
+    order.outbound_tkn = $(weth);
+    order.inbound_tkn = $(usdc);
+    order.offerId = offerId;
+    order.wants = 0.5 ether;
+    order.gives = cash(usdc, 1000);
+    /* `offerDetail` is only populated when necessary. */
+    order.offerDetail = mgv.offerDetails($(weth), $(usdc), offerId);
+    order.offer = mgv.offers($(weth), $(usdc), offerId);
+    (order.global, order.local) = mgv.config($(weth), $(usdc));
+    vm.expectRevert("mgv/insufficientProvision");
+    vm.prank($(mgv));
+    makerContract.makerPosthook(order, result);
+  }
+
+  function test_reposting_fails_with_expected_reason_when_innactive() public {
+    vm.prank(maker);
+    uint offerId = makerContract.newOffer{value: 0.1 ether}({
+      outbound_tkn: weth,
+      inbound_tkn: usdc,
+      wants: 2000 * 10 ** 6,
+      gives: 1 * 10 ** 18,
+      pivotId: 0
+    });
+    mgv.deactivate($(weth), $(usdc));
+    MgvLib.OrderResult memory result;
+    result.mgvData = "mgv/tradeSuccess";
+    MgvLib.SingleOrder memory order;
+    order.outbound_tkn = $(weth);
+    order.inbound_tkn = $(usdc);
+    order.offerId = offerId;
+    order.wants = 0.5 ether;
+    order.gives = cash(usdc, 1000);
+    /* `offerDetail` is only populated when necessary. */
+    order.offerDetail = mgv.offerDetails($(weth), $(usdc), offerId);
+    order.offer = mgv.offers($(weth), $(usdc), offerId);
+    (order.global, order.local) = mgv.config($(weth), $(usdc));
+    vm.expectRevert("posthook/failed");
+    vm.prank($(mgv));
+    makerContract.makerPosthook(order, result);
+  }
 }


### PR DESCRIPTION
This PR addresses remaining issues raised by the audit:
* [FIXES] 5.1 Forwarder.provisionOf Calculation Is Wrong
  * `MangroveOffer` provides a corrected internal calculation for locked provision
  * `Forwarder` exposes the function and adds  offer's `weiBalance` to the returned value
* [FIXES] 5.2 Users Can Steal Funds From MangroveOrder
  * a difference between Mangrove's `offer_gasbase` of update offer's `gasbase` now also triggers a recomputation of `gasprice`
  * `__posthookSuccess__` of MangroveOffer now uses internal `_updateOffer`'s implementation provided by Forwarder (and Direct). This avoids successfully reposting an offer on someone else's provision.
  * as a consequence `_updateOffer` no longer takes the spurious argument `owner` (but takes extra argument `offerId` as compared to `_newOffer` which now requires an `owner` argument for Forwarder strats.
* [GAS OPTIM] using local and global configuration sent by Mangrove during `makerExecute` instead of calling `MGV.config`
* [FIXES NEW ISSUE] We found an issue w.r.t the computation of residual provision initially defined on 
`__posthookFallback__` in Forwarder strats. The issue is that a strat builder can potentially override this hook the following way: 
```solidity 
function __posthookFallback__(…) … {   
  super.__posthookFallback(…);     
  additional_behavior 
}  
```
and all gas cost incurred by the `additional_behavior` is not taken into account by the computation occurring in `super`. This would force strat developers to always call super at the end of their override which is a rather strong constraint. Instead we decided to enforce this by delaying the computation of the residual provision *after* `__posthookFallback__` in a dedicated hook called `__handleResidualProvision__` which is a noop by default.  Note the computation is unchanged simply done later.
* [MINOR] the emitted log `OrderSummary` in `MangroveOrder` has more data.
 