### PR TITLE
feat: reader.MGV is public

### DIFF
--- a/src/periphery/MgvReader.sol
+++ b/src/periphery/MgvReader.sol
@@ -65,7 +65,7 @@ contract MgvReader {
     MgvStructs.LocalUnpacked config10;
   }
 
-  IMangrove immutable MGV;
+  IMangrove public immutable MGV;
 
   constructor(address mgv) {
     MGV = IMangrove(payable(mgv));


### PR DESCRIPTION
Reduces odds of giving an incompatible reader/mgv to scripts (just mgv is enough)
