### PR TITLE
feat: Follow consistent script conventions

### DIFF
--- a/script/ActivateMarket.s.sol
+++ b/script/ActivateMarket.s.sol
@@ -5,7 +5,7 @@ import {Deployer} from "mgv_script/lib/Deployer.sol";
 import {UpdateMarket} from "mgv_script/periphery/UpdateMarket.s.sol";
 import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
 import "mgv_src/Mangrove.sol";
-import {ERC20} from "mgv_src/toy/ERC20.sol";
+import {IERC20} from "mgv_src/IERC20.sol";
 
 import {ActivateSemibook} from "./ActivateSemibook.s.sol";
 /* Example: activate (USDC,WETH) offer lists. Assume $NATIVE_IN_USDC is the price of ETH/MATIC/native token in USDC; same for $NATIVE_IN_ETH.
@@ -21,8 +21,8 @@ contract ActivateMarket is Deployer {
     innerRun({
       mgv: Mangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
       reader: MgvReader(envAddressOrName("MGV_READER", fork.get("MgvReader"))),
-      tkn1: envAddressOrName("TKN1"),
-      tkn2: envAddressOrName("TKN2"),
+      tkn1: IERC20(envAddressOrName("TKN1")),
+      tkn2: IERC20(envAddressOrName("TKN2")),
       tkn1_in_gwei: vm.envUint("TKN1_IN_GWEI"),
       tkn2_in_gwei: vm.envUint("TKN2_IN_GWEI"),
       fee: vm.envUint("FEE")
@@ -48,8 +48,8 @@ contract ActivateMarket is Deployer {
   function innerRun(
     Mangrove mgv,
     MgvReader reader,
-    address tkn1,
-    address tkn2,
+    IERC20 tkn1,
+    IERC20 tkn2,
     uint tkn1_in_gwei,
     uint tkn2_in_gwei,
     uint fee

--- a/script/ActivateMarket.s.sol
+++ b/script/ActivateMarket.s.sol
@@ -19,8 +19,8 @@ import {ActivateSemibook} from "./ActivateSemibook.s.sol";
 contract ActivateMarket is Deployer {
   function run() public {
     innerRun({
-      mgv: Mangrove(envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove")),
-      reader: MgvReader(envHas("MGV_READER") ? envAddressOrName("MGV_READER") : fork.get("MgvReader")),
+      mgv: Mangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
+      reader: MgvReader(envAddressOrName("MGV_READER", fork.get("MgvReader"))),
       tkn1: envAddressOrName("TKN1"),
       tkn2: envAddressOrName("TKN2"),
       tkn1_in_gwei: vm.envUint("TKN1_IN_GWEI"),

--- a/script/ActivateMarket.s.sol
+++ b/script/ActivateMarket.s.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.13;
 
 import {Deployer} from "mgv_script/lib/Deployer.sol";
 import {UpdateMarket} from "mgv_script/periphery/UpdateMarket.s.sol";
-import {MgvOracle} from "mgv_src/periphery/MgvOracle.sol";
+import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
 import "mgv_src/Mangrove.sol";
 import {ERC20} from "mgv_src/toy/ERC20.sol";
 
@@ -19,12 +19,13 @@ import {ActivateSemibook} from "./ActivateSemibook.s.sol";
 contract ActivateMarket is Deployer {
   function run() public {
     innerRun({
+      mgv: Mangrove(envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove")),
+      reader: MgvReader(envHas("MGV_READER") ? envAddressOrName("MGV_READER") : fork.get("MgvReader")),
       tkn1: envAddressOrName("TKN1"),
       tkn2: envAddressOrName("TKN2"),
       tkn1_in_gwei: vm.envUint("TKN1_IN_GWEI"),
       tkn2_in_gwei: vm.envUint("TKN2_IN_GWEI"),
-      fee: vm.envUint("FEE"),
-      mgvReaderAddress: payable(envHas("MGV_READER") ? vm.envAddress("MGV_READER") : fork.get("MgvReader"))
+      fee: vm.envUint("FEE")
     });
   }
 
@@ -45,14 +46,16 @@ contract ActivateMarket is Deployer {
     3. Round to nearest integer
   */
   function innerRun(
+    Mangrove mgv,
+    MgvReader reader,
     address tkn1,
     address tkn2,
     uint tkn1_in_gwei,
     uint tkn2_in_gwei,
-    uint fee,
-    address mgvReaderAddress
+    uint fee
   ) public {
     new ActivateSemibook().innerRun({
+      mgv: mgv,
       outbound_tkn: tkn1,
       inbound_tkn: tkn2,
       outbound_in_gwei: tkn1_in_gwei,
@@ -60,12 +63,13 @@ contract ActivateMarket is Deployer {
     });
 
     new ActivateSemibook().innerRun({
+      mgv: mgv,
       outbound_tkn: tkn2,
       inbound_tkn: tkn1,
       outbound_in_gwei: tkn2_in_gwei,
       fee: fee
     });
 
-    new UpdateMarket().innerRun({tkn0: tkn1, tkn1: tkn2, mgvReaderAddress: mgvReaderAddress});
+    new UpdateMarket().innerRun({tkn0: tkn1, tkn1: tkn2, reader: reader});
   }
 }

