### PR TITLE
refactor: Rename MumbaiDeploy to MumbaiMangroveDeployer

### DIFF
--- a/script/MumbaiMangroveDeployer.s.sol
+++ b/script/MumbaiMangroveDeployer.s.sol
@@ -5,7 +5,7 @@ import {ToyENS} from "mgv_lib/ToyENS.sol";
 import {MangroveDeployer} from "mgv_script/MangroveDeployer.s.sol";
 import {Deployer} from "mgv_script/lib/Deployer.sol";
 
-contract MumbaiDeploy is Deployer {
+contract MumbaiMangroveDeployer is Deployer {
   function run() public {
     new MangroveDeployer().innerRun({
       chief: broadcaster(),


### PR DESCRIPTION
We've decided to use the following naming convention for deployment scripts:

- `<Contract>Deployer`: The general deployment script for `<Contract>`
- `<Chain><Contract>Deployer`: The chain-specific deployment script for `<Contract>` on `<Chain>`.