### PR TITLE
feat(scripts): Add lazy interpretation default contract names in `envAddressOrName`

### DIFF
--- a/script/ActivateMarket.s.sol
+++ b/script/ActivateMarket.s.sol
@@ -19,8 +19,8 @@ import {ActivateSemibook} from "./ActivateSemibook.s.sol";
 contract ActivateMarket is Deployer {
   function run() public {
     innerRun({
-      mgv: Mangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
-      reader: MgvReader(envAddressOrName("MGV_READER", fork.get("MgvReader"))),
+      mgv: Mangrove(envAddressOrName("MGV", "Mangrove")),
+      reader: MgvReader(envAddressOrName("MGV_READER", "MgvReader")),
       tkn1: IERC20(envAddressOrName("TKN1")),
       tkn2: IERC20(envAddressOrName("TKN2")),
       tkn1_in_gwei: vm.envUint("TKN1_IN_GWEI"),

--- a/script/ActivateSemibook.s.sol
+++ b/script/ActivateSemibook.s.sol
@@ -25,7 +25,7 @@ uint constant COVER_FACTOR = 1000;
 contract ActivateSemibook is Test2, Deployer {
   function run() public {
     innerRun({
-      mgv: Mangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
+      mgv: Mangrove(envAddressOrName("MGV", "Mangrove")),
       outbound_tkn: IERC20(envAddressOrName("OUTBOUND_TKN")),
       inbound_tkn: IERC20(envAddressOrName("INBOUND_TKN")),
       outbound_in_gwei: vm.envUint("OUTBOUND_IN_GWEI"),

--- a/script/DeactivateMarket.s.sol
+++ b/script/DeactivateMarket.s.sol
@@ -12,8 +12,8 @@ import {IERC20} from "mgv_src/IERC20.sol";
 contract DeactivateMarket is Deployer {
   function run() public {
     innerRun({
-      mgv: Mangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
-      reader: MgvReader(envAddressOrName("MGV_READER", fork.get("MgvReader"))),
+      mgv: Mangrove(envAddressOrName("MGV", "Mangrove")),
+      reader: MgvReader(envAddressOrName("MGV_READER", "MgvReader")),
       tkn0: IERC20(envAddressOrName("TKN0")),
       tkn1: IERC20(envAddressOrName("TKN1"))
     });

--- a/script/MangroveDeployer.s.sol
+++ b/script/MangroveDeployer.s.sol
@@ -21,7 +21,7 @@ contract MangroveDeployer is Deployer {
       chief: envAddressOrName("CHIEF", broadcaster()),
       gasprice: envHas("GASPRICE") ? vm.envUint("GASPRICE") : 1,
       gasmax: envHas("GASMAX") ? vm.envUint("GASMAX") : 2_000_000,
-      gasbot: envAddressOrName("GASBOT", fork.get("Gasbot"))
+      gasbot: envAddressOrName("GASBOT", "Gasbot")
     });
     outputDeployment();
   }

--- a/script/MumbaiMangroveDeployer.s.sol
+++ b/script/MumbaiMangroveDeployer.s.sol
@@ -11,7 +11,7 @@ contract MumbaiMangroveDeployer is Deployer {
       chief: broadcaster(),
       gasprice: 50,
       gasmax: 1_000_000,
-      gasbot: envAddressOrName("GASBOT", fork.get("Gasbot"))
+      gasbot: envAddressOrName("GASBOT", "Gasbot")
     });
     outputDeployment();
   }

--- a/script/UseOracle.s.sol
+++ b/script/UseOracle.s.sol
@@ -9,8 +9,8 @@ import {IMgvMonitor} from "mgv_src/MgvLib.sol";
 contract UseOracle is Deployer {
   function run() public {
     innerRun({
-      mgv: Mangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
-      oracle: IMgvMonitor(envAddressOrName("ORACLE", fork.get("MgvOracle")))
+      mgv: Mangrove(envAddressOrName("MGV", "Mangrove")),
+      oracle: IMgvMonitor(envAddressOrName("ORACLE", "MgvOracle"))
     });
     outputDeployment();
   }

--- a/script/lib/Deployer.sol
+++ b/script/lib/Deployer.sol
@@ -239,6 +239,13 @@ abstract contract Deployer is Script2 {
     return payable(defaultAddress);
   }
 
+  function envAddressOrName(string memory envVar, string memory defaultName) internal view returns (address payable) {
+    if (envHas(envVar)) {
+      return envAddressOrName(envVar);
+    }
+    return fork.get(defaultName);
+  }
+
   function envHas(string memory envVar) internal view returns (bool) {
     try vm.envString(envVar) {
       return true;

--- a/script/periphery/MgvCleanerDeployer.s.sol
+++ b/script/periphery/MgvCleanerDeployer.s.sol
@@ -13,7 +13,7 @@ import {Mangrove} from "mgv_src/Mangrove.sol";
 
 contract MgvCleanerDeployer is Deployer {
   function run() public {
-    innerRun({mgv: Mangrove(envAddressOrName("MGV", fork.get("Mangrove")))});
+    innerRun({mgv: Mangrove(envAddressOrName("MGV", "Mangrove"))});
     outputDeployment();
   }
 

--- a/script/periphery/MgvReaderDeployer.s.sol
+++ b/script/periphery/MgvReaderDeployer.s.sol
@@ -13,7 +13,7 @@ import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
 
 contract MgvReaderDeployer is Deployer {
   function run() public {
-    innerRun({mgv: Mangrove(envAddressOrName("MGV", fork.get("Mangrove")))});
+    innerRun({mgv: Mangrove(envAddressOrName("MGV", "Mangrove"))});
     outputDeployment();
   }
 

--- a/script/periphery/UpdateMarket.s.sol
+++ b/script/periphery/UpdateMarket.s.sol
@@ -16,7 +16,7 @@ import "forge-std/console.sol";
 contract UpdateMarket is Deployer {
   function run() public {
     innerRun({
-      reader: MgvReader(envAddressOrName("MGV_READER", fork.get("MgvReader"))),
+      reader: MgvReader(envAddressOrName("MGV_READER", "MgvReader")),
       tkn0: IERC20(envAddressOrName("TKN0")),
       tkn1: IERC20(envAddressOrName("TKN1"))
     });

--- a/script/strategies/kandel/AavePooledRouterDeployer.s.sol
+++ b/script/strategies/kandel/AavePooledRouterDeployer.s.sol
@@ -9,7 +9,7 @@ import {Deployer} from "mgv_script/lib/Deployer.sol";
 contract AavePooledRouterDeployer is Deployer {
   function run() public {
     innerRun({
-      addressProvider: envAddressOrName("AAVE", fork.get("Aave")),
+      addressProvider: envAddressOrName("AAVE", "Aave"),
       overhead: vm.envUint("GASREQ")
     });
   }

--- a/script/strategies/kandel/KandelDeployer.s.sol
+++ b/script/strategies/kandel/KandelDeployer.s.sol
@@ -20,7 +20,7 @@ contract KandelDeployer is Deployer {
 
   function run() public {
     innerRun({
-      mgv: IMangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
+      mgv: IMangrove(envAddressOrName("MGV", "Mangrove")),
       base: IERC20(envAddressOrName("BASE")),
       quote: IERC20(envAddressOrName("QUOTE")),
       gaspriceFactor: vm.envUint("GASPRICE_FACTOR"), // 10 means cover 10x the current gasprice of Mangrove

--- a/script/strategies/kandel/KandelPopulate.s.sol
+++ b/script/strategies/kandel/KandelPopulate.s.sol
@@ -41,7 +41,7 @@ contract KandelPopulate is Deployer {
         initQuote: vm.envUint("INIT_QUOTE"),
         volume: vm.envUint("VOLUME"),
         kdl: kdl,
-        mgvReader: MgvReader(envAddressOrName("MGV_READER", fork.get("MgvReader")))
+        mgvReader: MgvReader(envAddressOrName("MGV_READER", "MgvReader"))
       })
     );
   }

--- a/script/strategies/kandel/KandelSeederDeployer.s.sol
+++ b/script/strategies/kandel/KandelSeederDeployer.s.sol
@@ -18,8 +18,8 @@ import {AbstractRouter} from "mgv_src/strategies/routers/AbstractRouter.sol";
 contract KandelSeederDeployer is Deployer {
   function run() public {
     (KandelSeeder seeder, AaveKandelSeeder aaveSeeder) = innerRun({
-      mgv: IMangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
-      addressesProvider: envAddressOrName("AAVE", fork.get("Aave")),
+      mgv: IMangrove(envAddressOrName("MGV", "Mangrove")),
+      addressesProvider: envAddressOrName("AAVE", "Aave"),
       aaveKandelGasreq: 160_000,
       kandelGasreq: 160_000,
       aaveRouterGasreq: 500_000

--- a/script/strategies/kandel/KandelSower.s.sol
+++ b/script/strategies/kandel/KandelSower.s.sol
@@ -20,7 +20,7 @@ contract KandelSower is Deployer {
   function run() public {
     bool onAave = vm.envBool("ON_AAVE");
     innerRun({
-      mgv: IMangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
+      mgv: IMangrove(envAddressOrName("MGV", "Mangrove")),
       kandelSeeder: AbstractKandelSeeder(
         envAddressOrName("KANDEL_SEEDER", onAave ? fork.get("AaveKandelSeeder") : fork.get("KandelSeeder"))
         ),

--- a/script/strategies/mango/MangoDeployer.s.sol
+++ b/script/strategies/mango/MangoDeployer.s.sol
@@ -32,7 +32,7 @@ contract MangoDeployer is Deployer {
 
   function run() public {
     innerRun({
-      mgv: IMangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
+      mgv: IMangrove(envAddressOrName("MGV", "Mangrove")),
       base: IERC20(envAddressOrName("BASE")),
       quote: IERC20(envAddressOrName("QUOTE")),
       base_0: vm.envUint("BASE_0"),

--- a/script/strategies/mangroveOrder/ActivateMangroveOrder.s.sol
+++ b/script/strategies/mangroveOrder/ActivateMangroveOrder.s.sol
@@ -26,7 +26,7 @@ contract ActivateMangroveOrder is Deployer {
     }
 
     innerRun({
-      mgvOrder: MangroveOrder(envAddressOrName("MANGROVE_ORDER", fork.get("MangroveOrder"))),
+      mgvOrder: MangroveOrder(envAddressOrName("MANGROVE_ORDER", "MangroveOrder")),
       iercs: iercs
     });
   }

--- a/script/strategies/mangroveOrder/MangroveOrderDeployer.s.sol
+++ b/script/strategies/mangroveOrder/MangroveOrderDeployer.s.sol
@@ -16,7 +16,7 @@ import {Deployer} from "mgv_script/lib/Deployer.sol";
 contract MangroveOrderDeployer is Deployer {
   function run() public {
     innerRun({
-      mgv: IMangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
+      mgv: IMangrove(envAddressOrName("MGV", "Mangrove")),
       admin: envAddressOrName("MGV_GOVERNANCE", broadcaster())
     });
     outputDeployment();

--- a/script/toy/AmplifierDeployer.s.sol
+++ b/script/toy/AmplifierDeployer.s.sol
@@ -15,11 +15,11 @@ import {IERC20} from "mgv_src/MgvLib.sol";
 contract AmplifierDeployer is Deployer {
   function run() public {
     innerRun({
-      mgv: IMangrove(envAddressOrName("MGV", fork.get("Mangrove"))),
+      mgv: IMangrove(envAddressOrName("MGV", "Mangrove")),
       admin: envAddressOrName("ADMIN"),
-      base: IERC20(envAddressOrName("BASE", fork.get("WETH"))),
-      stable1: IERC20(envAddressOrName("STABLE1", fork.get("USDC"))),
-      stable2: IERC20(envAddressOrName("STABLE2", fork.get("DAI")))
+      base: IERC20(envAddressOrName("BASE", "WETH")),
+      stable1: IERC20(envAddressOrName("STABLE1", "USDC")),
+      stable2: IERC20(envAddressOrName("STABLE2", "DAI"))
     });
   }
 

--- a/script/toy/PixieMATIC.s.sol
+++ b/script/toy/PixieMATIC.s.sol
@@ -11,7 +11,7 @@ import {PixieMATIC} from "mgv_src/toy/PixieMATIC.sol";
 
 contract PixieMATICDeployer is Deployer {
   function run() public {
-    innerRun({admin: envAddressOrName("MGV_GOVERNANCE", fork.get("MgvGovernance"))});
+    innerRun({admin: envAddressOrName("MGV_GOVERNANCE", "MgvGovernance")});
     outputDeployment();
   }
 

--- a/script/toy/PixieUSDC.s.sol
+++ b/script/toy/PixieUSDC.s.sol
@@ -11,7 +11,7 @@ import {PixieUSDC} from "mgv_src/toy/PixieUSDC.sol";
 
 contract PixieUSDCDeployer is Deployer {
   function run() public {
-    innerRun({admin: envAddressOrName("MGV_GOVERNANCE", fork.get("MgvGovernance"))});
+    innerRun({admin: envAddressOrName("MGV_GOVERNANCE", "MgvGovernance")});
     outputDeployment();
   }
 


### PR DESCRIPTION
This enables calling scripts without the default contract names being defined in the context.