### PR TITLE
KandelSeederDeployer improvements

### DIFF
--- a/script/strategies/kandel/deployers/KandelSeederDeployer.s.sol
+++ b/script/strategies/kandel/deployers/KandelSeederDeployer.s.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.13;
 
 import {Script, console} from "forge-std/Script.sol";
-import {IMangrove, KandelSeeder} from "mgv_src/strategies/offer_maker/market_making/kandel/KandelSeeder.sol";
-import {AaveKandelSeeder} from "mgv_src/strategies/offer_maker/market_making/kandel/AaveKandelSeeder.sol";
+import {IMangrove, KandelSeeder, Kandel} from "mgv_src/strategies/offer_maker/market_making/kandel/KandelSeeder.sol";
+import {AaveKandelSeeder, AaveKandel} from "mgv_src/strategies/offer_maker/market_making/kandel/AaveKandelSeeder.sol";
 import {AbstractKandelSeeder} from
   "mgv_src/strategies/offer_maker/market_making/kandel/abstract/AbstractKandelSeeder.sol";
 import {CoreKandel, IERC20} from "mgv_src/strategies/offer_maker/market_making/kandel/abstract/CoreKandel.sol";
@@ -51,6 +51,18 @@ contract KandelSeederDeployer is Deployer {
     }
     fork.set("AaveKandelSeeder", address(aaveSeeder));
     fork.set("AavePooledRouter", address(aaveSeeder.AAVE_ROUTER()));
+
+    console.log("Deploying Kandel instances for code verification...");
+    IERC20 weth = IERC20(fork.get("WETH"));
+    IERC20 dai = IERC20(fork.get("DAI"));
+
+    prettyLog("Deploying Kandel instance...");
+    broadcast();
+    new Kandel(mgv, weth, dai, 1, 1, address(0));
+
+    prettyLog("Deploying AaveKandel instance...");
+    broadcast();
+    new AaveKandel(mgv, weth, dai, 1, 1, address(0));
 
     smokeTest(mgv, seeder, AbstractRouter(address(0)));
     smokeTest(mgv, aaveSeeder, aaveSeeder.AAVE_ROUTER());

--- a/script/strategies/kandel/deployers/KandelSeederDeployer.s.sol
+++ b/script/strategies/kandel/deployers/KandelSeederDeployer.s.sol
@@ -41,8 +41,15 @@ contract KandelSeederDeployer is Deployer {
     smokeTest(seeder, AbstractRouter(address(0)));
 
     prettyLog("Deploying AaveKandel seeder...");
+    // Bug workaround: Foundry has a bug where the nonce is not incremented when AaveKandelSeeder is deployed.
+    //                 We therefore ensure that this happens.
+    uint64 nonce = vm.getNonce(broadcaster());
     broadcast();
     aaveSeeder = new AaveKandelSeeder(mgv, addressesProvider, aaveRouterGasreq, aaveKandelGasreq);
+    // Bug workaround: See comment above `nonce` further up
+    if (nonce == vm.getNonce(broadcaster())) {
+      vm.setNonce(broadcaster(), nonce + 1);
+    }
     fork.set("AaveKandelSeeder", address(aaveSeeder));
     fork.set("AavePooledRouter", address(aaveSeeder.AAVE_ROUTER()));
     smokeTest(aaveSeeder, aaveSeeder.AAVE_ROUTER());


### PR DESCRIPTION
This PR includes two fixes and an improvement to the KandelSeederDeployer scripts:

# Fixes
**Workaround for forge bug in KandelSeederDeployer**
forge has a bug where it fails to increment the broadcaster nonce when deploying a contract which itself deploys a contract.
This is bug is triggered when deploying AaveKandelSeeder which deploys a router contract.

A workaround has been implemented which forces the nonce to be incremented if forge has not done it.

**Ensure market is open in KandelSeederDeployer smoketest**
The smoketest assumed that the WETH/DAI market would be open, but that need not be the case, eg on a new Mangrove instance.
The smoketest now pranks MgvGovernance and opens the market.

# Improvement
The script now deploys a Kandel and an AaveKandel instance. By deploying these instances as part of the KandelSeederDeployer script, the contracts will be verified and later instances will be recognized as matching their code.