### PR TITLE
feat(Core): Add deprovision flag to OfferRetract event

### DIFF
--- a/src/IMangrove.sol
+++ b/src/IMangrove.sol
@@ -25,7 +25,7 @@ interface IMangrove {
     uint takerGives,
     bytes32 mgvData
   );
-  event OfferRetract(address indexed outbound_tkn, address indexed inbound_tkn, uint id);
+  event OfferRetract(address indexed outbound_tkn, address indexed inbound_tkn, uint id, bool deprovision);
   event OfferSuccess(
     address indexed outbound_tkn, address indexed inbound_tkn, uint id, address taker, uint takerWants, uint takerGives
   );

--- a/src/MgvLib.sol
+++ b/src/MgvLib.sol
@@ -150,7 +150,7 @@ contract HasMgvEvents {
   );
 
   /* * `offerId` was present and is now removed from the book. */
-  event OfferRetract(address indexed outbound_tkn, address indexed inbound_tkn, uint id);
+  event OfferRetract(address indexed outbound_tkn, address indexed inbound_tkn, uint id, bool deprovision);
 }
 
 /* # IMaker interface */

--- a/src/MgvOfferMaking.sol
+++ b/src/MgvOfferMaking.sol
@@ -188,7 +188,7 @@ contract MgvOfferMaking is MgvHasOffers {
         // credit `balanceOf` and log transfer
         creditWei(msg.sender, provision);
       }
-      emit OfferRetract(outbound_tkn, inbound_tkn, offerId);
+      emit OfferRetract(outbound_tkn, inbound_tkn, offerId, deprovision);
     }
   }
 
@@ -267,7 +267,7 @@ contract MgvOfferMaking is MgvHasOffers {
       /* Log the write offer event. */
       emit OfferWrite(
         ofp.outbound_tkn, ofp.inbound_tkn, msg.sender, ofp.wants, ofp.gives, ofp.gasprice, ofp.gasreq, ofp.id, prev
-        );
+      );
 
       /* We now write the new `offerDetails` and remember the previous provision (0 by default, for new offers) to balance out maker's `balanceOf`. */
       uint oldProvision;

--- a/test/core/MakerOperations.t.sol
+++ b/test/core/MakerOperations.t.sol
@@ -158,7 +158,7 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     mkr.provisionMgv(1 ether);
     uint ofr = mkr.newOffer(1 ether, 1 ether, 2300, 0);
     expectFrom($(mgv));
-    emit OfferRetract($(base), $(quote), ofr);
+    emit OfferRetract($(base), $(quote), ofr, true);
     mkr.retractOfferWithDeprovision(ofr);
   }
 
@@ -203,7 +203,7 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     mkr.provisionMgv(1 ether);
     uint ofr = mkr.newOffer(0.9 ether, 1 ether, 2300, 100);
     expectFrom($(mgv));
-    emit OfferRetract($(base), $(quote), ofr);
+    emit OfferRetract($(base), $(quote), ofr, false);
     mkr.retractOffer(ofr);
   }
 
@@ -557,7 +557,7 @@ contract MakerOperationsTest is MangroveTest, IMaker {
       100_000,
       1,
       0
-      );
+    );
     expectFrom($(mgv));
     emit Debit(address(mkr), provision); // transfering missing provision into offer bounty
     uint ofr0 = mkr.newOffer(1.0 ether, 1 ether, 100_000, 0); // locking exact bounty
@@ -575,7 +575,7 @@ contract MakerOperationsTest is MangroveTest, IMaker {
       100_000,
       ofr0,
       0
-      );
+    );
     expectFrom($(mgv));
     emit Debit(address(mkr), provision_ - provision); // transfering missing provision into offer bounty
     mkr.updateOffer(1.0 ether + 2, 1.0 ether, 100_000, ofr0, ofr0);

