### PR TITLE
gas: use more stack args for better()

### DIFF
--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -76,7 +76,7 @@ uni.hospitable(true);
 
 /* # Data stuctures */
 
-/* Struct-like data structures are stored in storage and memory as 256 bits words. We avoid using structs due to significant gas savings gained by extracting data from words only when needed. To make development easier, we use the preprocessor `solpp` and generate getters and setters for each struct we declare. The generation is defined in `lib/preproc.js`. */
+/* Struct-like data structures are stored in storage and memory as 256 bits words. We avoid using structs due to significant gas savings gained by extracting data from words only when needed. The generation is defined in `lib/preproc.js`. */
 
 /* Struct fields that are common to multiple structs are factored here. Multiple field names refer to offer identifiers, so the `id` field is a function that takes a name as argument. */
 

--- a/src/MgvGovernable.sol
+++ b/src/MgvGovernable.sol
@@ -46,8 +46,8 @@ contract MgvGovernable is MgvRoot {
   function activate(address outbound_tkn, address inbound_tkn, uint fee, uint density, uint offer_gasbase) public {
     unchecked {
       authOnly();
-      Ofl storage ofl = ofls[outbound_tkn][inbound_tkn];
-      ofl.local = ofl.local.active(true);
+      Pair storage pair = pairs[outbound_tkn][inbound_tkn];
+      pair.local = pair.local.active(true);
       emit SetActive(outbound_tkn, inbound_tkn, true);
       setFee(outbound_tkn, inbound_tkn, fee);
       setDensity(outbound_tkn, inbound_tkn, density);
@@ -57,8 +57,8 @@ contract MgvGovernable is MgvRoot {
 
   function deactivate(address outbound_tkn, address inbound_tkn) public {
     authOnly();
-    Ofl storage ofl = ofls[outbound_tkn][inbound_tkn];
-    ofl.local = ofl.local.active(false);
+    Pair storage pair = pairs[outbound_tkn][inbound_tkn];
+    pair.local = pair.local.active(false);
     emit SetActive(outbound_tkn, inbound_tkn, false);
   }
 
@@ -68,8 +68,8 @@ contract MgvGovernable is MgvRoot {
       authOnly();
       /* `fee` is in basis points, i.e. in percents of a percent. */
       require(fee <= 500, "mgv/config/fee/<=500"); // at most 5%
-      Ofl storage ofl = ofls[outbound_tkn][inbound_tkn];
-      ofl.local = ofl.local.fee(fee);
+      Pair storage pair = pairs[outbound_tkn][inbound_tkn];
+      pair.local = pair.local.fee(fee);
       emit SetFee(outbound_tkn, inbound_tkn, fee);
     }
   }
@@ -82,8 +82,8 @@ contract MgvGovernable is MgvRoot {
 
       require(checkDensity(density), "mgv/config/density/112bits");
       //+clear+
-      Ofl storage ofl = ofls[outbound_tkn][inbound_tkn];
-      ofl.local = ofl.local.density(density);
+      Pair storage pair = pairs[outbound_tkn][inbound_tkn];
+      pair.local = pair.local.density(density);
       emit SetDensity(outbound_tkn, inbound_tkn, density);
     }
   }
@@ -95,8 +95,8 @@ contract MgvGovernable is MgvRoot {
       /* Checking the size of `offer_gasbase` is necessary to prevent a) data loss when copied to an `OfferDetail` struct, and b) overflow when used in calculations. */
       require(uint24(offer_gasbase) == offer_gasbase, "mgv/config/offer_gasbase/24bits");
       //+clear+
-      Ofl storage ofl = ofls[outbound_tkn][inbound_tkn];
-      ofl.local = ofl.local.offer_gasbase(offer_gasbase);
+      Pair storage pair = pairs[outbound_tkn][inbound_tkn];
+      pair.local = pair.local.offer_gasbase(offer_gasbase);
       emit SetGasbase(outbound_tkn, inbound_tkn, offer_gasbase);
     }
   }

--- a/src/MgvGovernable.sol
+++ b/src/MgvGovernable.sol
@@ -46,7 +46,8 @@ contract MgvGovernable is MgvRoot {
   function activate(address outbound_tkn, address inbound_tkn, uint fee, uint density, uint offer_gasbase) public {
     unchecked {
       authOnly();
-      locals[outbound_tkn][inbound_tkn] = locals[outbound_tkn][inbound_tkn].active(true);
+      Ofl storage ofl = ofls[outbound_tkn][inbound_tkn];
+      ofl.local = ofl.local.active(true);
       emit SetActive(outbound_tkn, inbound_tkn, true);
       setFee(outbound_tkn, inbound_tkn, fee);
       setDensity(outbound_tkn, inbound_tkn, density);
@@ -56,7 +57,8 @@ contract MgvGovernable is MgvRoot {
 
   function deactivate(address outbound_tkn, address inbound_tkn) public {
     authOnly();
-    locals[outbound_tkn][inbound_tkn] = locals[outbound_tkn][inbound_tkn].active(false);
+    Ofl storage ofl = ofls[outbound_tkn][inbound_tkn];
+    ofl.local = ofl.local.active(false);
     emit SetActive(outbound_tkn, inbound_tkn, false);
   }
 
@@ -66,7 +68,8 @@ contract MgvGovernable is MgvRoot {
       authOnly();
       /* `fee` is in basis points, i.e. in percents of a percent. */
       require(fee <= 500, "mgv/config/fee/<=500"); // at most 5%
-      locals[outbound_tkn][inbound_tkn] = locals[outbound_tkn][inbound_tkn].fee(fee);
+      Ofl storage ofl = ofls[outbound_tkn][inbound_tkn];
+      ofl.local = ofl.local.fee(fee);
       emit SetFee(outbound_tkn, inbound_tkn, fee);
     }
   }
@@ -79,7 +82,8 @@ contract MgvGovernable is MgvRoot {
 
       require(checkDensity(density), "mgv/config/density/112bits");
       //+clear+
-      locals[outbound_tkn][inbound_tkn] = locals[outbound_tkn][inbound_tkn].density(density);
+      Ofl storage ofl = ofls[outbound_tkn][inbound_tkn];
+      ofl.local = ofl.local.density(density);
       emit SetDensity(outbound_tkn, inbound_tkn, density);
     }
   }
@@ -91,7 +95,8 @@ contract MgvGovernable is MgvRoot {
       /* Checking the size of `offer_gasbase` is necessary to prevent a) data loss when copied to an `OfferDetail` struct, and b) overflow when used in calculations. */
       require(uint24(offer_gasbase) == offer_gasbase, "mgv/config/offer_gasbase/24bits");
       //+clear+
-      locals[outbound_tkn][inbound_tkn] = locals[outbound_tkn][inbound_tkn].offer_gasbase(offer_gasbase);
+      Ofl storage ofl = ofls[outbound_tkn][inbound_tkn];
+      ofl.local = ofl.local.offer_gasbase(offer_gasbase);
       emit SetGasbase(outbound_tkn, inbound_tkn, offer_gasbase);
     }
   }

--- a/src/MgvOfferMaking.sol
+++ b/src/MgvOfferMaking.sol
@@ -291,7 +291,7 @@ contract MgvOfferMaking is MgvHasOffers {
       }
       /* We now place the offer in the book at the position found by `findPosition`. */
 
-      /* First, we test if the offer has moved in the book or is not currently in the book. If `!isLive(ofp.oldOffer`, we must update its prev/next. If it is live but its prev has changed, we must also update them. Note that checking both `prev = oldPrev` and `next == oldNext` would be redundant. If either is true, then the updated offer has not changed position and there is nothing to update.
+      /* First, we test if the offer has moved in the book or is not currently in the book. If `!isLive(ofp.oldOffer)`, we must update its prev/next. If it is live but its prev has changed, we must also update them. Note that checking both `prev = oldPrev` and `next == oldNext` would be redundant. If either is true, then the updated offer has not changed position and there is nothing to update.
 
     As a note for future changes, there is a tricky edge case where `prev == oldPrev` yet the prev/next should be changed: a previously-used offer being brought back in the book, and ending with the same prev it had when it was in the book. In that case, the neighbor is currently pointing to _another_ offer, and thus must be updated. With the current code structure, this is taken care of as a side-effect of checking `!isLive`, but should be kept in mind. The same goes in the `next == oldNext` case. */
       if (!isLive(ofp.oldOffer) || prev != ofp.oldOffer.prev()) {
@@ -354,6 +354,7 @@ contract MgvOfferMaking is MgvHasOffers {
           uint pivotNextId = pivot.next();
           offerData = ofl.offerData[pivotNextId];
           pivotNext = offerData.offer;
+          // No need to test for pivotNextId == 0, we tested it above
           if (better(wants2, gives2, gasreq2, pivotNext, offerData)) {
             pivotId = pivotNextId;
             pivot = pivotNext;
@@ -371,6 +372,7 @@ contract MgvOfferMaking is MgvHasOffers {
           uint pivotPrevId = pivot.prev();
           offerData = ofl.offerData[pivotPrevId];
           pivotPrev = offerData.offer;
+          // No need to test for pivotPrevId == 0, we tested it above
           if (better(wants2, gives2, gasreq2, pivotPrev, offerData)) {
             break;
           } else {

--- a/src/MgvOfferMaking.sol
+++ b/src/MgvOfferMaking.sol
@@ -128,7 +128,7 @@ contract MgvOfferMaking is MgvHasOffers {
       ofp.gasreq = gasreq;
       ofp.gasprice = gasprice;
       ofp.pivotId = pivotId;
-      ofp.oldOffer = ofl.offers[offerId];
+      ofp.oldOffer = ofl.offerData[offerId].offer;
       // Save local config
       MgvStructs.LocalPacked oldLocal = ofp.local;
       /* The second argument indicates that we are updating an existing offer, not creating a new one. */
@@ -150,8 +150,9 @@ contract MgvOfferMaking is MgvHasOffers {
     unchecked {
       (, MgvStructs.LocalPacked local, Ofl storage ofl) = _config(outbound_tkn, inbound_tkn);
       unlockedMarketOnly(local);
-      MgvStructs.OfferPacked offer = ofl.offers[offerId];
-      MgvStructs.OfferDetailPacked offerDetail = ofl.offerDetails[offerId];
+      OfferData storage offerData = ofl.offerData[offerId];
+      MgvStructs.OfferPacked offer = offerData.offer;
+      MgvStructs.OfferDetailPacked offerDetail = offerData.detail;
       require(msg.sender == offerDetail.maker(), "mgv/retractOffer/unauthorized");
 
       /* Here, we are about to un-live an offer, so we start by taking it out of the book by stitching together its previous and next offers. Note that unconditionally calling `stitchOffers` would break the book since it would connect offers that may have since moved. */
@@ -164,7 +165,7 @@ contract MgvOfferMaking is MgvHasOffers {
         }
       }
       /* Set `gives` to 0. Moreover, the last argument depends on whether the user wishes to get their provision back (if true, `gasprice` will be set to 0 as well). */
-      dirtyDeleteOffer(ofl, offerId, offer, offerDetail, deprovision);
+      dirtyDeleteOffer(offerData, offer, offerDetail, deprovision);
 
       /* If the user wants to get their provision back, we compute its provision from the offer's `gasprice`, `offer_gasbase` and `gasreq`. */
       if (deprovision) {
@@ -257,7 +258,8 @@ contract MgvOfferMaking is MgvHasOffers {
       /* We now write the new `offerDetails` and remember the previous provision (0 by default, for new offers) to balance out maker's `balanceOf`. */
       uint oldProvision;
       {
-        MgvStructs.OfferDetailPacked offerDetail = ofl.offerDetails[ofp.id];
+        OfferData storage offerData = ofl.offerData[ofp.id];
+        MgvStructs.OfferDetailPacked offerDetail = offerData.detail;
         if (update) {
           require(msg.sender == offerDetail.maker(), "mgv/updateOffer/unauthorized");
           oldProvision = 10 ** 9 * offerDetail.gasprice() * (offerDetail.gasreq() + offerDetail.offer_gasbase());
@@ -269,7 +271,7 @@ contract MgvOfferMaking is MgvHasOffers {
             || offerDetail.offer_gasbase() != ofp.local.offer_gasbase()
         ) {
           uint offer_gasbase = ofp.local.offer_gasbase();
-          ofl.offerDetails[ofp.id] = MgvStructs.OfferDetail.pack({
+          offerData.detail = MgvStructs.OfferDetail.pack({
             __maker: msg.sender,
             __gasreq: ofp.gasreq,
             __offer_gasbase: offer_gasbase,
@@ -289,20 +291,22 @@ contract MgvOfferMaking is MgvHasOffers {
       }
       /* We now place the offer in the book at the position found by `findPosition`. */
 
-      /* First, we test if the offer has moved in the book or is not currently in the book. If `!isLive(ofp.oldOffer)`, we must update its prev/next. If it is live but its prev has changed, we must also update them. Note that checking both `prev = oldPrev` and `next == oldNext` would be redundant. If either is true, then the updated offer has not changed position and there is nothing to update.
+      /* First, we test if the offer has moved in the book or is not currently in the book. If `!isLive(ofp.oldOffer`, we must update its prev/next. If it is live but its prev has changed, we must also update them. Note that checking both `prev = oldPrev` and `next == oldNext` would be redundant. If either is true, then the updated offer has not changed position and there is nothing to update.
 
     As a note for future changes, there is a tricky edge case where `prev == oldPrev` yet the prev/next should be changed: a previously-used offer being brought back in the book, and ending with the same prev it had when it was in the book. In that case, the neighbor is currently pointing to _another_ offer, and thus must be updated. With the current code structure, this is taken care of as a side-effect of checking `!isLive`, but should be kept in mind. The same goes in the `next == oldNext` case. */
       if (!isLive(ofp.oldOffer) || prev != ofp.oldOffer.prev()) {
         /* * If the offer is not the best one, we update its predecessor; otherwise we update the `best` value. */
         if (prev != 0) {
-          ofl.offers[prev] = ofl.offers[prev].next(ofp.id);
+          OfferData storage offerData = ofl.offerData[prev];
+          offerData.offer = offerData.offer.next(ofp.id);
         } else {
           ofp.local = ofp.local.best(ofp.id);
         }
 
         /* * If the offer is not the last one, we update its successor. */
         if (next != 0) {
-          ofl.offers[next] = ofl.offers[next].prev(ofp.id);
+          OfferData storage offerData = ofl.offerData[next];
+          offerData.offer = offerData.offer.prev(ofp.id);
         }
 
         /* * Recall that in this branch, the offer has changed location, or is not currently in the book. If the offer is not new and already in the book, we must remove it from its previous location by stitching its previous prev/next. */
@@ -314,7 +318,7 @@ contract MgvOfferMaking is MgvHasOffers {
       /* With the `prev`/`next` in hand, we finally store the offer in the `offers` map. */
       MgvStructs.OfferPacked ofr =
         MgvStructs.Offer.pack({__prev: prev, __next: next, __wants: ofp.wants, __gives: ofp.gives});
-      ofl.offers[ofp.id] = ofr;
+      ofl.offerData[ofp.id].offer = ofr;
     }
   }
 
@@ -328,12 +332,12 @@ contract MgvOfferMaking is MgvHasOffers {
       uint nextId;
       uint pivotId = ofp.pivotId;
       /* Get `pivot`, optimizing for the case where pivot info is already known */
-      MgvStructs.OfferPacked pivot = pivotId == ofp.id ? ofp.oldOffer : ofl.offers[pivotId];
+      MgvStructs.OfferPacked pivot = pivotId == ofp.id ? ofp.oldOffer : ofl.offerData[pivotId].offer;
 
       /* In case pivotId is not an active offer, it is unusable (since it is out of the book). We default to the current best offer. If the book is empty pivot will be 0. That is handled through a test in the `better` comparison function. */
       if (!isLive(pivot)) {
         pivotId = ofp.local.best();
-        pivot = ofl.offers[pivotId];
+        pivot = ofl.offerData[pivotId].offer;
       }
 
       /* * Pivot is better than `wants/gives`, we follow `next`. */
@@ -345,7 +349,7 @@ contract MgvOfferMaking is MgvHasOffers {
         MgvStructs.OfferPacked pivotNext;
         while (pivot.next() != 0) {
           uint pivotNextId = pivot.next();
-          pivotNext = ofl.offers[pivotNextId];
+          pivotNext = ofl.offerData[pivotNextId].offer;
           if (better(ofl, wants2, gives2, gasreq2, pivotNext, pivotNextId)) {
             pivotId = pivotNextId;
             pivot = pivotNext;
@@ -361,7 +365,7 @@ contract MgvOfferMaking is MgvHasOffers {
         MgvStructs.OfferPacked pivotPrev;
         while (pivot.prev() != 0) {
           uint pivotPrevId = pivot.prev();
-          pivotPrev = ofl.offers[pivotPrevId];
+          pivotPrev = ofl.offerData[pivotPrevId].offer;
           if (better(ofl, wants2, gives2, gasreq2, pivotPrev, pivotPrevId)) {
             break;
           } else {
@@ -381,7 +385,7 @@ contract MgvOfferMaking is MgvHasOffers {
   /* The utility method `better` takes an offer represented by `ofp` and another represented by `offer1`. It returns true iff `offer1` is better or as good as `ofp`.
     "better" is defined on the lexicographic order $\textrm{price} \times_{\textrm{lex}} \textrm{density}^{-1}$. This means that for the same price, offers that deliver more volume per gas are taken first.
 
-      In addition to `offer1`, we also provide its id, `offerId1` in order to save gas. If necessary (ie. if the prices `wants1/gives1` and `wants2/gives2` are the same), we read storage to get `gasreq1` at `offerDetails[offerId1]. */
+      In addition to `offer1`, we also provide its id, `offerId1` in order to save gas. If necessary (ie. if the prices `wants1/gives1` and `wants2/gives2` are the same), we read storage to get `gasreq1` at `offerData[offerId1]. */
   function better(Ofl storage ofl, uint wants2, uint gives2, uint gasreq2, MgvStructs.OfferPacked offer1, uint offerId1)
     internal
     view
@@ -397,7 +401,7 @@ contract MgvOfferMaking is MgvHasOffers {
       uint weight1 = wants1 * gives2;
       uint weight2 = wants2 * gives1;
       if (weight1 == weight2) {
-        uint gasreq1 = ofl.offerDetails[offerId1].gasreq();
+        uint gasreq1 = ofl.offerData[offerId1].detail.gasreq();
         return (gives1 * gasreq2 >= gives2 * gasreq1);
       } else {
         return weight1 < weight2;

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -67,11 +67,11 @@ abstract contract MgvOfferTaking is MgvHasOffers {
       MgvLib.SingleOrder memory sor;
       sor.outbound_tkn = outbound_tkn;
       sor.inbound_tkn = inbound_tkn;
-      Ofl storage ofl;
-      (sor.global, sor.local, ofl) = _config(outbound_tkn, inbound_tkn);
+      Pair storage pair;
+      (sor.global, sor.local, pair) = _config(outbound_tkn, inbound_tkn);
       /* Throughout the execution of the market order, the `sor`'s offer id and other parameters will change. We start with the current best offer id (0 if the book is empty). */
       sor.offerId = sor.local.best();
-      sor.offer = ofl.offerData[sor.offerId].offer;
+      sor.offer = pair.offerData[sor.offerId].offer;
       /* `sor.wants` and `sor.gives` may evolve, but they are initially however much remains in the market order. */
       sor.wants = takerWants;
       sor.gives = takerGives;
@@ -88,12 +88,12 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
       /* We start be enabling the reentrancy lock for this (`outbound_tkn`,`inbound_tkn`) pair. */
       sor.local = sor.local.lock(true);
-      ofl.local = sor.local;
+      pair.local = sor.local;
 
       emit OrderStart();
 
       /* Call recursive `internalMarketOrder` function.*/
-      internalMarketOrder(ofl, mor, sor, true);
+      internalMarketOrder(pair, mor, sor, true);
 
       /* Over the course of the market order, a penalty reserved for `msg.sender` has accumulated in `mor.totalPenalty`. No actual transfers have occured yet -- all the ethers given by the makers as provision are owned by Mangrove. `sendPenalty` finally gives the accumulated penalty to `msg.sender`. */
       sendPenalty(mor.totalPenalty);
@@ -110,7 +110,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
   /* `internalMarketOrder` works recursively. Going downward, each successive offer is executed until the market order stops (due to: volume exhausted, bad price, or empty book). Then the [reentrancy lock is lifted](#internalMarketOrder/liftReentrancy). Going upward, each offer's `maker` contract is called again with its remaining gas and given the chance to update its offers on the book.
 
     The last argument is a boolean named `proceed`. If an offer was not executed, it means the price has become too high. In that case, we notify the next recursive call that the market order should end. In this initial call, no offer has been executed yet so `proceed` is true. */
-  function internalMarketOrder(Ofl storage ofl, MultiOrder memory mor, MgvLib.SingleOrder memory sor, bool proceed)
+  function internalMarketOrder(Pair storage pair, MultiOrder memory mor, MgvLib.SingleOrder memory sor, bool proceed)
     internal
   {
     unchecked {
@@ -133,12 +133,12 @@ abstract contract MgvOfferTaking is MgvHasOffers {
         bytes32 mgvData;
 
         /* Load additional information about the offer. We don't do it earlier to save one storage read in case `proceed` was false. */
-        sor.offerDetail = ofl.offerData[sor.offerId].detail;
+        sor.offerDetail = pair.offerData[sor.offerId].detail;
 
         /* `execute` will adjust `sor.wants`,`sor.gives`, and may attempt to execute the offer if its price is low enough. It is crucial that an error due to `taker` triggers a revert. That way, [`mgvData`](#MgvOfferTaking/statusCodes) not in `["mgv/notExecuted","mgv/tradeSuccess"]` means the failure is the maker's fault. */
         /* Post-execution, `sor.wants`/`sor.gives` reflect how much was sent/taken by the offer. We will need it after the recursive call, so we save it in local variables. Same goes for `offerId`, `sor.offer` and `sor.offerDetail`. */
 
-        (gasused, makerData, mgvData) = execute(ofl, mor, sor);
+        (gasused, makerData, mgvData) = execute(pair, mor, sor);
 
         /* Keep cached copy of current `sor` values. */
         uint takerWants = sor.wants;
@@ -157,12 +157,12 @@ abstract contract MgvOfferTaking is MgvHasOffers {
         */
           sor.gives = mor.initialGives - mor.totalGave;
           sor.offerId = sor.offer.next();
-          sor.offer = ofl.offerData[sor.offerId].offer;
+          sor.offer = pair.offerData[sor.offerId].offer;
         }
 
         /* note that internalMarketOrder may be called twice with same offerId, but in that case `proceed` will be false! */
         internalMarketOrder(
-          ofl,
+          pair,
           mor,
           sor,
           /* `proceed` value for next call. Currently, when an offer did not execute, it's because the offer's price was too high. In that case we interrupt the loop and let the taker leave with less than they asked for (but at a correct price). We could also revert instead of breaking; this could be a configurable flag for the taker to pick. */
@@ -185,7 +185,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
         /* If `proceed` is false, the taker has gotten its requested volume, or we have reached the end of the book, we conclude the market order. */
       } else {
         /* During the market order, all executed offers have been removed from the book. We end by stitching together the `best` offer pointer and the new best offer. */
-        sor.local = stitchOffers(ofl, 0, sor.offerId, sor.local);
+        sor.local = stitchOffers(pair, 0, sor.offerId, sor.local);
         /* <a id="internalMarketOrder/liftReentrancy"></a>Now that the market order is over, we can lift the lock on the book. In the same operation we
 
       * lift the reentrancy lock, and
@@ -194,7 +194,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
       so we are free from out of order storage writes.
       */
         sor.local = sor.local.lock(false);
-        ofl.local = sor.local;
+        pair.local = sor.local;
 
         /* `payTakerMinusFees` keeps the fee in Mangrove, proportional to the amount purchased, and gives the rest to the taker */
         payTakerMinusFees(mor, sor);
@@ -240,8 +240,8 @@ abstract contract MgvOfferTaking is MgvHasOffers {
       MgvLib.SingleOrder memory sor;
       sor.outbound_tkn = outbound_tkn;
       sor.inbound_tkn = inbound_tkn;
-      Ofl storage ofl;
-      (sor.global, sor.local, ofl) = _config(outbound_tkn, inbound_tkn);
+      Pair storage pair;
+      (sor.global, sor.local, pair) = _config(outbound_tkn, inbound_tkn);
 
       /* For the snipes to even start, the market needs to be both active and not currently protected from reentrancy. */
       activeMarketOnly(sor.global, sor.local);
@@ -253,7 +253,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
       //+clear+
 
       /* Call `internalSnipes` function. */
-      (successCount, snipesGot, snipesGave) = internalSnipes(ofl, mor, sor, targets);
+      (successCount, snipesGot, snipesGave) = internalSnipes(pair, mor, sor, targets);
 
       /* Over the course of the snipes order, a penalty reserved for `msg.sender` has accumulated in `mor.totalPenalty`. No actual transfers have occured yet -- all the ethers given by the makers as provision are owned by Mangrove. `sendPenalty` finally gives the accumulated penalty to `msg.sender`. */
       sendPenalty(mor.totalPenalty);
@@ -269,7 +269,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
   //+clear+
   /* `internalSnipes` works by looping over targets. Each successive offer is executed under a [reentrancy lock](#internalSnipes/liftReentrancy), then its posthook is called. Going upward, each offer's `maker` contract is called again with its remaining gas and given the chance to update its offers on the book. */
   function internalSnipes(
-    Ofl storage ofl,
+    Pair storage pair,
     MultiOrder memory mor,
     MgvLib.SingleOrder memory sor,
     uint[4][] calldata targets
@@ -282,7 +282,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
         /* Initialize single order struct. */
         sor.offerId = targets[i][0];
-        OfferData storage offerData = ofl.offerData[sor.offerId];
+        OfferData storage offerData = pair.offerData[sor.offerId];
         sor.offer = offerData.offer;
         sor.offerDetail = offerData.detail;
 
@@ -298,11 +298,11 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
           /* We start be enabling the reentrancy lock for this (`outbound_tkn`,`inbound_tkn`) pair. */
           sor.local = sor.local.lock(true);
-          ofl.local = sor.local;
+          pair.local = sor.local;
 
           /* `execute` will adjust `sor.wants`,`sor.gives`, and may attempt to execute the offer if its price is low enough. It is crucial that an error due to `taker` triggers a revert. That way [`mgvData`](#MgvOfferTaking/statusCodes) not in `["mgv/tradeSuccess","mgv/notExecuted"]` means the failure is the maker's fault. */
           /* Post-execution, `sor.wants`/`sor.gives` reflect how much was sent/taken by the offer. */
-          (uint gasused, bytes32 makerData, bytes32 mgvData) = execute(ofl, mor, sor);
+          (uint gasused, bytes32 makerData, bytes32 mgvData) = execute(pair, mor, sor);
 
           if (mgvData == "mgv/tradeSuccess") {
             successCount += 1;
@@ -310,7 +310,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
           /* In the market order, we were able to avoid stitching back offers after every `execute` since we knew a continuous segment starting at best would be consumed. Here, we cannot do this optimisation since offers in the `targets` array may be anywhere in the book. So we stitch together offers immediately after each `execute`. */
           if (mgvData != "mgv/notExecuted") {
-            sor.local = stitchOffers(ofl, sor.offer.prev(), sor.offer.next(), sor.local);
+            sor.local = stitchOffers(pair, sor.offer.prev(), sor.offer.next(), sor.local);
           }
 
           /* <a id="internalSnipes/liftReentrancy"></a> Now that the current snipe is over, we can lift the lock on the book. In the same operation we
@@ -320,7 +320,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
         so we are free from out of order storage writes.
         */
           sor.local = sor.local.lock(false);
-          ofl.local = sor.local;
+          pair.local = sor.local;
 
           /* `payTakerMinusFees` keeps the fee in Mangrove, proportional to the amount purchased, and gives the rest to the taker */
           payTakerMinusFees(mor, sor);
@@ -351,7 +351,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
     * `makerData` is the data returned after executing the offer
     * `mgvData` is an [internal Mangrove status code](#MgvOfferTaking/statusCodes).
   */
-  function execute(Ofl storage ofl, MultiOrder memory mor, MgvLib.SingleOrder memory sor)
+  function execute(Pair storage pair, MultiOrder memory mor, MgvLib.SingleOrder memory sor)
     internal
     returns (uint gasused, bytes32 makerData, bytes32 mgvData)
   {
@@ -473,7 +473,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
       }
 
       /* Delete the offer. The last argument indicates whether the offer should be stripped of its provision (yes if execution failed, no otherwise). We cannot partially strip an offer provision (for instance, remove only the penalty from a failing offer and leave the rest) since the provision associated with an offer is always deduced from the (gasprice,gasbase,gasreq) parameters and not stored independently. We delete offers whether the amount remaining on offer is > density or not for the sake of uniformity (code is much simpler). We also expect prices to move often enough that the maker will want to update their price anyway. To simulate leaving the remaining volume in the offer, the maker can program their `makerPosthook` to `updateOffer` and put the remaining volume back in. */
-      dirtyDeleteOffer(ofl.offerData[sor.offerId], sor.offer, sor.offerDetail, mgvData != "mgv/tradeSuccess");
+      dirtyDeleteOffer(pair.offerData[sor.offerId], sor.offer, sor.offerDetail, mgvData != "mgv/tradeSuccess");
     }
   }
 

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -16,7 +16,6 @@ abstract contract MgvOfferTaking is MgvHasOffers {
     address taker; // used globally
     bool fillWants; // used globally
     uint feePaid; // used globally
-    OflPacked ofl; // used globally
   }
 
   /* # Market Orders */
@@ -70,10 +69,9 @@ abstract contract MgvOfferTaking is MgvHasOffers {
       sor.inbound_tkn = inbound_tkn;
       Ofl storage ofl;
       (sor.global, sor.local, ofl) = _config(outbound_tkn, inbound_tkn);
-      mor.ofl = rs(ofl);
       /* Throughout the execution of the market order, the `sor`'s offer id and other parameters will change. We start with the current best offer id (0 if the book is empty). */
       sor.offerId = sor.local.best();
-      sor.offer = sr(mor.ofl).offers[sor.offerId];
+      sor.offer = ofl.offers[sor.offerId];
       /* `sor.wants` and `sor.gives` may evolve, but they are initially however much remains in the market order. */
       sor.wants = takerWants;
       sor.gives = takerGives;
@@ -90,12 +88,12 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
       /* We start be enabling the reentrancy lock for this (`outbound_tkn`,`inbound_tkn`) pair. */
       sor.local = sor.local.lock(true);
-      sr(mor.ofl).local = sor.local;
+      ofl.local = sor.local;
 
       emit OrderStart();
 
       /* Call recursive `internalMarketOrder` function.*/
-      internalMarketOrder(mor, sor, true);
+      internalMarketOrder(ofl, mor, sor, true);
 
       /* Over the course of the market order, a penalty reserved for `msg.sender` has accumulated in `mor.totalPenalty`. No actual transfers have occured yet -- all the ethers given by the makers as provision are owned by Mangrove. `sendPenalty` finally gives the accumulated penalty to `msg.sender`. */
       sendPenalty(mor.totalPenalty);
@@ -112,7 +110,9 @@ abstract contract MgvOfferTaking is MgvHasOffers {
   /* `internalMarketOrder` works recursively. Going downward, each successive offer is executed until the market order stops (due to: volume exhausted, bad price, or empty book). Then the [reentrancy lock is lifted](#internalMarketOrder/liftReentrancy). Going upward, each offer's `maker` contract is called again with its remaining gas and given the chance to update its offers on the book.
 
     The last argument is a boolean named `proceed`. If an offer was not executed, it means the price has become too high. In that case, we notify the next recursive call that the market order should end. In this initial call, no offer has been executed yet so `proceed` is true. */
-  function internalMarketOrder(MultiOrder memory mor, MgvLib.SingleOrder memory sor, bool proceed) internal {
+  function internalMarketOrder(Ofl storage ofl, MultiOrder memory mor, MgvLib.SingleOrder memory sor, bool proceed)
+    internal
+  {
     unchecked {
       /* #### Case 1 : End of order */
       /* We execute the offer currently stored in `sor`. */
@@ -133,12 +133,12 @@ abstract contract MgvOfferTaking is MgvHasOffers {
         bytes32 mgvData;
 
         /* Load additional information about the offer. We don't do it earlier to save one storage read in case `proceed` was false. */
-        sor.offerDetail = sr(mor.ofl).offerDetails[sor.offerId];
+        sor.offerDetail = ofl.offerDetails[sor.offerId];
 
         /* `execute` will adjust `sor.wants`,`sor.gives`, and may attempt to execute the offer if its price is low enough. It is crucial that an error due to `taker` triggers a revert. That way, [`mgvData`](#MgvOfferTaking/statusCodes) not in `["mgv/notExecuted","mgv/tradeSuccess"]` means the failure is the maker's fault. */
         /* Post-execution, `sor.wants`/`sor.gives` reflect how much was sent/taken by the offer. We will need it after the recursive call, so we save it in local variables. Same goes for `offerId`, `sor.offer` and `sor.offerDetail`. */
 
-        (gasused, makerData, mgvData) = execute(mor, sor);
+        (gasused, makerData, mgvData) = execute(ofl, mor, sor);
 
         /* Keep cached copy of current `sor` values. */
         uint takerWants = sor.wants;
@@ -157,11 +157,12 @@ abstract contract MgvOfferTaking is MgvHasOffers {
         */
           sor.gives = mor.initialGives - mor.totalGave;
           sor.offerId = sor.offer.next();
-          sor.offer = sr(mor.ofl).offers[sor.offerId];
+          sor.offer = ofl.offers[sor.offerId];
         }
 
         /* note that internalMarketOrder may be called twice with same offerId, but in that case `proceed` will be false! */
         internalMarketOrder(
+          ofl,
           mor,
           sor,
           /* `proceed` value for next call. Currently, when an offer did not execute, it's because the offer's price was too high. In that case we interrupt the loop and let the taker leave with less than they asked for (but at a correct price). We could also revert instead of breaking; this could be a configurable flag for the taker to pick. */
@@ -184,7 +185,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
         /* If `proceed` is false, the taker has gotten its requested volume, or we have reached the end of the book, we conclude the market order. */
       } else {
         /* During the market order, all executed offers have been removed from the book. We end by stitching together the `best` offer pointer and the new best offer. */
-        sor.local = stitchOffers(sr(mor.ofl), 0, sor.offerId, sor.local);
+        sor.local = stitchOffers(ofl, 0, sor.offerId, sor.local);
         /* <a id="internalMarketOrder/liftReentrancy"></a>Now that the market order is over, we can lift the lock on the book. In the same operation we
 
       * lift the reentrancy lock, and
@@ -193,7 +194,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
       so we are free from out of order storage writes.
       */
         sor.local = sor.local.lock(false);
-        sr(mor.ofl).local = sor.local;
+        ofl.local = sor.local;
 
         /* `payTakerMinusFees` keeps the fee in Mangrove, proportional to the amount purchased, and gives the rest to the taker */
         payTakerMinusFees(mor, sor);
@@ -241,7 +242,6 @@ abstract contract MgvOfferTaking is MgvHasOffers {
       sor.inbound_tkn = inbound_tkn;
       Ofl storage ofl;
       (sor.global, sor.local, ofl) = _config(outbound_tkn, inbound_tkn);
-      mor.ofl = rs(ofl);
 
       /* For the snipes to even start, the market needs to be both active and not currently protected from reentrancy. */
       activeMarketOnly(sor.global, sor.local);
@@ -253,7 +253,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
       //+clear+
 
       /* Call `internalSnipes` function. */
-      (successCount, snipesGot, snipesGave) = internalSnipes(mor, sor, targets);
+      (successCount, snipesGot, snipesGave) = internalSnipes(ofl, mor, sor, targets);
 
       /* Over the course of the snipes order, a penalty reserved for `msg.sender` has accumulated in `mor.totalPenalty`. No actual transfers have occured yet -- all the ethers given by the makers as provision are owned by Mangrove. `sendPenalty` finally gives the accumulated penalty to `msg.sender`. */
       sendPenalty(mor.totalPenalty);
@@ -268,10 +268,12 @@ abstract contract MgvOfferTaking is MgvHasOffers {
   /* ## Internal snipes */
   //+clear+
   /* `internalSnipes` works by looping over targets. Each successive offer is executed under a [reentrancy lock](#internalSnipes/liftReentrancy), then its posthook is called. Going upward, each offer's `maker` contract is called again with its remaining gas and given the chance to update its offers on the book. */
-  function internalSnipes(MultiOrder memory mor, MgvLib.SingleOrder memory sor, uint[4][] calldata targets)
-    internal
-    returns (uint successCount, uint snipesGot, uint snipesGave)
-  {
+  function internalSnipes(
+    Ofl storage ofl,
+    MultiOrder memory mor,
+    MgvLib.SingleOrder memory sor,
+    uint[4][] calldata targets
+  ) internal returns (uint successCount, uint snipesGot, uint snipesGave) {
     unchecked {
       for (uint i = 0; i < targets.length; ++i) {
         /* Reset these amounts since every snipe is treated individually. Only the total penalty is sent at the end of all snipes. */
@@ -280,8 +282,8 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
         /* Initialize single order struct. */
         sor.offerId = targets[i][0];
-        sor.offer = sr(mor.ofl).offers[sor.offerId];
-        sor.offerDetail = sr(mor.ofl).offerDetails[sor.offerId];
+        sor.offer = ofl.offers[sor.offerId];
+        sor.offerDetail = ofl.offerDetails[sor.offerId];
 
         /* If we removed the `isLive` conditional, a single expired or nonexistent offer in `targets` would revert the entire transaction (by the division by `offer.gives` below since `offer.gives` would be 0). We also check that `gasreq` is not worse than specified. A taker who does not care about `gasreq` can specify any amount larger than $2^{24}-1$. A mismatched price will be detected by `execute`. */
         if (!isLive(sor.offer) || sor.offerDetail.gasreq() > targets[i][3]) {
@@ -295,11 +297,11 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
           /* We start be enabling the reentrancy lock for this (`outbound_tkn`,`inbound_tkn`) pair. */
           sor.local = sor.local.lock(true);
-          sr(mor.ofl).local = sor.local;
+          ofl.local = sor.local;
 
           /* `execute` will adjust `sor.wants`,`sor.gives`, and may attempt to execute the offer if its price is low enough. It is crucial that an error due to `taker` triggers a revert. That way [`mgvData`](#MgvOfferTaking/statusCodes) not in `["mgv/tradeSuccess","mgv/notExecuted"]` means the failure is the maker's fault. */
           /* Post-execution, `sor.wants`/`sor.gives` reflect how much was sent/taken by the offer. */
-          (uint gasused, bytes32 makerData, bytes32 mgvData) = execute(mor, sor);
+          (uint gasused, bytes32 makerData, bytes32 mgvData) = execute(ofl, mor, sor);
 
           if (mgvData == "mgv/tradeSuccess") {
             successCount += 1;
@@ -307,7 +309,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
           /* In the market order, we were able to avoid stitching back offers after every `execute` since we knew a continuous segment starting at best would be consumed. Here, we cannot do this optimisation since offers in the `targets` array may be anywhere in the book. So we stitch together offers immediately after each `execute`. */
           if (mgvData != "mgv/notExecuted") {
-            sor.local = stitchOffers(sr(mor.ofl), sor.offer.prev(), sor.offer.next(), sor.local);
+            sor.local = stitchOffers(ofl, sor.offer.prev(), sor.offer.next(), sor.local);
           }
 
           /* <a id="internalSnipes/liftReentrancy"></a> Now that the current snipe is over, we can lift the lock on the book. In the same operation we
@@ -317,7 +319,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
         so we are free from out of order storage writes.
         */
           sor.local = sor.local.lock(false);
-          sr(mor.ofl).local = sor.local;
+          ofl.local = sor.local;
 
           /* `payTakerMinusFees` keeps the fee in Mangrove, proportional to the amount purchased, and gives the rest to the taker */
           payTakerMinusFees(mor, sor);
@@ -348,7 +350,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
     * `makerData` is the data returned after executing the offer
     * `mgvData` is an [internal Mangrove status code](#MgvOfferTaking/statusCodes).
   */
-  function execute(MultiOrder memory mor, MgvLib.SingleOrder memory sor)
+  function execute(Ofl storage ofl, MultiOrder memory mor, MgvLib.SingleOrder memory sor)
     internal
     returns (uint gasused, bytes32 makerData, bytes32 mgvData)
   {
@@ -470,7 +472,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
       }
 
       /* Delete the offer. The last argument indicates whether the offer should be stripped of its provision (yes if execution failed, no otherwise). We cannot partially strip an offer provision (for instance, remove only the penalty from a failing offer and leave the rest) since the provision associated with an offer is always deduced from the (gasprice,gasbase,gasreq) parameters and not stored independently. We delete offers whether the amount remaining on offer is > density or not for the sake of uniformity (code is much simpler). We also expect prices to move often enough that the maker will want to update their price anyway. To simulate leaving the remaining volume in the offer, the maker can program their `makerPosthook` to `updateOffer` and put the remaining volume back in. */
-      dirtyDeleteOffer(sr(mor.ofl), sor.offerId, sor.offer, sor.offerDetail, mgvData != "mgv/tradeSuccess");
+      dirtyDeleteOffer(ofl, sor.offerId, sor.offer, sor.offerDetail, mgvData != "mgv/tradeSuccess");
     }
   }
 

--- a/src/MgvOfferTakingWithPermit.sol
+++ b/src/MgvOfferTakingWithPermit.sol
@@ -113,9 +113,10 @@ abstract contract MgvOfferTakingWithPermit is MgvOfferTaking {
   /* Used by `*For` functions, its both checks that `msg.sender` was allowed to use the taker's funds, and decreases the former's allowance. */
   function deductSenderAllowance(address outbound_tkn, address inbound_tkn, address owner, uint amount) internal {
     unchecked {
-      uint allowed = allowances[outbound_tkn][inbound_tkn][owner][msg.sender];
+      mapping(address => uint) storage curriedAllow = allowances[outbound_tkn][inbound_tkn][owner];
+      uint allowed = curriedAllow[msg.sender];
       require(allowed >= amount, "mgv/lowAllowance");
-      allowances[outbound_tkn][inbound_tkn][owner][msg.sender] = allowed - amount;
+      curriedAllow[msg.sender] = allowed - amount;
 
       emit Approval(outbound_tkn, inbound_tkn, owner, msg.sender, allowed - amount);
     }

--- a/src/MgvRoot.sol
+++ b/src/MgvRoot.sol
@@ -24,7 +24,6 @@ import {MgvLib, HasMgvEvents, IMgvMonitor, MgvStructs, IERC20} from "./MgvLib.so
 
 /* `MgvRoot` contains state variables used everywhere in the operation of Mangrove and their related function. */
 contract MgvRoot is HasMgvEvents {
-  type OflPacked is uint;
   /* # State variables */
   //+clear+
 
@@ -36,18 +35,6 @@ contract MgvRoot is HasMgvEvents {
     MgvStructs.LocalPacked local;
     mapping(uint => MgvStructs.OfferPacked) offers;
     mapping(uint => MgvStructs.OfferDetailPacked) offerDetails;
-  }
-
-  function sr(OflPacked _ofl) internal pure returns (Ofl storage ofl) {
-    assembly ("memory-safe") {
-      ofl.slot := _ofl
-    }
-  }
-
-  function rs(Ofl storage _ofl) internal pure returns (OflPacked ofl) {
-    assembly ("memory-safe") {
-      ofl := _ofl.slot
-    }
   }
 
   mapping(address => mapping(address => Ofl)) internal ofls;

--- a/src/MgvRoot.sol
+++ b/src/MgvRoot.sol
@@ -31,10 +31,14 @@ contract MgvRoot is HasMgvEvents {
   MgvStructs.GlobalPacked internal internal_global;
   /* Configuration mapping for each token pair of the form `outbound_tkn => inbound_tkn => MgvStructs.LocalPacked`. The structure of each `MgvStructs.LocalPacked` value is detailed in [`structs.js`](#structs.js). It fits in one word. */
 
+  struct OfferData {
+    MgvStructs.OfferPacked offer;
+    MgvStructs.OfferDetailPacked detail;
+  }
+
   struct Ofl {
     MgvStructs.LocalPacked local;
-    mapping(uint => MgvStructs.OfferPacked) offers;
-    mapping(uint => MgvStructs.OfferDetailPacked) offerDetails;
+    mapping(uint => OfferData) offerData;
   }
 
   mapping(address => mapping(address => Ofl)) internal ofls;

--- a/test/strategies/kandel/AaveKandel.t.sol
+++ b/test/strategies/kandel/AaveKandel.t.sol
@@ -333,7 +333,7 @@ contract AaveKandelTest is CoreKandelTest {
 
   function test_liquidity_borrow_marketOrder_attack() public {
     /// adding as many offers as possible (adding more will stack overflow when failing offer will cascade)
-    deployOtherKandel(0.1 ether, 100 * 10 ** 6, uint24(1001 * 10 ** PRECISION / 1000), 1, 150);
+    deployOtherKandel(0.1 ether, 100 * 10 ** 6, uint24(1001 * 10 ** PRECISION / 1000), 1, 139);
     //printOrderBook($(quote), $(base));
     // base is weth and has a borrow cap, so trying the attack on quote
     address dai = fork.get("DAI");


### PR DESCRIPTION
improve on #357: use 3 stack args instead of 1 memory args that gets accessed everytime when calling `better`.

strict gas improvement, notably:

| name              | delta to develop (15c0e78b3d7e9ac5c791d269d36b45dfb3d27b1e)   | delta to #357 |
|-------------------|---------|-------------------|
| insert, move by 15 offers |  - 8.40% | -0.91% |
| insert, move by 49 offers |  - 8.12% | -1.07% |

Size is 23.074 kB (vs 23.067 on #357)