### PR TITLE
chore/0.8.20

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -8,8 +8,10 @@ out='out'
 libs=['lib']
 cache_path='cache'
 fs_permissions = [{ access = "read-write", path = "./addresses/"}, { access = "read", path = "./out/" }]
-solc_version="0.8.17"
+solc_version="0.8.20"
 ffi=true
+# new default "shanghai" since 0.8.20 is not compatible w/ polygon
+evm_version="paris"
 # optimizer=true
 # optimizer_runs=20000
 

--- a/src/toy_strategies/utils/SimpleOracle.sol
+++ b/src/toy_strategies/utils/SimpleOracle.sol
@@ -11,9 +11,9 @@ contract SimpleOracle is IOracle, AccessControlled {
   mapping(address => uint96) internal priceData;
 
   constructor(address base_, address admin) AccessControlled(admin) {
+    base_token = IERC20(base_);
     try IERC20(base_).decimals() returns (uint8 d) {
       require(d != 0, "Invalid decimals number for Oracle base");
-      base_token = IERC20(base_);
     } catch {
       revert("Invalid Oracle base address");
     }

--- a/src/toy_strategies/utils/SimpleOracle.sol
+++ b/src/toy_strategies/utils/SimpleOracle.sol
@@ -12,7 +12,7 @@ contract SimpleOracle is IOracle, AccessControlled {
 
   constructor(address base_, address admin) AccessControlled(admin) {
     base_token = IERC20(base_);
-    try IERC20(base_).decimals() returns (uint8 d) {
+    try base_token.decimals() returns (uint8 d) {
       require(d != 0, "Invalid decimals number for Oracle base");
     } catch {
       revert("Invalid Oracle base address");


### PR DESCRIPTION
new default evm version (shanghai) is only deployed on eth mainnet, so this commit also specifies the former evm version as the default.

Note: when applied to #358 , Mangrove contract size is improved (from 22.986 kB to 22.872 kB), but gas tests regress:

<img width="342" alt="image" src="https://github.com/mangrovedao/mangrove-core/assets/2977/dca67bc1-ffa7-4272-a833-afc09f2f8301">
