### PR TITLE
Feat/mangrove offer approve fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # next version
 
+- `MangroveOffer.approve` reverts if approval fails. This avoids missing approve failure during offchains calls to this function.
+
 # 1.4.6-2 (March 2023)
 
 - Remove console reference

--- a/src/strategies/MangroveOffer.sol
+++ b/src/strategies/MangroveOffer.sol
@@ -122,7 +122,7 @@ abstract contract MangroveOffer is AccessControlled, IOfferLogic {
       // logging what went wrong during `makerExecute`
       emit LogIncident(
         MGV, IERC20(order.outbound_tkn), IERC20(order.inbound_tkn), order.offerId, result.makerData, result.mgvData
-        );
+      );
       // calling strat specific todos in case of failure
       __posthookFallback__(order, result);
       __handleResidualProvision__(order);
@@ -143,7 +143,7 @@ abstract contract MangroveOffer is AccessControlled, IOfferLogic {
       // Offer failed to repost for bad reason, logging the incident
       emit LogIncident(
         MGV, IERC20(order.outbound_tkn), IERC20(order.inbound_tkn), order.offerId, makerData, repostStatus
-        );
+      );
     }
   }
 
@@ -155,7 +155,8 @@ abstract contract MangroveOffer is AccessControlled, IOfferLogic {
 
   /// @inheritdoc IOfferLogic
   function approve(IERC20 token, address spender, uint amount) public override onlyAdmin returns (bool) {
-    return TransferLib.approveToken(token, spender, amount);
+    require(TransferLib.approveToken(token, spender, amount), "mgvOffer/approve/failed");
+    return true;
   }
 
   /// @inheritdoc IOfferLogic

--- a/test/strategies/unit/MangroveOffer.t.sol
+++ b/test/strategies/unit/MangroveOffer.t.sol
@@ -189,7 +189,7 @@ contract MangroveOfferTest is MangroveTest {
     vm.expectEmit(true, false, false, true);
     emit LogIncident(
       IMangrove(payable(mgv)), IERC20(address(0)), IERC20(address(0)), 0, result.makerData, result.mgvData
-      );
+    );
     vm.prank(address(mgv));
     makerContract.makerPosthook(order, result);
   }
@@ -280,5 +280,18 @@ contract MangroveOfferTest is MangroveTest {
     emit SetAdmin(deployer);
     vm.startPrank(deployer);
     makerContract.setAdmin(deployer);
+  }
+
+  function test_approves_token() public {
+    vm.prank(deployer);
+    makerContract.approve(weth, address(this), 42);
+    assertEq(weth.allowance({spender: address(this), owner: address(makerContract)}), 42, "Incorrect allowance");
+  }
+
+  function test_approves_reverts_when_erc20_approve_fails() public {
+    vm.mockCall($(weth), abi.encodeWithSelector(weth.approve.selector), abi.encode(false));
+    vm.expectRevert("mgvOffer/approve/failed");
+    vm.prank(deployer);
+    makerContract.approve(weth, address(this), 42);
   }
 }


### PR DESCRIPTION
This PR prevents MangroveOffer.approve to fail "silently" for instance for out of gas.
Regression test are included.
