### PR TITLE
feat(MgvOracle): MgvOracle initial gasprice and ownership transfer 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Next version
 
+- MgvOracle: Allow initial gas price to be set
+- MgvOracle: Allow governance to transfer ownership of the oracle
+
 # 1.5.1
 
 - License updates:

--- a/script/core/deployers/MangroveDeployer.s.sol
+++ b/script/core/deployers/MangroveDeployer.s.sol
@@ -29,9 +29,9 @@ contract MangroveDeployer is Deployer {
   function innerRun(address chief, uint gasprice, uint gasmax, address gasbot) public {
     broadcast();
     if (forMultisig) {
-      oracle = new MgvOracle{salt: salt}({governance_: chief, initialMutator_: gasbot});
+      oracle = new MgvOracle{salt: salt}({governance_: chief, initialMutator_: gasbot, initialGasPrice_: gasprice});
     } else {
-      oracle = new MgvOracle({governance_: chief, initialMutator_: gasbot});
+      oracle = new MgvOracle({governance_: chief, initialMutator_: gasbot, initialGasPrice_: gasprice});
     }
     fork.set("MgvOracle", address(oracle));
 

--- a/src/periphery/MgvOracle.sol
+++ b/src/periphery/MgvOracle.sol
@@ -17,10 +17,11 @@ contract MgvOracle is IMgvMonitor {
   uint lastReceivedGasPrice;
   uint lastReceivedDensity;
 
-  constructor(address governance_, address initialMutator_) {
+  constructor(address governance_, address initialMutator_, uint initialGasPrice_) {
     governance = governance_;
     mutator = initialMutator_;
 
+    lastReceivedGasPrice = initialGasPrice_;
     /* Set initial density from the MgvOracle to let Mangrove use its internal density by default.
 
       Mangrove will reject densities from the Monitor that don't fit in 32 bits and use its internal density instead, so setting this contract's density to `type(uint).max` is a way to let Mangrove deal with density on its own. */
@@ -42,6 +43,12 @@ contract MgvOracle is IMgvMonitor {
 
   function notifyFail(MgvLib.SingleOrder calldata sor, address taker) external override {
     // Do nothing
+  }
+
+  function setGovernance(address governance_) external {
+    authOnly();
+
+    governance = governance_;
   }
 
   function setMutator(address mutator_) external {


### PR DESCRIPTION
Allow initial gas price to be set in MgvOracle.
Allow governance of MgvOracle to transfer ownership of the oracle.