### PR TITLE
Currify

### DIFF
--- a/src/MgvGovernable.sol
+++ b/src/MgvGovernable.sol
@@ -46,7 +46,8 @@ contract MgvGovernable is MgvRoot {
   function activate(address outbound_tkn, address inbound_tkn, uint fee, uint density, uint offer_gasbase) public {
     unchecked {
       authOnly();
-      locals[outbound_tkn][inbound_tkn] = locals[outbound_tkn][inbound_tkn].active(true);
+      Ofl storage ofl = ofls[outbound_tkn][inbound_tkn];
+      ofl.local = ofl.local.active(true);
       emit SetActive(outbound_tkn, inbound_tkn, true);
       setFee(outbound_tkn, inbound_tkn, fee);
       setDensity(outbound_tkn, inbound_tkn, density);
@@ -56,7 +57,8 @@ contract MgvGovernable is MgvRoot {
 
   function deactivate(address outbound_tkn, address inbound_tkn) public {
     authOnly();
-    locals[outbound_tkn][inbound_tkn] = locals[outbound_tkn][inbound_tkn].active(false);
+    Ofl storage ofl = ofls[outbound_tkn][inbound_tkn];
+    ofl.local = ofl.local.active(false);
     emit SetActive(outbound_tkn, inbound_tkn, false);
   }
 
@@ -66,7 +68,8 @@ contract MgvGovernable is MgvRoot {
       authOnly();
       /* `fee` is in basis points, i.e. in percents of a percent. */
       require(fee <= 500, "mgv/config/fee/<=500"); // at most 5%
-      locals[outbound_tkn][inbound_tkn] = locals[outbound_tkn][inbound_tkn].fee(fee);
+      Ofl storage ofl = ofls[outbound_tkn][inbound_tkn];
+      ofl.local = ofl.local.fee(fee);
       emit SetFee(outbound_tkn, inbound_tkn, fee);
     }
   }
@@ -79,7 +82,8 @@ contract MgvGovernable is MgvRoot {
 
       require(checkDensity(density), "mgv/config/density/112bits");
       //+clear+
-      locals[outbound_tkn][inbound_tkn] = locals[outbound_tkn][inbound_tkn].density(density);
+      Ofl storage ofl = ofls[outbound_tkn][inbound_tkn];
+      ofl.local = ofl.local.density(density);
       emit SetDensity(outbound_tkn, inbound_tkn, density);
     }
   }
@@ -91,7 +95,8 @@ contract MgvGovernable is MgvRoot {
       /* Checking the size of `offer_gasbase` is necessary to prevent a) data loss when copied to an `OfferDetail` struct, and b) overflow when used in calculations. */
       require(uint24(offer_gasbase) == offer_gasbase, "mgv/config/offer_gasbase/24bits");
       //+clear+
-      locals[outbound_tkn][inbound_tkn] = locals[outbound_tkn][inbound_tkn].offer_gasbase(offer_gasbase);
+      Ofl storage ofl = ofls[outbound_tkn][inbound_tkn];
+      ofl.local = ofl.local.offer_gasbase(offer_gasbase);
       emit SetGasbase(outbound_tkn, inbound_tkn, offer_gasbase);
     }
   }

--- a/src/MgvOfferMaking.sol
+++ b/src/MgvOfferMaking.sol
@@ -337,21 +337,25 @@ contract MgvOfferMaking is MgvHasOffers {
       uint pivotId = ofp.pivotId;
       Ofl storage ofl = sr(ofp.ofl);
       /* Get `pivot`, optimizing for the case where pivot info is already known */
-      MgvStructs.OfferPacked pivot = pivotId == ofp.id ? ofp.oldOffer : ofl.offerData[pivotId].offer;
+      OfferData storage offerData = ofl.offerData[pivotId];
+      MgvStructs.OfferPacked pivot = pivotId == ofp.id ? ofp.oldOffer : offerData.offer;
 
       /* In case pivotId is not an active offer, it is unusable (since it is out of the book). We default to the current best offer. If the book is empty pivot will be 0. That is handled through a test in the `better` comparison function. */
       if (!isLive(pivot)) {
         pivotId = ofp.local.best();
-        pivot = ofl.offerData[pivotId].offer;
+        offerData = ofl.offerData[pivotId];
+        pivot = offerData.offer;
       }
 
-      /* * Pivot is better than `wants/gives`, we follow `next`. */
-      if (better(ofp, pivot, pivotId)) {
+      /* * Pivot is better than `wants/gives`, or book is empty, we follow `next`. */
+      /* On an empty book, going into either branch of the conditional would work, but true is more consistent, and we want to avoid going into `better` and making a useless SLOAD for offer details. */
+      if (pivotId == 0 || better(ofp, pivot, offerData)) {
         MgvStructs.OfferPacked pivotNext;
         while (pivot.next() != 0) {
           uint pivotNextId = pivot.next();
-          pivotNext = ofl.offerData[pivotNextId].offer;
-          if (better(ofp, pivotNext, pivotNextId)) {
+          offerData = ofl.offerData[pivotNextId];
+          pivotNext = offerData.offer;
+          if (better(ofp, pivotNext, offerData)) {
             pivotId = pivotNextId;
             pivot = pivotNext;
           } else {
@@ -366,8 +370,9 @@ contract MgvOfferMaking is MgvHasOffers {
         MgvStructs.OfferPacked pivotPrev;
         while (pivot.prev() != 0) {
           uint pivotPrevId = pivot.prev();
-          pivotPrev = ofl.offerData[pivotPrevId].offer;
-          if (better(ofp, pivotPrev, pivotPrevId)) {
+          offerData = ofl.offerData[pivotPrevId];
+          pivotPrev = offerData.offer;
+          if (better(ofp, pivotPrev, offerData)) {
             break;
           } else {
             pivotId = pivotPrevId;
@@ -386,13 +391,13 @@ contract MgvOfferMaking is MgvHasOffers {
   /* The utility method `better` takes an offer represented by `ofp` and another represented by `offer1`. It returns true iff `offer1` is better or as good as `ofp`.
     "better" is defined on the lexicographic order $\textrm{price} \times_{\textrm{lex}} \textrm{density}^{-1}$. This means that for the same price, offers that deliver more volume per gas are taken first.
 
-      In addition to `offer1`, we also provide its id, `offerId1` in order to save gas. If necessary (ie. if the prices `wants1/gives1` and `wants2/gives2` are the same), we read storage to get `gasreq1` at `offerData[offerId1].detail. */
-  function better(OfferPack memory ofp, MgvStructs.OfferPacked offer1, uint offerId1) internal view returns (bool) {
+      In addition to `offer1`, we also provide offerData1 in order to save gas. If necessary (ie. if the prices `wants1/gives1` and `wants2/gives2` are the same), we read storage to get `gasreq1` at `offerData.detail.detail. */
+  function better(OfferPack memory ofp, MgvStructs.OfferPacked offer1, OfferData storage offerData1)
+    internal
+    view
+    returns (bool)
+  {
     unchecked {
-      if (offerId1 == 0) {
-        /* Happens on empty book. Returning `false` would work as well due to specifics of `findPosition` but true is more consistent. Here we just want to avoid reading `offerDetail[...][0]` for nothing. */
-        return true;
-      }
       uint wants1 = offer1.wants();
       uint gives1 = offer1.gives();
       uint wants2 = ofp.wants;
@@ -400,7 +405,7 @@ contract MgvOfferMaking is MgvHasOffers {
       uint weight1 = wants1 * gives2;
       uint weight2 = wants2 * gives1;
       if (weight1 == weight2) {
-        uint gasreq1 = sr(ofp.ofl).offerData[offerId1].detail.gasreq();
+        uint gasreq1 = offerData1.detail.gasreq();
         uint gasreq2 = ofp.gasreq;
         return (gives1 * gasreq2 >= gives2 * gasreq1);
       } else {

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -73,7 +73,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
       mor.ofl = rs(ofl);
       /* Throughout the execution of the market order, the `sor`'s offer id and other parameters will change. We start with the current best offer id (0 if the book is empty). */
       sor.offerId = sor.local.best();
-      sor.offer = sr(mor.ofl).offers[sor.offerId];
+      sor.offer = sr(mor.ofl).offerData[sor.offerId].offer;
       /* `sor.wants` and `sor.gives` may evolve, but they are initially however much remains in the market order. */
       sor.wants = takerWants;
       sor.gives = takerGives;
@@ -133,7 +133,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
         bytes32 mgvData;
 
         /* Load additional information about the offer. We don't do it earlier to save one storage read in case `proceed` was false. */
-        sor.offerDetail = sr(mor.ofl).offerDetails[sor.offerId];
+        sor.offerDetail = sr(mor.ofl).offerData[sor.offerId].detail;
 
         /* `execute` will adjust `sor.wants`,`sor.gives`, and may attempt to execute the offer if its price is low enough. It is crucial that an error due to `taker` triggers a revert. That way, [`mgvData`](#MgvOfferTaking/statusCodes) not in `["mgv/notExecuted","mgv/tradeSuccess"]` means the failure is the maker's fault. */
         /* Post-execution, `sor.wants`/`sor.gives` reflect how much was sent/taken by the offer. We will need it after the recursive call, so we save it in local variables. Same goes for `offerId`, `sor.offer` and `sor.offerDetail`. */
@@ -157,7 +157,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
         */
           sor.gives = mor.initialGives - mor.totalGave;
           sor.offerId = sor.offer.next();
-          sor.offer = sr(mor.ofl).offers[sor.offerId];
+          sor.offer = sr(mor.ofl).offerData[sor.offerId].offer;
         }
 
         /* note that internalMarketOrder may be called twice with same offerId, but in that case `proceed` will be false! */
@@ -280,8 +280,9 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
         /* Initialize single order struct. */
         sor.offerId = targets[i][0];
-        sor.offer = sr(mor.ofl).offers[sor.offerId];
-        sor.offerDetail = sr(mor.ofl).offerDetails[sor.offerId];
+        OfferData storage offerData = sr(mor.ofl).offerData[sor.offerId];
+        sor.offer = offerData.offer;
+        sor.offerDetail = offerData.detail;
 
         /* If we removed the `isLive` conditional, a single expired or nonexistent offer in `targets` would revert the entire transaction (by the division by `offer.gives` below since `offer.gives` would be 0). We also check that `gasreq` is not worse than specified. A taker who does not care about `gasreq` can specify any amount larger than $2^{24}-1$. A mismatched price will be detected by `execute`. */
         if (!isLive(sor.offer) || sor.offerDetail.gasreq() > targets[i][3]) {
@@ -470,7 +471,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
       }
 
       /* Delete the offer. The last argument indicates whether the offer should be stripped of its provision (yes if execution failed, no otherwise). We cannot partially strip an offer provision (for instance, remove only the penalty from a failing offer and leave the rest) since the provision associated with an offer is always deduced from the (gasprice,gasbase,gasreq) parameters and not stored independently. We delete offers whether the amount remaining on offer is > density or not for the sake of uniformity (code is much simpler). We also expect prices to move often enough that the maker will want to update their price anyway. To simulate leaving the remaining volume in the offer, the maker can program their `makerPosthook` to `updateOffer` and put the remaining volume back in. */
-      dirtyDeleteOffer(sr(mor.ofl), sor.offerId, sor.offer, sor.offerDetail, mgvData != "mgv/tradeSuccess");
+      dirtyDeleteOffer(sr(mor.ofl).offerData[sor.offerId], sor.offer, sor.offerDetail, mgvData != "mgv/tradeSuccess");
     }
   }
 

--- a/src/MgvOfferTakingWithPermit.sol
+++ b/src/MgvOfferTakingWithPermit.sol
@@ -113,9 +113,10 @@ abstract contract MgvOfferTakingWithPermit is MgvOfferTaking {
   /* Used by `*For` functions, its both checks that `msg.sender` was allowed to use the taker's funds, and decreases the former's allowance. */
   function deductSenderAllowance(address outbound_tkn, address inbound_tkn, address owner, uint amount) internal {
     unchecked {
-      uint allowed = allowances[outbound_tkn][inbound_tkn][owner][msg.sender];
+      mapping(address => uint) storage curriedAllow = allowances[outbound_tkn][inbound_tkn][owner];
+      uint allowed = curriedAllow[msg.sender];
       require(allowed >= amount, "mgv/lowAllowance");
-      allowances[outbound_tkn][inbound_tkn][owner][msg.sender] = allowed - amount;
+      curriedAllow[msg.sender] = allowed - amount;
 
       emit Approval(outbound_tkn, inbound_tkn, owner, msg.sender, allowed - amount);
     }

--- a/src/MgvRoot.sol
+++ b/src/MgvRoot.sol
@@ -32,10 +32,14 @@ contract MgvRoot is HasMgvEvents {
   MgvStructs.GlobalPacked internal internal_global;
   /* Configuration mapping for each token pair of the form `outbound_tkn => inbound_tkn => MgvStructs.LocalPacked`. The structure of each `MgvStructs.LocalPacked` value is detailed in [`structs.js`](#structs.js). It fits in one word. */
 
+  struct OfferData {
+    MgvStructs.OfferPacked offer;
+    MgvStructs.OfferDetailPacked detail;
+  }
+
   struct Ofl {
     MgvStructs.LocalPacked local;
-    mapping(uint => MgvStructs.OfferPacked) offers;
-    mapping(uint => MgvStructs.OfferDetailPacked) offerDetails;
+    mapping(uint => OfferData) offerData;
   }
 
   function sr(OflPacked _ofl) internal pure returns (Ofl storage ofl) {


### PR DESCRIPTION
Quick hack to test an idea. Move most data to a storage struct that is accessed when needed. Strictly improves gas in the test suite. Some specific improvements:

| name              | delta to develop (15c0e78b3d7e9ac5c791d269d36b45dfb3d27b1e)   |
|-------------------|---------|
| market_order_1    |  -0.84% |
| market_order_8    | -1.45%  |
| new_offer         | -2.26%  |
| update_full_offer |  -5.22% |
| insert, move by 15 offers |  - 6.49% |
| insert, move by 49 offers |  - 6.19% |

The `rs` and `sr` function are a workaround for Solidity's type system wherein you cannot have a storage ref inside a memory struct. Things are cleaner in #357.

Mangrove size change (0.8.17, NO via_ir, 20k runs):
| ref | size |
|----|-----|
| develop (15c0e78b3d7e9ac5c791d269d36b45dfb3d27b1e) | 23.031 kB |
| this PR | 23.292 kB |
| #357 | 23.067 kB |
