### PR TITLE
fix: adapt MangroveJs&TestToken,test MangroveJs, partial revert of 326bcca140e4c737a8d225e844cd7c84094e12a3

### DIFF
--- a/script/README.md
+++ b/script/README.md
@@ -2,11 +2,39 @@ This directory contains scripts (`*.s.sol`) for deploying, configuring, and gove
 
 # Principles for scripts
 
+This is a script example:
+
+```solidity
+// SPDX-License-Identifier:	AGPL-3.0
+// This script is SmallMgvReaderDeployer.s.sol
+pragma solidity ^0.8.13;
+
+import {Mangrove} from "mgv_src/Mangrove.sol";
+import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
+import {Deployer} from "mgv_script/lib/Deployer.sol";
+import "forge-std/console.sol";
+
+contract SmallMgvReaderDeployer is Deployer {
+  TestToken public myToken;
+
+  function run() public {
+    innerRun({mgv: Mangrove(envAddressOrName("MGV_GOVERNANCE","MgvGovernance"))});
+    outputDeployment();
+  }
+
+  function innerRun(Mangrove mgv) public {
+    broadcast();
+    reader = new MgvReader({mgv: address(mgv)});
+    fork.set("MgvReader", address(reader));
+  }
+}
+```
+
 Scripts should follow these principles:
 
-1. They should follow the `*.s.sol` naming convention.
+1. They should contain a single `<Contract>` and their filename should be `<Contract>.s.sol`.
 
-2. Should have both a `run` and a `innerRun` function.
+2. They should have both a `run` and a `innerRun` function.
 
    The `run` function is called when the script is called from the command line. This function should only do the following:
 
@@ -23,11 +51,11 @@ Scripts should follow these principles:
 
 4. Env vars specifying contracts should always allow either a contract name or an address.
 
-   This is easily achieved by using the `envAddressOrName(envVarName<, optional default address>)` function from `Deployer`.
+   This is easily achieved by using the `envAddressOrName(envVarName<, optional default address or contract instance name>)` function from `Deployer`.
 
 5. Contract names should be resolved in the `run` function, not the `innerRun` function.
 
-   This helps ensure that contract addresses specified by the user when calling the outermost script are not ignored by another script (which could happen before because scripts relied on the address provided by fork.get for a hardcoded name).
+   For instance, you should not write `fork.get("MgvGovernance")` inside an `innerRun` function. Otherwise if your script is called by a "parent" script, it will ignore whatever Mangrove Governance address the user provided.
 
 6. The user should always have the option to specify contract addresses via env vars.
 

--- a/script/toy/MangroveJs.s.sol
+++ b/script/toy/MangroveJs.s.sol
@@ -16,6 +16,7 @@ import {IMangrove} from "mgv_src/IMangrove.sol";
 import {Deployer} from "mgv_script/lib/Deployer.sol";
 import {ActivateMarket} from "mgv_script/core/ActivateMarket.s.sol";
 import {PoolAddressProviderMock} from "mgv_script/toy/AaveMock.sol";
