### PR TITLE
Fix/drop aave faucets

### DIFF
--- a/addresses/deployed/maticmum.json
+++ b/addresses/deployed/maticmum.json
@@ -34,5 +34,17 @@
   {
     "address": "0xB3ba79DB150E8650efa5c534EEaf6404a25Fdf00",
     "name": "AavePooledRouter"
+  },
+  {
+    "address": "0x4eD5b78ad82E61CA64E91f3f561a6531718BC9c1",
+    "name": "MGV_USDC"
+  },
+  {
+    "address": "0x99E1cfAE2696649386F11adbba48bA2d813E5e52",
+    "name": "MGV_WETH"
+  },
+  {
+    "address": "0xdfD37aF9483BA2Eb06d6Eb48E9D8934763Ed73BE",
+    "name": "MGV_DAI"
   }
 ]

--- a/script/toy/deployers/ERC20Deployer.sol
+++ b/script/toy/deployers/ERC20Deployer.sol
@@ -6,7 +6,7 @@ import {TestToken} from "mgv_test/lib/tokens/TestToken.sol";
 import {Deployer} from "mgv_script/lib/Deployer.sol";
 
 /* 
-This script deploys a testToken ERC20. Grants admin rights to `msg.sender`*/
+This script deploys a testToken ERC20. Grants admin rights to `broadcaster`*/
 /* Example:
 NAME="USDC" \
 SYMBOL=MGV_USDC \

--- a/test/core/Scenarii.t.sol
+++ b/test/core/Scenarii.t.sol
@@ -71,7 +71,7 @@ contract ScenariiTest is MangroveTest {
       deal($(base), address(maker), 5 ether);
     }
 
-    quote.mint(address(taker), 5 ether);
+    deal($(quote), address(taker), 5 ether);
     taker.approveMgv(quote, 5 ether);
     taker.approveMgv(base, 50 ether);
     saveBalances();

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -41,12 +41,11 @@ contract TakerOperationsTest is MangroveTest {
     failmkr.provisionMgv(1 ether);
     failmkr.approveMgv(base, 10 ether);
 
-    base.mint(address(mkr), 5 ether);
-    base.mint(address(failmkr), 5 ether);
-    base.mint(address(refusemkr), 5 ether);
+    deal($(base), address(mkr), 5 ether);
+    deal($(base), address(failmkr), 5 ether);
+    deal($(base), address(refusemkr), 5 ether);
 
-    quote.mint($(this), 5 ether);
-    quote.mint($(this), 5 ether);
+    deal($(quote), address(this), 10 ether);
   }
 
   function test_snipe_reverts_if_taker_is_blacklisted_for_quote() public {

--- a/test/lib/tokens/TestToken.sol
+++ b/test/lib/tokens/TestToken.sol
@@ -19,6 +19,9 @@ contract TestToken is ERC20BL {
   uint public __decimals; // full uint to help forge-std's stdstore
   // failSoftly triggers a `return false`, not a revert
   bool _failSoftly = false;
+  // minting disabled by default
+  uint public mintLimit = 0;
+
   MethodResponse internal _approveResponse = MethodResponse.Normal;
   MethodResponse internal _transferResponse = MethodResponse.Normal;
 
@@ -27,15 +30,23 @@ contract TestToken is ERC20BL {
     __decimals = _decimals;
   }
 
+  function setMintLimit(uint limit) external {
+    requireAdmin();
+    mintLimit = limit;
+  }
+
   function failSoftly(bool toggle) public {
+    requireAdmin();
     _failSoftly = toggle;
   }
 
   function approveResponse(MethodResponse response) external {
+    requireAdmin();
     _approveResponse = response;
   }
 
   function transferResponse(MethodResponse response) external {
+    requireAdmin();
     _transferResponse = response;
   }
 
@@ -76,11 +87,18 @@ contract TestToken is ERC20BL {
     admins[admin] = false;
   }
 
+  // freely mintable erc20
+  // mintLimit prevents minting too much by mistake
+  // hot SSLOAD detection prevents calling mint several times per tx
   function mint(address to, uint amount) external {
-    requireAdmin();
+    uint g = gasleft();
+    uint limit = mintLimit; //SLOAD should be 2100 not 100
+    require(g - gasleft() > 2000, "Too frequent minting required");
+    require(amount <= limit, "Too much minting required");
     _mint(to, amount);
   }
 
+  // only admin can burn
   function burn(address from, uint amount) external {
     requireAdmin();
     _burn(from, amount);

--- a/test/toy_strategies/TestToken.t.sol
+++ b/test/toy_strategies/TestToken.t.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier:	AGPL-3.0
+pragma solidity ^0.8.10;
+
+import "mgv_test/lib/MangroveTest.sol";
+import "mgv_test/lib/forks/Polygon.sol";
+import {ICreditDelegationToken, AaveV3Borrower} from "mgv_src/strategies/integrations/AaveV3Borrower.sol";
+import {AaveCaller, console} from "mgv_test/lib/agents/AaveCaller.sol";
+
+contract TestTokenTest is MangroveTest {
+  function setUp() public override {
+    super.setUp();
+    base.setMintLimit(100 * 10 ** base.decimals());
+  }
+
+  function test_mint_once_below_limit_succeeds(uint amount) public {
+    vm.assume(amount < 100 * 10 ** base.decimals());
+    uint b = base.balanceOf(address(this));
+    base.mint(address(this), 100);
+    assertEq(base.balanceOf(address(this)), 100 + b, "mint failed");
+  }
+
+  function test_mint_once_above_limit_fails() public {
+    uint amount = 101 * 10 ** base.decimals();
+    vm.expectRevert("Too much minting required");
+    base.mint(address(this), amount);
+  }
+
+  function test_mint_twice_below_limit_fails() public {
+    base.mint(address(this), 10);
+    vm.expectRevert("Too frequent minting required");
+    base.mint(address(this), 10);
+  }
+
+  function test_admin_can_burn() public {
+    base.mint(address(this), 10);
+    vm.expectRevert("TestToken/adminOnly");
+    vm.prank(freshAddress());
+    base.burn(address(this), 10);
+    assertEq(base.balanceOf(address(this)), 10, "guard failed");
+
+    base.burn(address(this), 10);
+    assertEq(base.balanceOf(address(this)), 0, "Burn failed");
+  }
+}


### PR DESCRIPTION
This PR publishes new faucets for DAI, WETH and USDC on mumbai. It contains:
* deploy script updated
* TestToken contracts that are mintable and admin burnable and that have a protection agains many mints within the same tx (using @adhusson's trick)
* addresses of deployed erc's

Faucets have standard symbols (WETH, DAI and USDC) but custom names (MGV_ prefixed) to avoid confusions.