--- a/test/core/MakerPosthook.t.sol
+++ b/test/core/MakerPosthook.t.sol
@@ -260,7 +260,7 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     expectFrom($(mgv));
     emit Credit($(this), mkr_provision);
     expectFrom($(mgv));
-    emit OfferRetract($(base), $(quote), ofr);
+    emit OfferRetract($(base), $(quote), ofr, true);
     bool success = tkr.take(ofr, 2 ether);
     assertTrue(success, "Snipe should succeed");
     assertTrue(called, "PostHook not called");
@@ -286,7 +286,7 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     expectFrom($(mgv));
     emit OfferFail($(base), $(quote), ofr, address(tkr), 1 ether, 1 ether, "mgv/makerRevert");
     expectFrom($(mgv));
-    emit OfferRetract($(base), $(quote), ofr);
+    emit OfferRetract($(base), $(quote), ofr, true);
     //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(this), 0 /*penalty*/ );
@@ -302,7 +302,7 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     expectFrom($(mgv));
     emit OfferSuccess($(base), $(quote), ofr, address(tkr), 1 ether, 1 ether);
     expectFrom($(mgv));
-    emit OfferRetract($(base), $(quote), ofr);
+    emit OfferRetract($(base), $(quote), ofr, true);
     bool success = tkr.take(ofr, 2 ether);
     assertTrue(called, "PostHook not called");
 
@@ -376,7 +376,7 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     expectFrom($(mgv));
     emit OfferFail($(base), $(quote), ofr, address(tkr), 1 ether, 1 ether, "mgv/makerRevert");
     expectFrom($(mgv));
-    emit OfferRetract($(base), $(quote), ofr);
+    emit OfferRetract($(base), $(quote), ofr, true);
     //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(this), 0 /*refund*/ );

--- a/test/strategies/kandel/abstract/CoreKandel.t.sol
+++ b/test/strategies/kandel/abstract/CoreKandel.t.sol
@@ -321,7 +321,7 @@ abstract contract CoreKandelTest is KandelTest {
     expectFrom($(kdl));
     emit RetractStart();
     expectFrom($(mgv));
-    emit OfferRetract(address(quote), address(base), kdl.offerIdOfIndex(Bid, 0));
+    emit OfferRetract(address(quote), address(base), kdl.offerIdOfIndex(Bid, 0), true);
     expectFrom($(kdl));
     emit RetractEnd();
 


### PR DESCRIPTION
When an offer is retracted we cannot discern whether it was deprovisioned by looking at events.

We do emit a `Credit` event in case deprovision is true, so one could try to discern deprovisioning based on whether that event is emitted immediately prior to the `OfferRetract` event. However, that event is also emitted by, e.g., `fund`, so looking at the event sequence within a transaction is not enough in case both retract and fund is invoked in the same TX. This is actually possible with Kandel's populate which can retract an offer, and fund mangrove in one go.

The solution is to add the "deprovision" flag to the event. This is a very tiny change, so should be good wrt audits, and the cost of the event is only applied when retractOffer is invoked.

With this change we can for all offers discern their locked provision via events, and thus the sum of that and mgv.balanceOf(maker) is the maker's entire balance on mangrove.

Locked provision is `
```solidity
provision = 10 ** 9 * offerDetail.gasprice() //gasprice is 0 if offer was deprovisioned
    * (offerDetail.gasreq() + offerDetail.offer_gasbase());
```

We do not emit offer_gasbase during `OfferWrite`, but at that point it is equal to the offer lists `offer_gasbase()`, and we do get events when that change.

1. Live offers locks provision - OfferWrite events can monitor this.
2. Taken offers locks provision (if successful), so same calculation as during initial OfferWrite applies
3. Failed offers subtracts penalty, and frees the rest of the provision to be read by `balanceOf`.
4. RetractOffer can be discerned with the new change.

Note, in the future we may want to extend the Debit, Credit events with Outbound, Inbound, OfferId for more explicit tracking. For now we will deduce provision based on the circumstantial evidence of other events.