### PR TITLE
feat: Configure oracle on deploy

### DIFF
--- a/script/MangroveDeployer.s.sol
+++ b/script/MangroveDeployer.s.sol
@@ -20,12 +20,13 @@ contract MangroveDeployer is Deployer {
     innerRun({
       chief: envHas("CHIEF") ? vm.envAddress("CHIEF") : broadcaster(),
       gasprice: envHas("GASPRICE") ? vm.envUint("GASPRICE") : 1,
-      gasmax: envHas("GASMAX") ? vm.envUint("GASMAX") : 2_000_000
+      gasmax: envHas("GASMAX") ? vm.envUint("GASMAX") : 2_000_000,
+      gasbot: envHas("GASBOT") ? vm.envAddress("GASBOT") : fork.get("Gasbot")
     });
     outputDeployment();
   }
 
-  function innerRun(address chief, uint gasprice, uint gasmax) public {
+  function innerRun(address chief, uint gasprice, uint gasmax, address gasbot) public {
     broadcast();
     if (forMultisig) {
       mgv = new Mangrove{salt:salt}({governance: chief, gasprice: gasprice, gasmax: gasmax});
@@ -42,9 +43,9 @@ contract MangroveDeployer is Deployer {
 
     broadcast();
     if (forMultisig) {
-      oracle = new MgvOracle{salt: salt}({governance_: chief, initialMutator_: chief});
+      oracle = new MgvOracle{salt: salt}({governance_: chief, initialMutator_: gasbot});
     } else {
-      oracle = new MgvOracle({governance_: chief, initialMutator_: chief});
+      oracle = new MgvOracle({governance_: chief, initialMutator_: gasbot});
     }
     fork.set("MgvOracle", address(oracle));
   }

--- a/script/MangroveDeployer.s.sol
+++ b/script/MangroveDeployer.s.sol
@@ -29,24 +29,31 @@ contract MangroveDeployer is Deployer {
   function innerRun(address chief, uint gasprice, uint gasmax, address gasbot) public {
     broadcast();
     if (forMultisig) {
-      mgv = new Mangrove{salt:salt}({governance: chief, gasprice: gasprice, gasmax: gasmax});
+      oracle = new MgvOracle{salt: salt}({governance_: chief, initialMutator_: gasbot});
     } else {
-      mgv = new Mangrove({governance: chief, gasprice: gasprice, gasmax: gasmax});
+      oracle = new MgvOracle({governance_: chief, initialMutator_: gasbot});
+    }
+    fork.set("MgvOracle", address(oracle));
+
+    broadcast();
+    if (forMultisig) {
+      mgv = new Mangrove{salt:salt}({governance: broadcaster(), gasprice: gasprice, gasmax: gasmax});
+    } else {
+      mgv = new Mangrove({governance: broadcaster(), gasprice: gasprice, gasmax: gasmax});
     }
     fork.set("Mangrove", address(mgv));
+
+    broadcast();
+    mgv.setMonitor(address(oracle));
+    broadcast();
+    mgv.setUseOracle(true);
+    broadcast();
+    mgv.setGovernance(chief);
 
     (new MgvReaderDeployer()).innerRun(address(mgv));
     reader = MgvReader(fork.get("MgvReader"));
 
     (new MgvCleanerDeployer()).innerRun(address(mgv));
     cleaner = MgvCleaner(fork.get("MgvCleaner"));
-
-    broadcast();
-    if (forMultisig) {
-      oracle = new MgvOracle{salt: salt}({governance_: chief, initialMutator_: gasbot});
-    } else {
-      oracle = new MgvOracle({governance_: chief, initialMutator_: gasbot});
-    }
-    fork.set("MgvOracle", address(oracle));
   }
 }

--- a/script/MumbaiMangroveDeployer.s.sol
+++ b/script/MumbaiMangroveDeployer.s.sol
@@ -10,7 +10,8 @@ contract MumbaiMangroveDeployer is Deployer {
     new MangroveDeployer().innerRun({
       chief: broadcaster(),
       gasprice: 50,
-      gasmax: 1_000_000
+      gasmax: 1_000_000,
+      gasbot: envHas("GASBOT") ? vm.envAddress("GASBOT") : fork.get("Gasbot")
     });
     outputDeployment();
   }

--- a/script/UseOracle.s.sol
+++ b/script/UseOracle.s.sol
@@ -2,30 +2,23 @@
 pragma solidity ^0.8.13;
 
 import {Deployer} from "mgv_script/lib/Deployer.sol";
-import {MgvOracle} from "mgv_src/periphery/MgvOracle.sol";
 import {Mangrove} from "mgv_src/Mangrove.sol";
 
-contract ConfigureMgvOracle is Deployer {
+contract UseOracle is Deployer {
   function run() public {
     innerRun({
       oracleAddress: envHas("ORACLE") ? vm.envAddress("ORACLE") : fork.get("MgvOracle"),
-      gasbotAddress: envHas("GASBOT") ? vm.envAddress("GASBOT") : fork.get("Gasbot"),
       mgvAddress: payable(envHas("MGV") ? vm.envAddress("MGV") : fork.get("Mangrove"))
     });
     outputDeployment();
   }
 
-  function innerRun(address oracleAddress, address gasbotAddress, address payable mgvAddress) public {
-    MgvOracle oracle = MgvOracle(oracleAddress);
+  function innerRun(address oracleAddress, address payable mgvAddress) public {
     Mangrove mgv = Mangrove(mgvAddress);
 
     broadcast();
-    oracle.setMutator(gasbotAddress);
-    broadcast();
-    mgv.setMonitor(address(oracle));
+    mgv.setMonitor(oracleAddress);
     broadcast();
     mgv.setUseOracle(true);
-
-    outputDeployment();
   }
 }

--- a/script/toy/MangroveJs.s.sol
+++ b/script/toy/MangroveJs.s.sol
@@ -33,14 +33,14 @@ contract MangroveJsDeploy is Deployer {
   MangroveOrder mgo;
 
   function run() public {
-    innerRun({chief: broadcaster(), gasprice: 1, gasmax: 2_000_000});
+    innerRun({chief: broadcaster(), gasprice: 1, gasmax: 2_000_000, gasbot: broadcaster()});
     outputDeployment();
   }
 
-  function innerRun(address chief, uint gasprice, uint gasmax) public {
+  function innerRun(address chief, uint gasprice, uint gasmax, address gasbot) public {
     MangroveDeployer mgvDeployer = new MangroveDeployer();
 
-    mgvDeployer.innerRun({chief: chief, gasprice: gasprice, gasmax: gasmax});
+    mgvDeployer.innerRun({chief: chief, gasprice: gasprice, gasmax: gasmax, gasbot: gasbot});
 
     address mgv = address(mgvDeployer.mgv());
 

--- a/test/script/DeactivateMarket.t.sol
+++ b/test/script/DeactivateMarket.t.sol
@@ -16,6 +16,7 @@ contract DeactivateMarketTest is Test2 {
   address chief;
   uint gasprice;
   uint gasmax;
+  address gasbot;
 
   function setUp() public {
     deployer = new MangroveDeployer();
@@ -23,7 +24,8 @@ contract DeactivateMarketTest is Test2 {
     chief = freshAddress("chief");
     gasprice = 42;
     gasmax = 8_000_000;
-    deployer.innerRun(chief, gasprice, gasmax);
+    gasbot = freshAddress("gasbot");
+    deployer.innerRun(chief, gasprice, gasmax, gasbot);
   }
 
   function test_deactivate(address tkn0, address tkn1) public {

--- a/test/script/UpdateMarket.t.sol
+++ b/test/script/UpdateMarket.t.sol
@@ -15,6 +15,7 @@ contract UpdateMarketTest is Test2 {
   address chief;
   uint gasprice;
   uint gasmax;
+  address gasbot;
 
   function setUp() public {
     deployer = new MangroveDeployer();
@@ -22,7 +23,8 @@ contract UpdateMarketTest is Test2 {
     chief = freshAddress("chief");
     gasprice = 42;
     gasmax = 8_000_000;
-    deployer.innerRun(chief, gasprice, gasmax);
+    gasbot = freshAddress("gasbot");
+    deployer.innerRun(chief, gasprice, gasmax, gasbot);
   }
 
   function test_updater(address tkn0, address tkn1) public {

--- a/test/script/lib/MangroveDeployer.t.sol
+++ b/test/script/lib/MangroveDeployer.t.sol
@@ -18,6 +18,7 @@ contract MangroveDeployerTest is Deployer, Test2 {
   address chief;
   uint gasprice;
   uint gasmax;
+  address gasbot;
 
   function setUp() public {
     mgvDeployer = new MangroveDeployer();
@@ -25,7 +26,8 @@ contract MangroveDeployerTest is Deployer, Test2 {
     chief = freshAddress("chief");
     gasprice = 42;
     gasmax = 8_000_000;
-    mgvDeployer.innerRun(chief, gasprice, gasmax);
+    gasbot = freshAddress("gasbot");
+    mgvDeployer.innerRun(chief, gasprice, gasmax, gasbot);
   }
 
   function test_toy_ens_has_addresses() public {
@@ -65,6 +67,6 @@ contract MangroveDeployerTest is Deployer, Test2 {
     bytes32 oracleGovernance = vm.load(address(oracle), bytes32(uint(0)));
     assertEq(chief, address(uint160(uint(oracleGovernance))));
     bytes32 oracleMutator = vm.load(address(oracle), bytes32(uint(1)));
-    assertEq(chief, address(uint160(uint(oracleMutator))));
+    assertEq(gasbot, address(uint160(uint(oracleMutator))));
   }
 }

--- a/test/script/strategies/MangroveOrderDeployer.t.sol
+++ b/test/script/strategies/MangroveOrderDeployer.t.sol
@@ -20,6 +20,7 @@ contract MangroveOrderDeployerTest is Deployer, Test2 {
   address chief;
   uint gasprice;
   uint gasmax;
+  address gasbot;
 
   function setUp() public {
     mgoDeployer = new MangroveOrderDeployer();
@@ -27,7 +28,8 @@ contract MangroveOrderDeployerTest is Deployer, Test2 {
     chief = freshAddress("admin");
     gasprice = 42;
     gasmax = 8_000_000;
-    (new MangroveDeployer()).innerRun(chief, gasprice, gasmax);
+    gasbot = freshAddress("gasbot");
+    (new MangroveDeployer()).innerRun(chief, gasprice, gasmax, gasbot);
   }
 
   function test_normal_deploy() public {


### PR DESCRIPTION
This PR simplifies deployment and configuration related to MgvOracle:

1. Previously, the MgvOracle mutator was set to `chief` on deploy and then changed to `gasbot` when Mangrove was configured to use the oracle. Now, the mutator is immediately set to gasbot.

2. The script to configure Mangrove to use an oracle has been simplified and now supports any oracle, not just MgvOracle.

3. Mangrove is now configured to use MgvOracle as part of the deployment script (`MangroveDeployer`).