+import "forge-std/console.sol";
 
 /* 
 This script prepares a local server for testing by mangrove.js.
@@ -26,13 +27,13 @@ interact with.  b) For any additional deployments needed, those files should be
 hosted in mangrove.js.*/
 
 contract MangroveJsDeploy is Deployer {
-  TestToken tokenA;
-  TestToken tokenB;
-  IERC20 dai;
-  IERC20 usdc;
-  IERC20 weth;
-  SimpleTestMaker simpleTestMaker;
-  MangroveOrder mgo;
+  TestToken public tokenA;
+  TestToken public tokenB;
+  IERC20 public dai;
+  IERC20 public usdc;
+  IERC20 public weth;
+  SimpleTestMaker public simpleTestMaker;
+  MangroveOrder public mgo;
 
   function run() public {
     innerRun({chief: broadcaster(), gasprice: 1, gasmax: 2_000_000, gasbot: broadcaster()});
@@ -40,7 +41,9 @@ contract MangroveJsDeploy is Deployer {
   }
 
   function innerRun(address chief, uint gasprice, uint gasmax, address gasbot) public {
-    fork.set("MgvGovernance", chief);
+    if (chief != broadcaster()) {
+      console.log("Warning: chief is not the broadcaster; deployed contracts will not obey their orders.");
+    }
     MangroveDeployer mgvDeployer = new MangroveDeployer();
 
     mgvDeployer.innerRun({chief: chief, gasprice: gasprice, gasmax: gasmax, gasbot: gasbot});
@@ -58,7 +61,11 @@ contract MangroveJsDeploy is Deployer {
       symbol: "TokenA",
       _decimals: 18
     });
+
+    broadcast();
+    tokenA.setMintLimit(type(uint).max);
     fork.set("TokenA", address(tokenA));
+
     broadcast();
     tokenA.setMintLimit(type(uint).max);
 
@@ -69,7 +76,11 @@ contract MangroveJsDeploy is Deployer {
       symbol: "TokenB",
       _decimals: 6
     });
+
+    broadcast();
+    tokenB.setMintLimit(type(uint).max);
     fork.set("TokenB", address(tokenB));
+
     broadcast();
     tokenB.setMintLimit(type(uint).max);
 

--- a/script/toy/MangroveJs.s.sol
+++ b/script/toy/MangroveJs.s.sol
@@ -36,17 +36,14 @@ contract MangroveJsDeploy is Deployer {
   MangroveOrder public mgo;
 
   function run() public {
-    innerRun({chief: broadcaster(), gasprice: 1, gasmax: 2_000_000, gasbot: broadcaster()});
+    innerRun({gasprice: 1, gasmax: 2_000_000, gasbot: broadcaster()});
     outputDeployment();
   }
 
-  function innerRun(address chief, uint gasprice, uint gasmax, address gasbot) public {
-    if (chief != broadcaster()) {
-      console.log("Warning: chief is not the broadcaster; deployed contracts will not obey their orders.");
-    }
+  function innerRun(uint gasprice, uint gasmax, address gasbot) public {
     MangroveDeployer mgvDeployer = new MangroveDeployer();
 
-    mgvDeployer.innerRun({chief: chief, gasprice: gasprice, gasmax: gasmax, gasbot: gasbot});
+    mgvDeployer.innerRun({chief: broadcaster(), gasprice: gasprice, gasmax: gasmax, gasbot: gasbot});
 
     Mangrove mgv = mgvDeployer.mgv();
     MgvReader mgvReader = mgvDeployer.reader();
@@ -56,7 +53,7 @@ contract MangroveJsDeploy is Deployer {
 
     broadcast();
     tokenA = new TestToken({
-      admin: chief,
+      admin: broadcaster(),
       name: "Token A",
       symbol: "TokenA",
       _decimals: 18
@@ -68,7 +65,7 @@ contract MangroveJsDeploy is Deployer {
 
     broadcast();
     tokenB = new TestToken({
-      admin: chief,
+      admin: broadcaster(),
       name: "Token B",
       symbol: "TokenB",
       _decimals: 6
@@ -80,7 +77,7 @@ contract MangroveJsDeploy is Deployer {
 
     broadcast();
     dai = new TestToken({
-      admin: chief,
+      admin: broadcaster(),
       name: "DAI",
       symbol: "DAI",
       _decimals: 18
@@ -89,7 +86,7 @@ contract MangroveJsDeploy is Deployer {
 
     broadcast();
     usdc = new TestToken({
-      admin: chief,
+      admin: broadcaster(),
       name: "USD Coin",
       symbol: "USDC",
       _decimals: 6
@@ -98,7 +95,7 @@ contract MangroveJsDeploy is Deployer {
 
     broadcast();
     weth = new TestToken({
-      admin: chief,
+      admin: broadcaster(),
       name: "Wrapped Ether",
       symbol: "WETH",
       _decimals: 18
@@ -121,7 +118,7 @@ contract MangroveJsDeploy is Deployer {
     activateMarket.innerRun(mgv, mgvReader, weth, usdc, 1e9, 1e9 / 1000, 0);
 
     MangroveOrderDeployer mgoeDeployer = new MangroveOrderDeployer();
-    mgoeDeployer.innerRun({admin: chief, mgv: IMangrove(payable(mgv))});
+    mgoeDeployer.innerRun({admin: broadcaster(), mgv: IMangrove(payable(mgv))});
 
     address[] memory underlying =
       dynamic([address(tokenA), address(tokenB), address(dai), address(usdc), address(weth)]);
@@ -138,7 +135,7 @@ contract MangroveJsDeploy is Deployer {
     });
 
     broadcast();
-    mgo = new MangroveOrder({mgv: IMangrove(payable(mgv)), deployer: chief, gasreq:30_000});
+    mgo = new MangroveOrder({mgv: IMangrove(payable(mgv)), deployer: broadcaster(), gasreq:30_000});
     fork.set("MangroveOrder", address(mgo));
   }
 }

--- a/script/toy/MangroveJs.s.sol
+++ b/script/toy/MangroveJs.s.sol
@@ -67,9 +67,6 @@ contract MangroveJsDeploy is Deployer {
     fork.set("TokenA", address(tokenA));
 
     broadcast();
-    tokenA.setMintLimit(type(uint).max);
-
-    broadcast();
     tokenB = new TestToken({
       admin: chief,
       name: "Token B",
@@ -80,9 +77,6 @@ contract MangroveJsDeploy is Deployer {
     broadcast();
     tokenB.setMintLimit(type(uint).max);
     fork.set("TokenB", address(tokenB));
-
-    broadcast();
-    tokenB.setMintLimit(type(uint).max);
 
     broadcast();
     dai = new TestToken({

--- a/test/lib/tokens/TestToken.sol
+++ b/test/lib/tokens/TestToken.sol
@@ -101,8 +101,12 @@ contract TestToken is ERC20BL {
   function mintTo(address to, uint amount) public {
     uint g = gasleft();
     uint limit = mintLimit; //SLOAD should be 2100 not 100
-    require(g - gasleft() > 2000, "Too frequent minting required");
-    require(amount <= limit, "Too much minting required");
+    g = g - gasleft();
+    if (limit != type(uint).max) {
+      // limit=uint.max encodes "no limit at all"
+      require(g > 2000, "Too frequent minting required");
+      require(amount <= limit, "Too much minting required");
+    }
     _mint(to, amount);
   }
 

--- a/test/script/toy/MangroveJs.t.sol
+++ b/test/script/toy/MangroveJs.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier:	AGPL-3.0
+pragma solidity ^0.8.10;
+
+import {Deployer, SINGLETON_BROADCASTER} from "mgv_script/lib/Deployer.sol";
+import {MangroveJsDeploy} from "mgv_script/toy/MangroveJs.s.sol";
+
+import {MangroveTest} from "mgv_test/lib/MangroveTest.sol";
+import "forge-std/console.sol";
+
+contract MangroveJsDeployTest is MangroveTest {
+  function test_runs(address chief, uint gasprice, uint gasmax, address gasbot, uint mintA, uint mintB) public {
+    vm.assume(chief != address(0));
+    gasprice = bound(gasprice, 0, type(uint16).max);
+    gasmax = bound(gasmax, 0, type(uint24).max);
+    // execution
+    MangroveJsDeploy deployer = new MangroveJsDeploy();
+    deployer.broadcaster(chief);
+    deployer.innerRun(chief, gasprice, gasmax, gasbot);
+    // mintability of test tokens
+    deployer.tokenA().mint(mintA);
+    deployer.tokenB().mint(mintB);
+  }
+}

--- a/test/script/toy/MangroveJs.t.sol
+++ b/test/script/toy/MangroveJs.t.sol
@@ -15,7 +15,7 @@ contract MangroveJsDeployTest is MangroveTest {
     // execution
     MangroveJsDeploy deployer = new MangroveJsDeploy();
     deployer.broadcaster(chief);
-    deployer.innerRun(chief, gasprice, gasmax, gasbot);
+    deployer.innerRun(gasprice, gasmax, gasbot);
     // mintability of test tokens
     deployer.tokenA().mint(mintA);
     deployer.tokenB().mint(mintB);


### PR DESCRIPTION
This commit does the following:
- TestToken has not mint frequency limit when its `mintLimit = type(uint).max`
- MangroveJs is tested
- MangroveJs warns when its configured `chief` is not the broadcaster (it's possible but incoherent).
- MangroveJs removes all mint limits on its Test tokens
- Partial revert of 326bcca140e4c737a8d225e844cd7c84094e12a3: remove the added line `fork.set("MgvGovernance", chief);`

1. On that topic, to check my understanding: this line is not necessary thanks to the other half of 326bcca140e4c737a8d225e844cd7c84094e12a3, right?

2. Also, I would recommend the following, if agreed we can include it somewhere in the doc:
    - `MgvGovernance` should not be used by scripts except at the top level, most likely  by scripts that are chain-specific and bundle their entire config.
    - Other scripts should inherit who governance is from either a) an argument or b) `mgv.governance()`
    - The way to reference `MgvGovernance` from the outside is as follows (see related [comment](https://github.com/mangrovedao/mangrove-core/blob/af2ffc8bc44cf6bbbeaa9b0e51fda3c1657de61e/script/lib/Deployer.sol#L137-L142)):

      ```bash
      CHIEF=MgvGovernance forge script MangroveJsDeploy ...
      ```
      The Deployer will pickup the `CHIEF` value and look for the corresponding address.

3. I'm suspicious of MangroveJsDeploy even having a `chief` argument since it doesn't even work when `chief != broadcaster()`, what do you think?
