### PR TITLE
Revert "build(deps-dev): Bump yargs from 17.6.2 to 17.7.1 (#231)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "shelljs": "^0.8.4",
     "solcco": ">=1.0.11",
     "solpp": "^0.11.5",
-    "yargs": "^17.7.1"
+    "yargs": "^17.6.2"
   },
   "packageManager": "yarn@3.2.3"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,7 +68,7 @@ __metadata:
     shelljs: ^0.8.4
     solcco: ">=1.0.11"
     solpp: ^0.11.5
-    yargs: ^17.7.1
+    yargs: ^17.6.2
   languageName: unknown
   linkType: soft
 
@@ -2791,9 +2791,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.7.1":
-  version: 17.7.1
-  resolution: "yargs@npm:17.7.1"
+"yargs@npm:^17.6.2":
+  version: 17.6.2
+  resolution: "yargs@npm:17.6.2"
   dependencies:
     cliui: ^8.0.1
     escalade: ^3.1.1
@@ -2802,6 +2802,6 @@ __metadata:
     string-width: ^4.2.3
     y18n: ^5.0.5
     yargs-parser: ^21.1.1
-  checksum: 3d8a43c336a4942bc68080768664aca85c7bd406f018bad362fd255c41c8f4e650277f42fd65d543fce99e084124ddafee7bbfc1a5c6a8fda4cec78609dcf8d4
+  checksum: 47da1b0d854fa16d45a3ded57b716b013b2179022352a5f7467409da5a04a1eef5b3b3d97a2dfc13e8bbe5f2ffc0afe3bc6a4a72f8254e60f5a4bd7947138643
   languageName: node
   linkType: hard


### PR DESCRIPTION
This reverts commit bf6cb39ddacf4f8eef690f4ba30c2558b70e2e0c.

Apparently tripped build up.