--- a/script/ActivateSemibook.s.sol
+++ b/script/ActivateSemibook.s.sol
@@ -25,7 +25,7 @@ uint constant COVER_FACTOR = 1000;
 contract ActivateSemibook is Test2, Deployer {
   function run() public {
     innerRun({
-      mgv: Mangrove(envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove")),
+      mgv: Mangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
       outbound_tkn: envAddressOrName("OUTBOUND_TKN"),
       inbound_tkn: envAddressOrName("INBOUND_TKN"),
       outbound_in_gwei: vm.envUint("OUTBOUND_IN_GWEI"),

--- a/script/ActivateSemibook.s.sol
+++ b/script/ActivateSemibook.s.sol
@@ -26,14 +26,14 @@ contract ActivateSemibook is Test2, Deployer {
   function run() public {
     innerRun({
       mgv: Mangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
-      outbound_tkn: envAddressOrName("OUTBOUND_TKN"),
-      inbound_tkn: envAddressOrName("INBOUND_TKN"),
+      outbound_tkn: IERC20(envAddressOrName("OUTBOUND_TKN")),
+      inbound_tkn: IERC20(envAddressOrName("INBOUND_TKN")),
       outbound_in_gwei: vm.envUint("OUTBOUND_IN_GWEI"),
       fee: vm.envUint("FEE")
     });
   }
 
-  function innerRun(Mangrove mgv, address outbound_tkn, address inbound_tkn, uint outbound_in_gwei, uint fee) public {
+  function innerRun(Mangrove mgv, IERC20 outbound_tkn, IERC20 inbound_tkn, uint outbound_in_gwei, uint fee) public {
     /*
 
     The gasbase is the gas spent by Mangrove to manage one order execution.  We
@@ -61,30 +61,30 @@ contract ActivateSemibook is Test2, Deployer {
        - so density is in (base token units token)/gas
     */
     (MgvStructs.GlobalPacked global,) = mgv.config(address(0), address(0));
-    uint outbound_decimals = IERC20(outbound_tkn).decimals();
+    uint outbound_decimals = outbound_tkn.decimals();
     uint density = (COVER_FACTOR * global.gasprice() * 10 ** outbound_decimals) / outbound_in_gwei;
     console.log("Derived density (in wei per gas unit)", density);
 
     broadcast();
     mgv.activate({
-      outbound_tkn: outbound_tkn,
-      inbound_tkn: inbound_tkn,
+      outbound_tkn: address(outbound_tkn),
+      inbound_tkn: address(inbound_tkn),
       fee: fee,
       density: density,
       offer_gasbase: gasbase
     });
   }
 
-  function measureTransferGas(address tkn) internal returns (uint) {
+  function measureTransferGas(IERC20 tkn) internal returns (uint) {
     address someone = freshAddress();
     vm.prank(someone);
-    IERC20(tkn).approve(address(this), type(uint).max);
-    deal(tkn, someone, 10);
+    tkn.approve(address(this), type(uint).max);
+    deal(address(tkn), someone, 10);
     /* WARNING: gas metering is done by local execution, which means that on
      * networks that have different EIPs activated, there will be discrepancies. */
     uint post;
     uint pre = gasleft();
-    IERC20(tkn).transferFrom(someone, address(this), 1);
+    tkn.transferFrom(someone, address(this), 1);
     post = gasleft();
     return pre - post;
   }

--- a/script/ActivateSemibook.s.sol
+++ b/script/ActivateSemibook.s.sol
@@ -25,16 +25,15 @@ uint constant COVER_FACTOR = 1000;
 contract ActivateSemibook is Test2, Deployer {
   function run() public {
     innerRun({
-      outbound_tkn: vm.envAddress("OUTBOUND_TKN"),
-      inbound_tkn: vm.envAddress("INBOUND_TKN"),
+      mgv: Mangrove(envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove")),
+      outbound_tkn: envAddressOrName("OUTBOUND_TKN"),
+      inbound_tkn: envAddressOrName("INBOUND_TKN"),
       outbound_in_gwei: vm.envUint("OUTBOUND_IN_GWEI"),
       fee: vm.envUint("FEE")
     });
   }
 
-  function innerRun(address outbound_tkn, address inbound_tkn, uint outbound_in_gwei, uint fee) public {
-    Mangrove mgv = Mangrove(fork.get("Mangrove"));
-
+  function innerRun(Mangrove mgv, address outbound_tkn, address inbound_tkn, uint outbound_in_gwei, uint fee) public {
     /*
 
     The gasbase is the gas spent by Mangrove to manage one order execution.  We

--- a/script/DeactivateMarket.s.sol
+++ b/script/DeactivateMarket.s.sol
@@ -5,6 +5,8 @@ import {Deployer} from "mgv_script/lib/Deployer.sol";
 import {Mangrove} from "mgv_src/Mangrove.sol";
 import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
 import {UpdateMarket} from "mgv_script/periphery/UpdateMarket.s.sol";
+import {IERC20} from "mgv_src/IERC20.sol";
+
 
 /* Deactivate a market (aka two mangrove semibooks) & update MgvReader. */
 contract DeactivateMarket is Deployer {
@@ -12,27 +14,27 @@ contract DeactivateMarket is Deployer {
     innerRun({
       mgv: Mangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
       reader: MgvReader(envAddressOrName("MGV_READER", fork.get("MgvReader"))),
-      tkn0: envAddressOrName("TKN0"),
-      tkn1: envAddressOrName("TKN1")
+      tkn0: IERC20(envAddressOrName("TKN0")),
+      tkn1: IERC20(envAddressOrName("TKN1"))
     });
     outputDeployment();
   }
 
-  function innerRun(Mangrove mgv, MgvReader reader, address tkn0, address tkn1) public {
+  function innerRun(Mangrove mgv, MgvReader reader, IERC20 tkn0, IERC20 tkn1) public {
     broadcast();
-    mgv.deactivate(tkn0, tkn1);
+    mgv.deactivate(address(tkn0), address(tkn1));
 
     broadcast();
-    mgv.deactivate(tkn1, tkn0);
+    mgv.deactivate(address(tkn1), address(tkn0));
 
     (new UpdateMarket()).innerRun({tkn0: tkn0, tkn1: tkn1, reader: reader});
 
     smokeTest(reader, tkn0, tkn1);
   }
 
-  function smokeTest(MgvReader reader, address tkn0, address tkn1) internal view {
-    MgvReader.MarketConfig memory config = reader.marketConfig(tkn0, tkn1);
+  function smokeTest(MgvReader reader, IERC20 tkn0, IERC20 tkn1) internal view {
+    MgvReader.MarketConfig memory config = reader.marketConfig(address(tkn0), address(tkn1));
     require(!(config.config01.active || config.config10.active), "Market was not deactivated");
-    require(!reader.isMarketOpen(tkn0, tkn1), "Reader state not updated");
+    require(!reader.isMarketOpen(address(tkn0), address(tkn1)), "Reader state not updated");
   }
 }

--- a/script/DeactivateMarket.s.sol
+++ b/script/DeactivateMarket.s.sol
@@ -10,8 +10,8 @@ import {UpdateMarket} from "mgv_script/periphery/UpdateMarket.s.sol";
 contract DeactivateMarket is Deployer {
   function run() public {
     innerRun({
-      mgv: Mangrove(envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove")),
-      reader: MgvReader(envHas("MGV_READER") ? envAddressOrName("MGV_READER") : fork.get("MgvReader")),
+      mgv: Mangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
+      reader: MgvReader(envAddressOrName("MGV_READER", fork.get("MgvReader"))),
       tkn0: envAddressOrName("TKN0"),
       tkn1: envAddressOrName("TKN1")
     });

--- a/script/DeactivateMarket.s.sol
+++ b/script/DeactivateMarket.s.sol
@@ -9,21 +9,23 @@ import {UpdateMarket} from "mgv_script/periphery/UpdateMarket.s.sol";
 /* Deactivate a market (aka two mangrove semibooks) & update MgvReader. */
 contract DeactivateMarket is Deployer {
   function run() public {
-    innerRun({tkn0: envAddressOrName("TKN0"), tkn1: envAddressOrName("TKN1")});
+    innerRun({
+      mgv: Mangrove(envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove")),
+      reader: MgvReader(envHas("MGV_READER") ? envAddressOrName("MGV_READER") : fork.get("MgvReader")),
+      tkn0: envAddressOrName("TKN0"),
+      tkn1: envAddressOrName("TKN1")
+    });
     outputDeployment();
   }
 
-  function innerRun(address tkn0, address tkn1) public {
-    Mangrove mgv = Mangrove(fork.get("Mangrove"));
-    MgvReader reader = MgvReader(fork.get("MgvReader"));
-
+  function innerRun(Mangrove mgv, MgvReader reader, address tkn0, address tkn1) public {
     broadcast();
     mgv.deactivate(tkn0, tkn1);
 
     broadcast();
     mgv.deactivate(tkn1, tkn0);
 
-    (new UpdateMarket()).innerRun({tkn0: tkn0, tkn1: tkn1, mgvReaderAddress: address(reader)});
+    (new UpdateMarket()).innerRun({tkn0: tkn0, tkn1: tkn1, reader: reader});
 
     smokeTest(reader, tkn0, tkn1);
   }

--- a/script/MangroveDeployer.s.sol
+++ b/script/MangroveDeployer.s.sol
@@ -18,10 +18,10 @@ contract MangroveDeployer is Deployer {
 
   function run() public {
     innerRun({
-      chief: envHas("CHIEF") ? envAddressOrName("CHIEF") : broadcaster(),
+      chief: envAddressOrName("CHIEF", broadcaster()),
       gasprice: envHas("GASPRICE") ? vm.envUint("GASPRICE") : 1,
       gasmax: envHas("GASMAX") ? vm.envUint("GASMAX") : 2_000_000,
-      gasbot: envHas("GASBOT") ? envAddressOrName("GASBOT") : fork.get("Gasbot")
+      gasbot: envAddressOrName("GASBOT", fork.get("Gasbot"))
     });
     outputDeployment();
   }

--- a/script/MangroveDeployer.s.sol
+++ b/script/MangroveDeployer.s.sol
@@ -18,10 +18,10 @@ contract MangroveDeployer is Deployer {
 
   function run() public {
     innerRun({
-      chief: envHas("CHIEF") ? vm.envAddress("CHIEF") : broadcaster(),
+      chief: envHas("CHIEF") ? envAddressOrName("CHIEF") : broadcaster(),
       gasprice: envHas("GASPRICE") ? vm.envUint("GASPRICE") : 1,
       gasmax: envHas("GASMAX") ? vm.envUint("GASMAX") : 2_000_000,
-      gasbot: envHas("GASBOT") ? vm.envAddress("GASBOT") : fork.get("Gasbot")
+      gasbot: envHas("GASBOT") ? envAddressOrName("GASBOT") : fork.get("Gasbot")
     });
     outputDeployment();
   }
@@ -50,10 +50,10 @@ contract MangroveDeployer is Deployer {
     broadcast();
     mgv.setGovernance(chief);
 
-    (new MgvReaderDeployer()).innerRun(address(mgv));
+    (new MgvReaderDeployer()).innerRun(mgv);
     reader = MgvReader(fork.get("MgvReader"));
 
-    (new MgvCleanerDeployer()).innerRun(address(mgv));
+    (new MgvCleanerDeployer()).innerRun(mgv);
     cleaner = MgvCleaner(fork.get("MgvCleaner"));
   }
 }

--- a/script/MumbaiMangroveDeployer.s.sol
+++ b/script/MumbaiMangroveDeployer.s.sol
@@ -11,7 +11,7 @@ contract MumbaiMangroveDeployer is Deployer {
       chief: broadcaster(),
       gasprice: 50,
       gasmax: 1_000_000,
-      gasbot: envHas("GASBOT") ? vm.envAddress("GASBOT") : fork.get("Gasbot")
+      gasbot: envHas("GASBOT") ? envAddressOrName("GASBOT") : fork.get("Gasbot")
     });
     outputDeployment();
   }

--- a/script/MumbaiMangroveDeployer.s.sol
+++ b/script/MumbaiMangroveDeployer.s.sol
@@ -11,7 +11,7 @@ contract MumbaiMangroveDeployer is Deployer {
       chief: broadcaster(),
       gasprice: 50,
       gasmax: 1_000_000,
-      gasbot: envHas("GASBOT") ? envAddressOrName("GASBOT") : fork.get("Gasbot")
+      gasbot: envAddressOrName("GASBOT", fork.get("Gasbot"))
     });
     outputDeployment();
   }

--- a/script/README.md
+++ b/script/README.md
@@ -1,0 +1,44 @@
+This directory contains scripts (`*.s.sol`) for deploying, configuring, and governing the contracts of the repo.
+
+# Principles for scripts
+
+Scripts should follow these principles:
+
+1. They should follow the `*.s.sol` naming convention.
+
+2. Should have both a `run` and a `innerRun` function.
+
+   The `run` function is called when the script is called from the command line. This function should only do the following:
+
+   - interpret and validate inputs (eg env vars)
+   - call `innerRun`
+   - optionally call `outputDeployment`.
+
+   The `innerRun` function should do the actual work of the script. If it calls other scripts, it should call their `innerRun` functions.
+   &nbsp;
+
+3. Env vars should be read in the `run` function, not the `innerRun` function.
+
+   This ensures that env vars are only read by the script the user invoked and will not accidentally be picked up (and possibly misinterpreted) by another script.
+
+4. Env vars specifying contracts should always allow either a contract name or an address.
+
+   This is easily achieved by using the `envAddressOrName(envVarName<, optional default address>)` function from `Deployer`.
+
+5. Contract names should be resolved in the `run` function, not the `innerRun` function.
+
+   This helps ensure that contract addresses specified by the user when calling the outermost script are not ignored by another script (which could happen before because scripts relied on the address provided by fork.get for a hardcoded name).
+
+6. The user should always have the option to specify contract addresses via env vars.
+
+   Instead of always of relying on all addresses being registered in ToyENS and looking these up via hardcoded names, all scripts should allow contract addresses/names to be specified in env vars. This makes the scripts more flexible at no cost.
+
+   This is easily achieved by using the `envAddressOrName(envVarName<, optional default address>)` function from `Deployer`.
+
+7. Specific contract/interface types should be preferred for `innerRun` parameters instead of `address`.
+
+   This reduces the risk of passing a wrong a address from another script.
+
+8. `outputDeployment()` should be called in the `run` function, not in `innerRun`.
+
+   This ensures the outermost script is in control of when the deployment is output.

--- a/script/UseOracle.s.sol
+++ b/script/UseOracle.s.sol
@@ -7,8 +7,8 @@ import {Mangrove} from "mgv_src/Mangrove.sol";
 contract UseOracle is Deployer {
   function run() public {
     innerRun({
-      mgv: Mangrove(envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove")),
-      oracleAddress: envHas("ORACLE") ? envAddressOrName("ORACLE") : fork.get("MgvOracle")
+      mgv: Mangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
+      oracleAddress: envAddressOrName("ORACLE", fork.get("MgvOracle"))
     });
     outputDeployment();
   }

--- a/script/UseOracle.s.sol
+++ b/script/UseOracle.s.sol
@@ -7,15 +7,13 @@ import {Mangrove} from "mgv_src/Mangrove.sol";
 contract UseOracle is Deployer {
   function run() public {
     innerRun({
-      oracleAddress: envHas("ORACLE") ? vm.envAddress("ORACLE") : fork.get("MgvOracle"),
-      mgvAddress: payable(envHas("MGV") ? vm.envAddress("MGV") : fork.get("Mangrove"))
+      mgv: Mangrove(envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove")),
+      oracleAddress: envHas("ORACLE") ? envAddressOrName("ORACLE") : fork.get("MgvOracle")
     });
     outputDeployment();
   }
 
-  function innerRun(address oracleAddress, address payable mgvAddress) public {
-    Mangrove mgv = Mangrove(mgvAddress);
-
+  function innerRun(Mangrove mgv, address oracleAddress) public {
     broadcast();
     mgv.setMonitor(oracleAddress);
     broadcast();

--- a/script/UseOracle.s.sol
+++ b/script/UseOracle.s.sol
@@ -2,20 +2,22 @@
 pragma solidity ^0.8.13;
 
 import {Deployer} from "mgv_script/lib/Deployer.sol";
+
 import {Mangrove} from "mgv_src/Mangrove.sol";
+import {IMgvMonitor} from "mgv_src/MgvLib.sol";
 
 contract UseOracle is Deployer {
   function run() public {
     innerRun({
       mgv: Mangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
-      oracleAddress: envAddressOrName("ORACLE", fork.get("MgvOracle"))
+      oracle: IMgvMonitor(envAddressOrName("ORACLE", fork.get("MgvOracle")))
     });
     outputDeployment();
   }
 
-  function innerRun(Mangrove mgv, address oracleAddress) public {
+  function innerRun(Mangrove mgv, IMgvMonitor oracle) public {
     broadcast();
-    mgv.setMonitor(oracleAddress);
+    mgv.setMonitor(address(oracle));
     broadcast();
     mgv.setUseOracle(true);
   }

--- a/script/lib/Deployer.sol
+++ b/script/lib/Deployer.sol
@@ -232,6 +232,13 @@ abstract contract Deployer is Script2 {
     }
   }
 
+  function envAddressOrName(string memory envVar, address defaultAddress) internal view returns (address payable) {
+    if (envHas(envVar)) {
+      return envAddressOrName(envVar);
+    }
+    return payable(defaultAddress);
+  }
+
   function envHas(string memory envVar) internal view returns (bool) {
     try vm.envString(envVar) {
       return true;

--- a/script/periphery/MgvCleanerDeployer.s.sol
+++ b/script/periphery/MgvCleanerDeployer.s.sol
@@ -5,23 +5,25 @@ import {Script, console} from "forge-std/Script.sol";
 import {Deployer} from "../lib/Deployer.sol";
 
 import {MgvCleaner} from "mgv_src/periphery/MgvCleaner.sol";
+import {Mangrove} from "mgv_src/Mangrove.sol";
+
 /**
  * @notice deploys a MgvReader instance
  */
 
 contract MgvCleanerDeployer is Deployer {
   function run() public {
-    innerRun({mgv: envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove")});
+    innerRun({mgv: Mangrove(envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove"))});
     outputDeployment();
   }
 
-  function innerRun(address mgv) public {
+  function innerRun(Mangrove mgv) public {
     broadcast();
     MgvCleaner cleaner;
     if (forMultisig) {
-      cleaner = new MgvCleaner{salt:salt}({mgv: payable(mgv)});
+      cleaner = new MgvCleaner{salt:salt}({mgv: address(mgv)});
     } else {
-      cleaner = new MgvCleaner({mgv: payable(mgv)});
+      cleaner = new MgvCleaner({mgv: address(mgv)});
     }
     fork.set("MgvCleaner", address(cleaner));
   }

--- a/script/periphery/MgvCleanerDeployer.s.sol
+++ b/script/periphery/MgvCleanerDeployer.s.sol
@@ -13,7 +13,7 @@ import {Mangrove} from "mgv_src/Mangrove.sol";
 
 contract MgvCleanerDeployer is Deployer {
   function run() public {
-    innerRun({mgv: Mangrove(envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove"))});
+    innerRun({mgv: Mangrove(envAddressOrName("MGV", fork.get("Mangrove")))});
     outputDeployment();
   }
 

--- a/script/periphery/MgvReaderDeployer.s.sol
+++ b/script/periphery/MgvReaderDeployer.s.sol
@@ -13,7 +13,7 @@ import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
 
 contract MgvReaderDeployer is Deployer {
   function run() public {
-    innerRun({mgv: Mangrove(envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove"))});
+    innerRun({mgv: Mangrove(envAddressOrName("MGV", fork.get("Mangrove")))});
     outputDeployment();
   }
 

--- a/script/periphery/MgvReaderDeployer.s.sol
+++ b/script/periphery/MgvReaderDeployer.s.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.13;
 import {Script, console} from "forge-std/Script.sol";
 import {Deployer} from "../lib/Deployer.sol";
 
+import {Mangrove} from "mgv_src/Mangrove.sol";
 import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
 
 /**
@@ -12,17 +13,17 @@ import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
 
 contract MgvReaderDeployer is Deployer {
   function run() public {
-    innerRun({mgv: envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove")});
+    innerRun({mgv: Mangrove(envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove"))});
     outputDeployment();
   }
 
-  function innerRun(address mgv) public {
+  function innerRun(Mangrove mgv) public {
     MgvReader reader;
     broadcast();
     if (forMultisig) {
-      reader = new MgvReader{salt:salt}({mgv: payable(mgv)});
+      reader = new MgvReader{salt:salt}({mgv: address(mgv)});
     } else {
-      reader = new MgvReader({mgv: payable(mgv)});
+      reader = new MgvReader({mgv: address(mgv)});
     }
     fork.set("MgvReader", address(reader));
   }

--- a/script/periphery/UpdateMarket.s.sol
+++ b/script/periphery/UpdateMarket.s.sol
@@ -13,30 +13,26 @@ import "forge-std/console.sol";
   The token pair is not directed! You do not need to call it once with
   (tkn0,tkn1) then (tkn1,tkn0). Doing it once is fine.*/
 contract UpdateMarket is Deployer {
-  MgvReader reader;
-
   function run() public {
     innerRun({
+      reader: MgvReader(envHas("MGV_READER") ? envAddressOrName("MGV_READER") : fork.get("MgvReader")),
       tkn0: envAddressOrName("TKN0"),
-      tkn1: envAddressOrName("TKN1"),
-      mgvReaderAddress: payable(envHas("MGV_READER") ? vm.envAddress("MGV_READER") : fork.get("MgvReader"))
+      tkn1: envAddressOrName("TKN1")
     });
     outputDeployment();
   }
 
-  function innerRun(address tkn0, address tkn1, address mgvReaderAddress) public {
-    reader = MgvReader(mgvReaderAddress);
-
+  function innerRun(MgvReader reader, address tkn0, address tkn1) public {
     console.log("Updating Market on MgvReader.  tkn0: %s, tkn1: %s", vm.toString(tkn0), vm.toString(tkn1));
-    logReaderState("[before script]", tkn0, tkn1);
+    logReaderState("[before script]", reader, tkn0, tkn1);
 
     broadcast();
     reader.updateMarket(tkn0, tkn1);
 
-    logReaderState("[after  script]", tkn0, tkn1);
+    logReaderState("[after  script]", reader, tkn0, tkn1);
   }
 
-  function logReaderState(string memory intro, address tkn0, address tkn1) internal view {
+  function logReaderState(string memory intro, MgvReader reader, address tkn0, address tkn1) internal view {
     string memory open = reader.isMarketOpen(tkn0, tkn1) ? "open" : "closed";
     console.log("%s MgvReader sees market as: %s", intro, open);
   }

--- a/script/periphery/UpdateMarket.s.sol
+++ b/script/periphery/UpdateMarket.s.sol
@@ -15,7 +15,7 @@ import "forge-std/console.sol";
 contract UpdateMarket is Deployer {
   function run() public {
     innerRun({
-      reader: MgvReader(envHas("MGV_READER") ? envAddressOrName("MGV_READER") : fork.get("MgvReader")),
+      reader: MgvReader(envAddressOrName("MGV_READER", fork.get("MgvReader"))),
       tkn0: envAddressOrName("TKN0"),
       tkn1: envAddressOrName("TKN1")
     });

--- a/script/periphery/UpdateMarket.s.sol
+++ b/script/periphery/UpdateMarket.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
+import {IERC20} from "mgv_src/IERC20.sol";
 import {Deployer} from "mgv_script/lib/Deployer.sol";
 import "forge-std/console.sol";
 
@@ -16,24 +17,24 @@ contract UpdateMarket is Deployer {
   function run() public {
     innerRun({
       reader: MgvReader(envAddressOrName("MGV_READER", fork.get("MgvReader"))),
-      tkn0: envAddressOrName("TKN0"),
-      tkn1: envAddressOrName("TKN1")
+      tkn0: IERC20(envAddressOrName("TKN0")),
+      tkn1: IERC20(envAddressOrName("TKN1"))
     });
     outputDeployment();
   }
 
-  function innerRun(MgvReader reader, address tkn0, address tkn1) public {
-    console.log("Updating Market on MgvReader.  tkn0: %s, tkn1: %s", vm.toString(tkn0), vm.toString(tkn1));
+  function innerRun(MgvReader reader, IERC20 tkn0, IERC20 tkn1) public {
+    console.log("Updating Market on MgvReader.  tkn0: %s, tkn1: %s", vm.toString(address(tkn0)), vm.toString(address(tkn1)));
     logReaderState("[before script]", reader, tkn0, tkn1);
 
     broadcast();
-    reader.updateMarket(tkn0, tkn1);
+    reader.updateMarket(address(tkn0), address(tkn1));
 
     logReaderState("[after  script]", reader, tkn0, tkn1);
   }
 
-  function logReaderState(string memory intro, MgvReader reader, address tkn0, address tkn1) internal view {
-    string memory open = reader.isMarketOpen(tkn0, tkn1) ? "open" : "closed";
+  function logReaderState(string memory intro, MgvReader reader, IERC20 tkn0, IERC20 tkn1) internal view {
+    string memory open = reader.isMarketOpen(address(tkn0), address(tkn1)) ? "open" : "closed";
     console.log("%s MgvReader sees market as: %s", intro, open);
   }
 }

--- a/script/strategies/kandel/AavePooledRouterDeployer.s.sol
+++ b/script/strategies/kandel/AavePooledRouterDeployer.s.sol
@@ -8,7 +8,10 @@ import {Deployer} from "mgv_script/lib/Deployer.sol";
 ///@title  AavePooledRouter deployer
 contract AavePooledRouterDeployer is Deployer {
   function run() public {
-    innerRun({addressProvider: fork.get("Aave"), overhead: vm.envUint("GASREQ")});
+    innerRun({
+      addressProvider: envHas("AAVE") ? envAddressOrName("AAVE") : fork.get("Aave"),
+      overhead: vm.envUint("GASREQ")
+    });
   }
 
   function innerRun(address addressProvider, uint overhead) public {

--- a/script/strategies/kandel/AavePooledRouterDeployer.s.sol
+++ b/script/strategies/kandel/AavePooledRouterDeployer.s.sol
@@ -9,7 +9,7 @@ import {Deployer} from "mgv_script/lib/Deployer.sol";
 contract AavePooledRouterDeployer is Deployer {
   function run() public {
     innerRun({
-      addressProvider: envHas("AAVE") ? envAddressOrName("AAVE") : fork.get("Aave"),
+      addressProvider: envAddressOrName("AAVE", fork.get("Aave")),
       overhead: vm.envUint("GASREQ")
     });
   }

--- a/script/strategies/kandel/KandelDeployer.s.sol
+++ b/script/strategies/kandel/KandelDeployer.s.sol
@@ -20,7 +20,7 @@ contract KandelDeployer is Deployer {
 
   function run() public {
     innerRun({
-      mgv: IMangrove(envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove")),
+      mgv: IMangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
       base: envAddressOrName("BASE"),
       quote: envAddressOrName("QUOTE"),
       gaspriceFactor: vm.envUint("GASPRICE_FACTOR"), // 10 means cover 10x the current gasprice of Mangrove

--- a/script/strategies/kandel/KandelDeployer.s.sol
+++ b/script/strategies/kandel/KandelDeployer.s.sol
@@ -21,8 +21,8 @@ contract KandelDeployer is Deployer {
   function run() public {
     innerRun({
       mgv: IMangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
-      base: envAddressOrName("BASE"),
-      quote: envAddressOrName("QUOTE"),
+      base: IERC20(envAddressOrName("BASE")),
+      quote: IERC20(envAddressOrName("QUOTE")),
       gaspriceFactor: vm.envUint("GASPRICE_FACTOR"), // 10 means cover 10x the current gasprice of Mangrove
       compoundRateBase: vm.envUint("COMPOUND_RATE_BASE"), // in percent
       compoundRateQuote: vm.envUint("COMPOUND_RATE_QUOTE"), // in percent
@@ -33,8 +33,8 @@ contract KandelDeployer is Deployer {
   }
 
   /**
-   * @param base Address of the base token of the market Kandel will act on
-   * @param quote Address of the quote token of the market Kandel will act on
+   * @param base The base token of the market Kandel will act on
+   * @param quote The quote token of the market Kandel will act on
    * @param gasreq the gas required for the offer logic
    * @param gaspriceFactor multiplier of Mangrove's gasprice used to compute Kandel's provision
    * @param compoundRateBase <= 10**4, the proportion of the spread Kandel will reinvest automatically for base
@@ -43,8 +43,8 @@ contract KandelDeployer is Deployer {
    */
   function innerRun(
     IMangrove mgv,
-    address base,
-    address quote,
+    IERC20 base,
+    IERC20 quote,
     uint gasreq,
     uint gaspriceFactor,
     uint compoundRateBase,
@@ -56,8 +56,8 @@ contract KandelDeployer is Deployer {
     broadcast();
     current = new Kandel(
       mgv,
-      IERC20(base),
-      IERC20(quote),
+      base,
+      quote,
       gasreq,
       global.gasprice() * gaspriceFactor,
       broadcaster()
@@ -67,7 +67,7 @@ contract KandelDeployer is Deployer {
     broadcast();
     current.setCompoundRates(compoundRateBase * 10 ** (precision - 2), compoundRateQuote * 10 ** (precision - 2));
 
-    string memory kandelName = getName(name, IERC20(base), IERC20(quote));
+    string memory kandelName = getName(name, base, quote);
     fork.set(kandelName, address(current));
   }
 

--- a/script/strategies/kandel/KandelPopulate.s.sol
+++ b/script/strategies/kandel/KandelPopulate.s.sol
@@ -40,7 +40,8 @@ contract KandelPopulate is Deployer {
         params: params,
         initQuote: vm.envUint("INIT_QUOTE"),
         volume: vm.envUint("VOLUME"),
-        kdl: kdl
+        kdl: kdl,
+        mgvReader: MgvReader(envHas("MGV_READER") ? envAddressOrName("MGV_READER") : fork.get("MgvReader"))
       })
     );
   }
@@ -54,6 +55,7 @@ contract KandelPopulate is Deployer {
   ///@param mgv is kdl.MGV()
   ///@param base is kdl.BASE()
   ///@param quote is kdl.QUOTE()
+  ///@param mgvReader the MgvReader
 
   struct HeapArgs {
     uint from;
@@ -63,6 +65,7 @@ contract KandelPopulate is Deployer {
     uint initQuote;
     uint volume;
     GeometricKandel kdl;
+    MgvReader mgvReader;
   }
 
   struct HeapVars {
@@ -85,7 +88,7 @@ contract KandelPopulate is Deployer {
   function innerRun(HeapArgs memory args) public {
     HeapVars memory vars;
 
-    vars.mgvReader = MgvReader(fork.get("MgvReader"));
+    vars.mgvReader = args.mgvReader;
     vars.BASE = args.kdl.BASE();
     vars.QUOTE = args.kdl.QUOTE();
     (

--- a/script/strategies/kandel/KandelPopulate.s.sol
+++ b/script/strategies/kandel/KandelPopulate.s.sol
@@ -41,7 +41,7 @@ contract KandelPopulate is Deployer {
         initQuote: vm.envUint("INIT_QUOTE"),
         volume: vm.envUint("VOLUME"),
         kdl: kdl,
-        mgvReader: MgvReader(envHas("MGV_READER") ? envAddressOrName("MGV_READER") : fork.get("MgvReader"))
+        mgvReader: MgvReader(envAddressOrName("MGV_READER", fork.get("MgvReader")))
       })
     );
   }

--- a/script/strategies/kandel/KandelSeederDeployer.s.sol
+++ b/script/strategies/kandel/KandelSeederDeployer.s.sol
@@ -18,8 +18,8 @@ import {AbstractRouter} from "mgv_src/strategies/routers/AbstractRouter.sol";
 contract KandelSeederDeployer is Deployer {
   function run() public {
     (KandelSeeder seeder, AaveKandelSeeder aaveSeeder) = innerRun({
-      mgv: IMangrove(envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove")),
-      addressesProvider: envHas("AAVE") ? envAddressOrName("AAVE") : fork.get("Aave"),
+      mgv: IMangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
+      addressesProvider: envAddressOrName("AAVE", fork.get("Aave")),
       aaveKandelGasreq: 160_000,
       kandelGasreq: 160_000,
       aaveRouterGasreq: 500_000

--- a/script/strategies/kandel/KandelSeederDeployer.s.sol
+++ b/script/strategies/kandel/KandelSeederDeployer.s.sol
@@ -18,8 +18,8 @@ import {AbstractRouter} from "mgv_src/strategies/routers/AbstractRouter.sol";
 contract KandelSeederDeployer is Deployer {
   function run() public {
     (KandelSeeder seeder, AaveKandelSeeder aaveSeeder) = innerRun({
-      mgv: IMangrove(fork.get("Mangrove")),
-      addressesProvider: fork.get("Aave"),
+      mgv: IMangrove(envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove")),
+      addressesProvider: envHas("AAVE") ? envAddressOrName("AAVE") : fork.get("Aave"),
       aaveKandelGasreq: 160_000,
       kandelGasreq: 160_000,
       aaveRouterGasreq: 500_000

--- a/script/strategies/kandel/KandelSower.s.sol
+++ b/script/strategies/kandel/KandelSower.s.sol
@@ -20,7 +20,7 @@ contract KandelSower is Deployer {
   function run() public {
     bool onAave = vm.envBool("ON_AAVE");
     innerRun({
-      mgv: IMangrove(envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove")),
+      mgv: IMangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
       kandelSeeder: envHas("KANDEL_SEEDER")
         ? envAddressOrName("KANDEL_SEEDER")
         : onAave ? fork.get("AaveKandelSeeder") : fork.get("KandelSeeder"),

--- a/script/strategies/kandel/KandelSower.s.sol
+++ b/script/strategies/kandel/KandelSower.s.sol
@@ -18,27 +18,44 @@ import {MangroveTest, Test} from "mgv_test/lib/MangroveTest.sol";
 
 contract KandelSower is Deployer {
   function run() public {
+    bool onAave = vm.envBool("ON_AAVE");
     innerRun({
+      mgv: IMangrove(envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove")),
+      kandelSeeder: envHas("KANDEL_SEEDER")
+        ? envAddressOrName("KANDEL_SEEDER")
+        : onAave ? fork.get("AaveKandelSeeder") : fork.get("KandelSeeder"),
       base: envAddressOrName("BASE"),
       quote: envAddressOrName("QUOTE"),
       gaspriceFactor: vm.envUint("GASPRICE_FACTOR"), // 10 means cover 10x the current gasprice of Mangrove
       sharing: vm.envBool("SHARING"),
-      onAave: vm.envBool("ON_AAVE")
+      onAave: onAave,
+      name: envHas("NAME") ? vm.envString("NAME") : ""
     });
     outputDeployment();
   }
 
   /**
+   * @param mgv The Mangrove Kandel will trade on
+   * @param kandelSeeder The address of the (Aave)KandelSeeder
    * @param base Address of the base token of the market Kandel will act on
    * @param quote Address of the quote token of the market Kandel will act on
    * @param gaspriceFactor multiplier of Mangrove's gasprice used to compute Kandel's provision
    * @param sharing whether the deployed (aave) Kandel should allow shared liquidity
    * @param onAave whether AaveKandel should be deployed instead of Kandel
+   * @param name The name to register the deployed Kandel instance under. If empty, a name will be generated
    */
-  function innerRun(address base, address quote, uint gaspriceFactor, bool sharing, bool onAave) public {
-    IMangrove mgv = IMangrove(fork.get("Mangrove"));
+  function innerRun(
+    IMangrove mgv,
+    address kandelSeeder,
+    address base,
+    address quote,
+    uint gaspriceFactor,
+    bool sharing,
+    bool onAave,
+    string memory name
+  ) public {
     (MgvStructs.GlobalPacked global,) = mgv.config(address(0), address(0));
-    AbstractKandelSeeder seeder = AbstractKandelSeeder(onAave ? fork.get("AaveKandelSeeder") : fork.get("KandelSeeder"));
+    AbstractKandelSeeder seeder = AbstractKandelSeeder(kandelSeeder);
 
     broadcast();
     GeometricKandel kdl = seeder.sow(
@@ -50,15 +67,15 @@ contract KandelSower is Deployer {
       })
     );
 
-    string memory kandelName = getName(IERC20(base), IERC20(quote), onAave);
+    string memory kandelName = getName(name, IERC20(base), IERC20(quote), onAave);
     fork.set(kandelName, address(kdl));
     smokeTest(kdl, onAave);
   }
 
-  function getName(IERC20 base, IERC20 quote, bool onAave) public view returns (string memory) {
-    try vm.envString("NAME") returns (string memory name) {
+  function getName(string memory name, IERC20 base, IERC20 quote, bool onAave) public view returns (string memory) {
+    if (bytes(name).length > 0) {
       return name;
-    } catch {
+    } else {
       string memory baseName = onAave ? "AaveKandel_" : "Kandel_";
       return string.concat(baseName, base.symbol(), "_", quote.symbol());
     }

--- a/script/strategies/mango/MangoDeployer.s.sol
+++ b/script/strategies/mango/MangoDeployer.s.sol
@@ -33,8 +33,8 @@ contract MangoDeployer is Deployer {
   function run() public {
     innerRun({
       mgv: IMangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
-      base: envAddressOrName("BASE"),
-      quote: envAddressOrName("QUOTE"),
+      base: IERC20(envAddressOrName("BASE")),
+      quote: IERC20(envAddressOrName("QUOTE")),
       base_0: vm.envUint("BASE_0"),
       quote_0: vm.envUint("QUOTE_0"),
       nslots: vm.envUint("NSLOTS"),
@@ -47,8 +47,8 @@ contract MangoDeployer is Deployer {
 
   /**
    * @param mgv The Mangrove that Mango will trade on
-   * @param base Address of the base currency of the market Mango will act upon
-   * @param quote Addres of the quote of Mango's market
+   * @param base The base currency of the market Mango will act upon
+   * @param quote The quote currency of Mango's market
    * @param base_0 in units of base. Amounts of initial `makerGives` for Mango's asks
    * @param quote_0 in units of quote. Amounts of initial `makerGives` for Mango's bids
    * @notice min price of Mango is determined by `quote_0/base_0`
@@ -59,8 +59,8 @@ contract MangoDeployer is Deployer {
    */
   function innerRun(
     IMangrove mgv,
-    address base,
-    address quote,
+    IERC20 base,
+    IERC20 quote,
     uint base_0,
     uint quote_0,
     uint nslots,
@@ -72,15 +72,15 @@ contract MangoDeployer is Deployer {
     console.log(broadcaster(), broadcaster().balance);
     current = new Mango(
       mgv,
-      IERC20(base),
-      IERC20(quote),
+      base,
+      quote,
       base_0,
       quote_0,
       nslots,
       price_incr,
       admin
     );
-    string memory mangoName = getName(name, IERC20(base), IERC20(quote));
+    string memory mangoName = getName(name, base, quote);
     fork.set(mangoName, address(current));
   }
 

--- a/script/strategies/mango/MangoDeployer.s.sol
+++ b/script/strategies/mango/MangoDeployer.s.sol
@@ -32,7 +32,7 @@ contract MangoDeployer is Deployer {
 
   function run() public {
     innerRun({
-      mgv: IMangrove(envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove")),
+      mgv: IMangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
       base: envAddressOrName("BASE"),
       quote: envAddressOrName("QUOTE"),
       base_0: vm.envUint("BASE_0"),

--- a/script/strategies/mango/ShiftMango.s.sol
+++ b/script/strategies/mango/ShiftMango.s.sol
@@ -29,18 +29,18 @@ contract ShiftMango is Deployer {
 
   function run() public {
     innerRun({
-      mgo: payable(envAddressOrName("MANGO")),
+      mgo: Mango(envAddressOrName("MANGO")),
       shift: vm.envInt("SHIFT"),
       default_gives_amount: vm.envUint("DEFAULT_GIVES_AMOUNT")
     });
   }
 
   function innerRun(
-    address payable mgo,
+    Mango mgo,
     int shift,
     uint default_gives_amount // in base amount if shift < 0, in quote amount otherwise
   ) public {
-    MGO = Mango(mgo);
+    MGO = mgo;
     require(MGO.admin() == broadcaster(), "This script requires admin rights");
     BASE = MGO.BASE();
     console.log("This mango uses", BASE.symbol(), "as base");

--- a/script/strategies/mango/ShiftMango.s.sol
+++ b/script/strategies/mango/ShiftMango.s.sol
@@ -29,7 +29,7 @@ contract ShiftMango is Deployer {
 
   function run() public {
     innerRun({
-      mgo: payable(vm.envAddress("MANGO")),
+      mgo: payable(envAddressOrName("MANGO")),
       shift: vm.envInt("SHIFT"),
       default_gives_amount: vm.envUint("DEFAULT_GIVES_AMOUNT")
     });

--- a/script/strategies/mango/StopMango.s.sol
+++ b/script/strategies/mango/StopMango.s.sol
@@ -24,7 +24,7 @@ import {Deployer} from "mgv_script/lib/Deployer.sol";
 
 contract StopMango is Deployer {
   function run() public {
-    innerRun({$mgo: payable(vm.envAddress("MANGO")), from: vm.envUint("FROM"), to: vm.envUint("TO")});
+    innerRun({$mgo: payable(envAddressOrName("MANGO")), from: vm.envUint("FROM"), to: vm.envUint("TO")});
   }
 
   function innerRun(address payable $mgo, uint from, uint to) public {

--- a/script/strategies/mango/StopMango.s.sol
+++ b/script/strategies/mango/StopMango.s.sol
@@ -24,11 +24,10 @@ import {Deployer} from "mgv_script/lib/Deployer.sol";
 
 contract StopMango is Deployer {
   function run() public {
-    innerRun({$mgo: payable(envAddressOrName("MANGO")), from: vm.envUint("FROM"), to: vm.envUint("TO")});
+    innerRun({mgo: Mango(envAddressOrName("MANGO")), from: vm.envUint("FROM"), to: vm.envUint("TO")});
   }
 
-  function innerRun(address payable $mgo, uint from, uint to) public {
-    Mango mgo = Mango($mgo);
+  function innerRun(Mango mgo, uint from, uint to) public {
     uint n = mgo.NSLOTS();
     require(mgo.admin() == broadcaster(), "This script requires admin rights");
     require(from < n, "invalid start index");
@@ -39,7 +38,7 @@ contract StopMango is Deployer {
       from, // from
       to
     );
-    uint bal = mgo.MGV().balanceOf($mgo);
+    uint bal = mgo.MGV().balanceOf(payable(mgo));
     if (bal > 0) {
       collected += bal;
       broadcast();

--- a/script/strategies/mangroveOrder/ActivateMangroveOrder.s.sol
+++ b/script/strategies/mangroveOrder/ActivateMangroveOrder.s.sol
@@ -12,26 +12,35 @@ import {Deployer} from "mgv_script/lib/Deployer.sol";
     mgvOrder: address of MangroveOrder contract
     tkns: array of token addresses to activate
    
-    The TKNS env variable should be given as a comma-separated list of names (known by ens).
+    The TKNS env variable should be given as a comma-separated list of names (known by ens) or addresses.
     For instance:
 
   TKNS="DAI,USDC,WETH,DAI_AAVE,USDC_AAVE,WETH_AAVE" forge script --fork-url mumbai ActivateMangroveOrder*/
 
 contract ActivateMangroveOrder is Deployer {
   function run() public {
-    innerRun({mgvOrder: MangroveOrder(fork.get("MangroveOrder")), tkns: vm.envString("TKNS", ",")});
+    string[] memory tkns_env = vm.envString("TKNS", ",");
+    address[] memory tkns = new address[](tkns_env.length);
+    for (uint i = 0; i < tkns_env.length; ++i) {
+      tkns[i] = envAddressOrName(tkns_env[i]);
+    }
+
+    innerRun({
+      mgvOrder: MangroveOrder(envHas("MANGROVE_ORDER") ? envAddressOrName("MANGROVE_ORDER") : fork.get("MangroveOrder")),
+      tkns: tkns
+    });
   }
 
-  function innerRun(MangroveOrder mgvOrder, string[] memory tkns) public {
+  function innerRun(MangroveOrder mgvOrder, address[] memory tkns) public {
     console.log("MangroveOrder (%s) is acting of Mangrove (%s)", address(mgvOrder), address(mgvOrder.MGV()));
     console.log("Activating tokens...");
     IERC20[] memory iercs = new IERC20[](tkns.length);
     for (uint i = 0; i < tkns.length; ++i) {
-      iercs[i] = IERC20(fork.get(tkns[i]));
+      iercs[i] = IERC20(tkns[i]);
       console.log("%s (%s)", iercs[i].symbol(), address(iercs[i]));
     }
     broadcast();
-    MangroveOrder(payable(mgvOrder)).activate(iercs);
+    mgvOrder.activate(iercs);
     console.log("done!");
   }
 }

--- a/script/strategies/mangroveOrder/ActivateMangroveOrder.s.sol
+++ b/script/strategies/mangroveOrder/ActivateMangroveOrder.s.sol
@@ -26,7 +26,7 @@ contract ActivateMangroveOrder is Deployer {
     }
 
     innerRun({
-      mgvOrder: MangroveOrder(envHas("MANGROVE_ORDER") ? envAddressOrName("MANGROVE_ORDER") : fork.get("MangroveOrder")),
+      mgvOrder: MangroveOrder(envAddressOrName("MANGROVE_ORDER", fork.get("MangroveOrder"))),
       tkns: tkns
     });
   }

--- a/script/strategies/mangroveOrder/ActivateMangroveOrder.s.sol
+++ b/script/strategies/mangroveOrder/ActivateMangroveOrder.s.sol
@@ -19,24 +19,22 @@ import {Deployer} from "mgv_script/lib/Deployer.sol";
 
 contract ActivateMangroveOrder is Deployer {
   function run() public {
-    string[] memory tkns_env = vm.envString("TKNS", ",");
-    address[] memory tkns = new address[](tkns_env.length);
-    for (uint i = 0; i < tkns_env.length; ++i) {
-      tkns[i] = envAddressOrName(tkns_env[i]);
+    string[] memory tkns = vm.envString("TKNS", ",");
+    IERC20[] memory iercs = new IERC20[](tkns.length);
+    for (uint i = 0; i < tkns.length; ++i) {
+      iercs[i] = IERC20(envAddressOrName(tkns[i]));
     }
 
     innerRun({
       mgvOrder: MangroveOrder(envAddressOrName("MANGROVE_ORDER", fork.get("MangroveOrder"))),
-      tkns: tkns
+      iercs: iercs
     });
   }
 
-  function innerRun(MangroveOrder mgvOrder, address[] memory tkns) public {
+  function innerRun(MangroveOrder mgvOrder, IERC20[] memory iercs) public {
     console.log("MangroveOrder (%s) is acting of Mangrove (%s)", address(mgvOrder), address(mgvOrder.MGV()));
     console.log("Activating tokens...");
-    IERC20[] memory iercs = new IERC20[](tkns.length);
-    for (uint i = 0; i < tkns.length; ++i) {
-      iercs[i] = IERC20(tkns[i]);
+    for (uint i = 0; i < iercs.length; ++i) {
       console.log("%s (%s)", iercs[i].symbol(), address(iercs[i]));
     }
     broadcast();

--- a/script/strategies/mangroveOrder/MangroveOrderDeployer.s.sol
+++ b/script/strategies/mangroveOrder/MangroveOrderDeployer.s.sol
@@ -12,21 +12,21 @@ import {Deployer} from "mgv_script/lib/Deployer.sol";
  WRITE_DEPLOY=true forge script --fork-url mumbai MangroveOrderDeployer -vvv --broadcast --verify
     Remember to activate it using ActivateMangroveOrder
 
-  You can specify a mangrove address with the MANGROVE env var.*/
+  You can specify a mangrove address with the MGV env var.*/
 contract MangroveOrderDeployer is Deployer {
   function run() public {
-    address mgv = envHas("MANGROVE") ? envAddressOrName("MANGROVE") : fork.get("Mangrove");
-    address governance = envHas("MgvGovernance") ? envAddressOrName("MgvGovernance") : broadcaster();
-
-    innerRun({mangrove: mgv, admin: governance});
+    innerRun({
+      mgv: IMangrove(envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove")),
+      admin: envHas("MGV_GOVERNANCE") ? envAddressOrName("MGV_GOVERNANCE") : broadcaster()
+    });
     outputDeployment();
   }
 
   /**
+   * @param mgv The Mangrove that MangroveOrder should operate on
    * @param admin address of the admin on MangroveOrder after deployment
    */
-  function innerRun(address admin, address mangrove) public {
-    IMangrove mgv = IMangrove(payable(mangrove));
+  function innerRun(IMangrove mgv, address admin) public {
     MangroveOrder mgvOrder;
     broadcast();
     if (forMultisig) {

--- a/script/strategies/mangroveOrder/MangroveOrderDeployer.s.sol
+++ b/script/strategies/mangroveOrder/MangroveOrderDeployer.s.sol
@@ -16,8 +16,8 @@ import {Deployer} from "mgv_script/lib/Deployer.sol";
 contract MangroveOrderDeployer is Deployer {
   function run() public {
     innerRun({
-      mgv: IMangrove(envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove")),
-      admin: envHas("MGV_GOVERNANCE") ? envAddressOrName("MGV_GOVERNANCE") : broadcaster()
+      mgv: IMangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
+      admin: envAddressOrName("MGV_GOVERNANCE", broadcaster())
     });
     outputDeployment();
   }

--- a/script/toy/AmplifierDeployer.s.sol
+++ b/script/toy/AmplifierDeployer.s.sol
@@ -14,10 +14,11 @@ import {Deployer} from "mgv_script/lib/Deployer.sol";
 contract AmplifierDeployer is Deployer {
   function run() public {
     innerRun({
-      admin: vm.envAddress("ADMIN"),
-      base: fork.get("WETH"),
-      stable1: fork.get("USDC"),
-      stable2: fork.get("DAI")
+      mgv: IMangrove(envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove")),
+      admin: envAddressOrName("ADMIN"),
+      base: envHas("BASE") ? envAddressOrName("BASE") : fork.get("WETH"),
+      stable1: envHas("STABLE1") ? envAddressOrName("STABLE1") : fork.get("USDC"),
+      stable2: envHas("STABLE2") ? envAddressOrName("STABLE2") : fork.get("DAI")
     });
   }
 
@@ -27,9 +28,7 @@ contract AmplifierDeployer is Deployer {
    * @param stable1 address of the first stable coin on Amplifier after deployment
    * @param stable2 address of the second stable coin on Amplifier after deployment
    */
-  function innerRun(address admin, address base, address stable1, address stable2) public {
-    IMangrove mgv = IMangrove(fork.get("Mangrove"));
-
+  function innerRun(IMangrove mgv, address admin, address base, address stable1, address stable2) public {
     try fork.get("Amplifier") returns (address payable old_amplifier_address) {
       Amplifier old_amplifier = Amplifier(old_amplifier_address);
       uint bal = mgv.balanceOf(old_amplifier_address);

--- a/script/toy/AmplifierDeployer.s.sol
+++ b/script/toy/AmplifierDeployer.s.sol
@@ -14,11 +14,11 @@ import {Deployer} from "mgv_script/lib/Deployer.sol";
 contract AmplifierDeployer is Deployer {
   function run() public {
     innerRun({
-      mgv: IMangrove(envHas("MGV") ? envAddressOrName("MGV") : fork.get("Mangrove")),
+      mgv: IMangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
       admin: envAddressOrName("ADMIN"),
-      base: envHas("BASE") ? envAddressOrName("BASE") : fork.get("WETH"),
-      stable1: envHas("STABLE1") ? envAddressOrName("STABLE1") : fork.get("USDC"),
-      stable2: envHas("STABLE2") ? envAddressOrName("STABLE2") : fork.get("DAI")
+      base: envAddressOrName("BASE", fork.get("WETH")),
+      stable1: envAddressOrName("STABLE1", fork.get("USDC")),
+      stable2: envAddressOrName("STABLE2", fork.get("DAI"))
     });
   }
 

--- a/script/toy/AmplifierDeployer.s.sol
+++ b/script/toy/AmplifierDeployer.s.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.13;
 import {Script, console} from "forge-std/Script.sol";
 import {Amplifier, AbstractRouter, IERC20, IMangrove} from "mgv_src/toy_strategies/offer_maker/Amplifier.sol";
 import {Deployer} from "mgv_script/lib/Deployer.sol";
+import {IERC20} from "mgv_src/MgvLib.sol";
 
 /*  Deploys a Amplifier instance
     First test:
@@ -16,9 +17,9 @@ contract AmplifierDeployer is Deployer {
     innerRun({
       mgv: IMangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
       admin: envAddressOrName("ADMIN"),
-      base: envAddressOrName("BASE", fork.get("WETH")),
-      stable1: envAddressOrName("STABLE1", fork.get("USDC")),
-      stable2: envAddressOrName("STABLE2", fork.get("DAI"))
+      base: IERC20(envAddressOrName("BASE", fork.get("WETH"))),
+      stable1: IERC20(envAddressOrName("STABLE1", fork.get("USDC"))),
+      stable2: IERC20(envAddressOrName("STABLE2", fork.get("DAI")))
     });
   }
 
@@ -28,7 +29,7 @@ contract AmplifierDeployer is Deployer {
    * @param stable1 address of the first stable coin on Amplifier after deployment
    * @param stable2 address of the second stable coin on Amplifier after deployment
    */
-  function innerRun(IMangrove mgv, address admin, address base, address stable1, address stable2) public {
+  function innerRun(IMangrove mgv, address admin, IERC20 base, IERC20 stable1, IERC20 stable2) public {
     try fork.get("Amplifier") returns (address payable old_amplifier_address) {
       Amplifier old_amplifier = Amplifier(old_amplifier_address);
       uint bal = mgv.balanceOf(old_amplifier_address);
@@ -46,23 +47,23 @@ contract AmplifierDeployer is Deployer {
     }
     console.log("Deploying Amplifier...");
     broadcast();
-    Amplifier amplifier = new Amplifier(mgv, IERC20(base), IERC20(stable1), IERC20(stable2), admin );
+    Amplifier amplifier = new Amplifier(mgv, base, stable1, stable2, admin );
     fork.set("Amplifier", address(amplifier));
     require(amplifier.MGV() == mgv, "Smoke test failed.");
     outputDeployment();
     console.log("Deployed!", address(amplifier));
     console.log("Activating Amplifier");
     IERC20[] memory tokens = new IERC20[](3);
-    tokens[0] = IERC20(base);
-    tokens[1] = IERC20(stable1);
-    tokens[2] = IERC20(stable2);
+    tokens[0] = base;
+    tokens[1] = stable1;
+    tokens[2] = stable2;
     broadcast();
     amplifier.activate(tokens);
     AbstractRouter router = amplifier.router();
     broadcast();
-    IERC20(base).approve(address(router), type(uint).max);
+    base.approve(address(router), type(uint).max);
     IERC20[] memory tokens2 = new IERC20[](1);
-    tokens2[0] = IERC20(base);
+    tokens2[0] = base;
     amplifier.checkList(tokens2);
   }
 }

--- a/script/toy/MangroveJs.s.sol
+++ b/script/toy/MangroveJs.s.sol
@@ -102,10 +102,10 @@ contract MangroveJsDeploy is Deployer {
 
     ActivateMarket activateMarket = new ActivateMarket();
 
-    activateMarket.innerRun(mgv, mgvReader, address(tokenA), address(tokenB), 2 * 1e9, 3 * 1e9, 0);
-    activateMarket.innerRun(mgv, mgvReader, address(dai), address(usdc), 1e9 / 1000, 1e9 / 1000, 0);
-    activateMarket.innerRun(mgv, mgvReader, address(weth), address(dai), 1e9, 1e9 / 1000, 0);
-    activateMarket.innerRun(mgv, mgvReader, address(weth), address(usdc), 1e9, 1e9 / 1000, 0);
+    activateMarket.innerRun(mgv, mgvReader, tokenA, tokenB, 2 * 1e9, 3 * 1e9, 0);
+    activateMarket.innerRun(mgv, mgvReader, dai, usdc, 1e9 / 1000, 1e9 / 1000, 0);
+    activateMarket.innerRun(mgv, mgvReader, weth, dai, 1e9, 1e9 / 1000, 0);
+    activateMarket.innerRun(mgv, mgvReader, weth, usdc, 1e9, 1e9 / 1000, 0);
 
     MangroveOrderDeployer mgoeDeployer = new MangroveOrderDeployer();
     mgoeDeployer.innerRun({admin: chief, mgv: IMangrove(payable(mgv))});

--- a/script/toy/MangroveJs.s.sol
+++ b/script/toy/MangroveJs.s.sol
@@ -9,7 +9,9 @@ import {TestToken} from "mgv_test/lib/tokens/TestToken.sol";
 import {MangroveOrderDeployer} from "mgv_script/strategies/mangroveOrder/MangroveOrderDeployer.s.sol";
 import {KandelSeederDeployer} from "mgv_script/strategies/kandel/KandelSeederDeployer.s.sol";
 import {MangroveOrder} from "mgv_src/strategies/MangroveOrder.sol";
+import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
 import {SimpleTestMaker} from "mgv_test/lib/agents/TestMaker.sol";
+import {Mangrove} from "mgv_src/Mangrove.sol";
 import {IMangrove} from "mgv_src/IMangrove.sol";
 import {Deployer} from "mgv_script/lib/Deployer.sol";
 import {ActivateMarket} from "mgv_script/ActivateMarket.s.sol";
@@ -42,8 +44,8 @@ contract MangroveJsDeploy is Deployer {
 
     mgvDeployer.innerRun({chief: chief, gasprice: gasprice, gasmax: gasmax, gasbot: gasbot});
 
-    address mgv = address(mgvDeployer.mgv());
-    address mgvReader = address(mgvDeployer.reader());
+    Mangrove mgv = mgvDeployer.mgv();
+    MgvReader mgvReader = mgvDeployer.reader();
 
     broadcast();
     tokenA = new TestToken({
@@ -100,13 +102,13 @@ contract MangroveJsDeploy is Deployer {
 
     ActivateMarket activateMarket = new ActivateMarket();
 
-    activateMarket.innerRun(address(tokenA), address(tokenB), 2 * 1e9, 3 * 1e9, 0, mgvReader);
-    activateMarket.innerRun(address(dai), address(usdc), 1e9 / 1000, 1e9 / 1000, 0, mgvReader);
-    activateMarket.innerRun(address(weth), address(dai), 1e9, 1e9 / 1000, 0, mgvReader);
-    activateMarket.innerRun(address(weth), address(usdc), 1e9, 1e9 / 1000, 0, mgvReader);
+    activateMarket.innerRun(mgv, mgvReader, address(tokenA), address(tokenB), 2 * 1e9, 3 * 1e9, 0);
+    activateMarket.innerRun(mgv, mgvReader, address(dai), address(usdc), 1e9 / 1000, 1e9 / 1000, 0);
+    activateMarket.innerRun(mgv, mgvReader, address(weth), address(dai), 1e9, 1e9 / 1000, 0);
+    activateMarket.innerRun(mgv, mgvReader, address(weth), address(usdc), 1e9, 1e9 / 1000, 0);
 
     MangroveOrderDeployer mgoeDeployer = new MangroveOrderDeployer();
-    mgoeDeployer.innerRun({admin: chief, mangrove: mgv});
+    mgoeDeployer.innerRun({admin: chief, mgv: IMangrove(payable(mgv))});
 
     address[] memory underlying =
       dynamic([address(tokenA), address(tokenB), address(dai), address(usdc), address(weth)]);

--- a/script/toy/PixieMATIC.s.sol
+++ b/script/toy/PixieMATIC.s.sol
@@ -11,7 +11,7 @@ import {PixieMATIC} from "mgv_src/toy/PixieMATIC.sol";
 
 contract PixieMATICDeployer is Deployer {
   function run() public {
-    innerRun({admin: fork.get("MgvGovernance")});
+    innerRun({admin: envHas("MGV_GOVERNANCE") ? envAddressOrName("MGV_GOVERNANCE") : fork.get("MgvGovernance")});
     outputDeployment();
   }
 

--- a/script/toy/PixieMATIC.s.sol
+++ b/script/toy/PixieMATIC.s.sol
@@ -11,7 +11,7 @@ import {PixieMATIC} from "mgv_src/toy/PixieMATIC.sol";
 
 contract PixieMATICDeployer is Deployer {
   function run() public {
-    innerRun({admin: envHas("MGV_GOVERNANCE") ? envAddressOrName("MGV_GOVERNANCE") : fork.get("MgvGovernance")});
+    innerRun({admin: envAddressOrName("MGV_GOVERNANCE", fork.get("MgvGovernance"))});
     outputDeployment();
   }
 

--- a/script/toy/PixieUSDC.s.sol
+++ b/script/toy/PixieUSDC.s.sol
@@ -11,7 +11,7 @@ import {PixieUSDC} from "mgv_src/toy/PixieUSDC.sol";
 
 contract PixieUSDCDeployer is Deployer {
   function run() public {
-    innerRun({admin: fork.get("MgvGovernance")});
+    innerRun({admin: envHas("MGV_GOVERNANCE") ? envAddressOrName("MGV_GOVERNANCE") : fork.get("MgvGovernance")});
     outputDeployment();
   }
 

--- a/script/toy/PixieUSDC.s.sol
+++ b/script/toy/PixieUSDC.s.sol
@@ -11,7 +11,7 @@ import {PixieUSDC} from "mgv_src/toy/PixieUSDC.sol";
 
 contract PixieUSDCDeployer is Deployer {
   function run() public {
-    innerRun({admin: envHas("MGV_GOVERNANCE") ? envAddressOrName("MGV_GOVERNANCE") : fork.get("MgvGovernance")});
+    innerRun({admin: envAddressOrName("MGV_GOVERNANCE", fork.get("MgvGovernance"))});
     outputDeployment();
   }
 

--- a/test/script/DeactivateMarket.t.sol
+++ b/test/script/DeactivateMarket.t.sol
@@ -35,7 +35,7 @@ contract DeactivateMarketTest is Test2 {
     vm.prank(chief);
     mgv.activate(tkn0, tkn1, 1, 1, 1);
 
-    (new UpdateMarket()).innerRun(tkn0, tkn1, address(reader));
+    (new UpdateMarket()).innerRun(reader, tkn0, tkn1);
 
     assertEq(reader.isMarketOpen(tkn0, tkn1), true, "market should be open");
 
@@ -43,6 +43,6 @@ contract DeactivateMarketTest is Test2 {
     // the script self-tests, so no need to test here. This file is only for
     // incorporating testing the script into the CI.
     deactivator.broadcaster(chief);
-    deactivator.innerRun(tkn0, tkn1);
+    deactivator.innerRun(mgv, reader, tkn0, tkn1);
   }
 }

--- a/test/script/DeactivateMarket.t.sol
+++ b/test/script/DeactivateMarket.t.sol
@@ -3,13 +3,14 @@ pragma solidity ^0.8.10;
 
 import {Deployer} from "mgv_script/lib/Deployer.sol";
 import {MangroveDeployer} from "mgv_script/MangroveDeployer.s.sol";
+import {DeactivateMarket} from "mgv_script/DeactivateMarket.s.sol";
+import {UpdateMarket} from "mgv_script/periphery/UpdateMarket.s.sol";
 
 import {Test2} from "mgv_lib/Test2.sol";
 
 import {Mangrove} from "mgv_src/Mangrove.sol";
 import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
-import {DeactivateMarket} from "mgv_script/DeactivateMarket.s.sol";
-import {UpdateMarket} from "mgv_script/periphery/UpdateMarket.s.sol";
+import {IERC20} from "mgv_src/IERC20.sol";
 
 contract DeactivateMarketTest is Test2 {
   MangroveDeployer deployer;
@@ -35,7 +36,7 @@ contract DeactivateMarketTest is Test2 {
     vm.prank(chief);
     mgv.activate(tkn0, tkn1, 1, 1, 1);
 
-    (new UpdateMarket()).innerRun(reader, tkn0, tkn1);
+    (new UpdateMarket()).innerRun(reader, IERC20(tkn0), IERC20(tkn1));
 
     assertEq(reader.isMarketOpen(tkn0, tkn1), true, "market should be open");
 
@@ -43,6 +44,6 @@ contract DeactivateMarketTest is Test2 {
     // the script self-tests, so no need to test here. This file is only for
     // incorporating testing the script into the CI.
     deactivator.broadcaster(chief);
-    deactivator.innerRun(mgv, reader, tkn0, tkn1);
+    deactivator.innerRun(mgv, reader, IERC20(tkn0), IERC20(tkn1));
   }
 }

--- a/test/script/UpdateMarket.t.sol
+++ b/test/script/UpdateMarket.t.sol
@@ -3,12 +3,13 @@ pragma solidity ^0.8.10;
 
 import {Deployer} from "mgv_script/lib/Deployer.sol";
 import {MangroveDeployer} from "mgv_script/MangroveDeployer.s.sol";
+import {UpdateMarket} from "mgv_script/periphery/UpdateMarket.s.sol";
 
 import {Test2} from "mgv_lib/Test2.sol";
 
 import {Mangrove} from "mgv_src/Mangrove.sol";
 import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
-import {UpdateMarket} from "mgv_script/periphery/UpdateMarket.s.sol";
+import {IERC20} from "mgv_src/IERC20.sol";
 
 contract UpdateMarketTest is Test2 {
   MangroveDeployer deployer;
@@ -33,19 +34,19 @@ contract UpdateMarketTest is Test2 {
 
     UpdateMarket updater = new UpdateMarket();
 
-    updater.innerRun(reader, tkn0, tkn1);
+    updater.innerRun(reader, IERC20(tkn0), IERC20(tkn1));
     assertEq(reader.isMarketOpen(tkn0, tkn1), false);
 
     vm.prank(chief);
     mgv.activate(tkn0, tkn1, 1, 1, 1);
 
-    updater.innerRun(reader, tkn0, tkn1);
+    updater.innerRun(reader, IERC20(tkn0), IERC20(tkn1));
     assertEq(reader.isMarketOpen(tkn0, tkn1), true);
 
     vm.prank(chief);
     mgv.deactivate(tkn0, tkn1);
 
-    updater.innerRun(reader, tkn0, tkn1);
+    updater.innerRun(reader, IERC20(tkn0), IERC20(tkn1));
     assertEq(reader.isMarketOpen(tkn0, tkn1), false);
   }
 }

--- a/test/script/UpdateMarket.t.sol
+++ b/test/script/UpdateMarket.t.sol
@@ -33,19 +33,19 @@ contract UpdateMarketTest is Test2 {
 
     UpdateMarket updater = new UpdateMarket();
 
-    updater.innerRun(tkn0, tkn1, address(reader));
+    updater.innerRun(reader, tkn0, tkn1);
     assertEq(reader.isMarketOpen(tkn0, tkn1), false);
 
     vm.prank(chief);
     mgv.activate(tkn0, tkn1, 1, 1, 1);
 
-    updater.innerRun(tkn0, tkn1, address(reader));
+    updater.innerRun(reader, tkn0, tkn1);
     assertEq(reader.isMarketOpen(tkn0, tkn1), true);
 
     vm.prank(chief);
     mgv.deactivate(tkn0, tkn1);
 
-    updater.innerRun(tkn0, tkn1, address(reader));
+    updater.innerRun(reader, tkn0, tkn1);
     assertEq(reader.isMarketOpen(tkn0, tkn1), false);
   }
 }

--- a/test/script/strategies/MangroveOrderDeployer.t.sol
+++ b/test/script/strategies/MangroveOrderDeployer.t.sol
@@ -35,7 +35,7 @@ contract MangroveOrderDeployerTest is Deployer, Test2 {
   function test_normal_deploy() public {
     // MangroveOrder - verify mgv is used and admin is chief
     address mgv = fork.get("Mangrove");
-    mgoDeployer.innerRun(chief, mgv);
+    mgoDeployer.innerRun(IMangrove(payable(mgv)), chief);
     MangroveOrder mgoe = MangroveOrder(fork.get("MangroveOrder"));
     address mgvOrderRouter = fork.get("MangroveOrder-Router");
 


### PR DESCRIPTION
The following conventions have been applied to all *.s.sol scripts:

1. Env vars are read in the `run` function, not the `innerRun` function.
   This ensures that env vars are only read by the script the user invoked and will not accidentally be picked up (and possibly misinterpreted) by another script.

3. Env vars specifying contracts can always contain either a contract name or an address.
   This functionality (provided by the envAddressOrName function) was used in some places, but not all, resulting in an inconsistent user experience. Contract names are resolved via the `fork.get` function, ie the ToyENS registry.

5. Contract names are resolved in the `run` function, not the `innerRun` function.
   This helps ensure that contract addresses specified by the user when calling the outermost script are not ignored by another script (which could happen before because scripts relied on the address provided by fork.get for a hardcoded name).

6. Contract addresses can always be specified by the user via env vars.
   Instead of always of relying on all addresses being registered in ToyENS and looking these up via hardcoded names, all scripts now allow contract addresses/names to be specified in env vars.

7. Specific contract/interface types are preferred for `innerRun` parameters instead of `address`.
   This reduces the risk of passing a wrong a address from another script.

8. `outputDeployment` is called in the `run` function, not in `innerRun`.
   This ensures the outermost script is in control of when the deployment is output.