### PR TITLE
feat(ci): Simplify CI by moving away from pull_request_target

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -65,12 +65,11 @@ jobs:
       run: yarn run build
 
     # Pinned forks are used in tests and utilize secrets. For PRs from forks these are not available
-    # Let the tests attempt to run with the cached state, but if they fail, then the tests have to be disabled
-    # until the PR is merged.
+    # Let the tests attempt to run with demo endpoints which are more unstable.
     - name: Mangrove Solidity Tests
       run: yarn run test
       env:
-        POLYGON_NODE_URL: ${{ secrets.POLYGON_NODE_URL || 'http://localhost:4444' }}
+        POLYGON_NODE_URL: ${{ secrets.POLYGON_NODE_URL || 'https://polygon-mumbai.g.alchemy.com/v2/demo' }}
         MUMBAI_NODE_URL: ${{ secrets.MUMBAI_NODE_URL || 'http://localhost:4444' }}
 
     # For push runs we also create a coverage report

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -8,7 +8,7 @@ on:
       - develop
       - 'run-ci/**'
   pull_request:
-    branches: [ master, develop, test-pr ]
+    branches: [ master, develop, test-pr, feat/simplifyci ]
     types: [opened, synchronize, reopened, labeled]
 
 concurrency: 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -8,7 +8,7 @@ on:
       - develop
       - 'run-ci/**'
   pull_request:
-    branches: [ master, develop, test-pr, feat/simplifyci ]
+    branches: [ master, develop, test-pr ]
     types: [opened, synchronize, reopened, labeled]
 
 concurrency: 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -7,7 +7,7 @@ on:
       - master
       - develop
       - 'run-ci/**'
-  pull_request_target:
+  pull_request:
     branches: [ master, develop, test-pr ]
     types: [opened, synchronize, reopened, labeled]
 
@@ -17,56 +17,12 @@ concurrency:
 
 env:
   NODE_ENV: test
-  # Ternary-esque expression hack: The first line is the condition,
-  # the 2nd line is the value if `true`, the 3rd line is the value if `false`.
-  GIT_REF_TO_TEST: >
-                   ${{  (   github.event_name != 'pull_request_target'
-                         && github.ref )
-                      || format('refs/pull/{0}/merge', github.event.number) }}
-  NOTIFY_SLACK_FOR_THIS_WORKFLOW_RUN: ${{ github.ref_name == 'master' && github.event_name != 'pull_request_target' }}
 jobs:
-  # ==== Job: Security guard ====
-  # The security guard job only allows workflows triggered by external PR's to continue
-  # if they are labelled 'safe to test'.
-  security-guard:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Comment external PR's with first time (before being labelled 'external PR')
-      if: >
-          !(   github.event_name != 'pull_request_target'
-            || github.event.pull_request.head.repo.full_name == github.repository
-            || contains(github.event.pull_request.labels.*.name, 'external PR') )
-      uses: peter-evans/create-or-update-comment@v3
-      with:
-        issue-number: ${{ github.event.pull_request.number }}
-        body: >
-              Pull requests from forks must be reviewed before build and tests are run.
-
-              A maintainer will review and add the 'safe to test' label if everything looks good.
-
-    - name: Label external PR's with 'external PR'
-      if: >
-          !(   github.event_name != 'pull_request_target'
-            || github.event.pull_request.head.repo.full_name == github.repository
-            || contains(github.event.pull_request.labels.*.name, 'external PR') )
-      uses: actions-ecosystem/action-add-labels@v1
-      with:
-        labels: external PR
-
-  # ==== End job: Security guard ====
   file-guard:
-    needs: [security-guard]
     runs-on: ubuntu-latest
     steps:
-    # == Git checkout ==
     - name: Checkout
       uses: actions/checkout@v3
-      # Workaround for https://github.com/npm/cli/issues/2610
-      with:
-        persist-credentials: false
-        ref: ${{ env.GIT_REF_TO_TEST }}
-        submodules: recursive
 
     - uses: dorny/paths-filter@v2
       id: changes
@@ -77,7 +33,7 @@ jobs:
 
     - name: Fail if addresses changed unless PR has 'update address' label
       if: >
-          (    github.event_name == 'pull_request_target'
+          (    github.event_name == 'pull_request'
            &&  !contains(github.event.pull_request.labels.*.name,'update address') 
            &&  steps.changes.outputs.addresses == 'true')
       uses: actions/github-script@v6
@@ -86,61 +42,41 @@ jobs:
 
   # ==== Job: Build and test mangrove-core
   mangrove-core:
-    needs: [security-guard]
-
     runs-on: ubuntu-latest
 
     steps:
 
-    # == Git checkout ==
     - name: Checkout
       uses: actions/checkout@v3
-      # Workaround for https://github.com/npm/cli/issues/2610
       with:
-        persist-credentials: false
-        ref: ${{ env.GIT_REF_TO_TEST }}
         submodules: recursive
 
-    - name: Reconfigure git to use HTTP authentication
-      # Workaround for https://github.com/npm/cli/issues/2610    
-      run: >
-        git config --global url."https://github.com/".insteadOf
-        ssh://git@github.com/
-
-    # == yarn setup ==
     - name: Yarn setup (caching yarn dependencies)
       uses: actions/setup-node@v3
       with:
-        node-version: ${{ matrix.node-version }}
         cache: 'yarn'
         
     - run: yarn install --immutable
-      working-directory: . # Yarn must run in root to ensure monorepo setup
 
     - name: Foundry Setup
       uses: ./.github/actions/foundry-setup
 
-    # == build ==
     - name: Solidity Compile
       run: yarn run build
 
-    - name: Save status of build
-      # So we can fail-fast and drop the X Test Report steps, if build fails
-      # A tiny bit hacky, but it's simple and works
-      run: echo "mangrove_built=true" >> $GITHUB_ENV
-
-    # Run local Solidity tests
+    # Pinned forks are used in tests and utilize secrets. For PRs from forks these are not available
+    # Let the tests attempt to run with the cached state, but if they fail, then the tests have to be disabled
+    # until the PR is merged.
     - name: Mangrove Solidity Tests
       run: yarn run test
       env:
-        POLYGON_NODE_URL: ${{ secrets.POLYGON_NODE_URL }}
-        MUMBAI_NODE_URL: ${{ secrets.MUMBAI_NODE_URL }}
+        POLYGON_NODE_URL: ${{ secrets.POLYGON_NODE_URL || 'http://localhost:4444' }}
+        MUMBAI_NODE_URL: ${{ secrets.MUMBAI_NODE_URL || 'http://localhost:4444' }}
 
     # For push runs we also create a coverage report
     - name: Create coverage report for mangrove-solidity
-      if: github.event_name != 'pull_request_target' 
+      if: github.event_name != 'pull_request' 
       run: forge coverage --report lcov
-      working-directory: . # coverage cannot find contracts if executed inside mangrove-solidity
       env:
         POLYGON_NODE_URL: ${{ secrets.POLYGON_NODE_URL }}
         MUMBAI_NODE_URL: ${{ secrets.MUMBAI_NODE_URL }}
@@ -150,12 +86,12 @@ jobs:
      # to HEAD because a branch is checked out. We here find the actual SHA for HEAD.
     - name: Set Coveralls vars
       id: coveralls_vars
-      if: github.event_name != 'pull_request_target' 
+      if: github.event_name != 'pull_request' 
       run: echo "::set-output name=sha_for_head::$(git rev-parse HEAD)"
 
     - name: Upload to Coveralls for mangrove-solidity
       uses: coverallsapp/github-action@master
-      if: github.event_name != 'pull_request_target' 
+      if: github.event_name != 'pull_request' 
       with:
         git-commit: ${{ steps.coveralls_vars.outputs.sha_for_head }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -170,7 +106,7 @@ jobs:
     #   if: ${{ env.mangrove_built && (success() || failure()) }}
     #   with:
     #     name: Solidity Tests                  # Name of the check run which will be created
-    #     path: ${{env.working-directory}}/solidity-mocha-test-report.json # Path to test results
+    #     path: ./solidity-mocha-test-report.json # Path to test results
     #     reporter: mocha-json                  # Format of test results
 
     # == check docs can be created ==
@@ -179,17 +115,6 @@ jobs:
     # == check precommit works ==
     - run: yarn run precommit
 
-    - name: Report Failure to Slack
-      if: ${{ failure() && fromJSON(env.NOTIFY_SLACK_FOR_THIS_WORKFLOW_RUN) }}
-      uses: ravsamhq/notify-slack-action@v2
-      with:
-        status: ${{ job.status }}
-        message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}@{branch}> on <{commit_url}|{commit_sha}> at {job}'
-        footer: '<{run_url}|View Run>'
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
-  # ==== End job mangrove-core ====
-
   # ==== final "check" job, using alls-green to have one single job to check for green workflow ====
   # see https://github.com/re-actors/alls-green
 
@@ -197,7 +122,6 @@ jobs:
     if: always()
 
     needs:
-    - security-guard
     - file-guard
     - mangrove-core
 
@@ -207,5 +131,5 @@ jobs:
     - name: Decide whether the needed jobs succeeded or failed
       uses: re-actors/alls-green@release/v1
       with:
-        allowed-skips: security-guard, file-guard, mangrove-core
+        allowed-skips: file-guard, mangrove-core
         jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -69,8 +69,8 @@ jobs:
     - name: Mangrove Solidity Tests
       run: yarn run test
       env:
-        POLYGON_NODE_URL: ${{ secrets.POLYGON_NODE_URL || 'https://polygon-mumbai.g.alchemy.com/v2/demo' }}
-        MUMBAI_NODE_URL: ${{ secrets.MUMBAI_NODE_URL || 'http://localhost:4444' }}
+        POLYGON_NODE_URL: ${{ secrets.POLYGON_NODE_URL || 'https://polygon.llamarpc.com' }}
+        MUMBAI_NODE_URL: ${{ secrets.MUMBAI_NODE_URL || 'unused' }}
 
     # For push runs we also create a coverage report
     - name: Create coverage report for mangrove-solidity

--- a/test/script/toy/MangroveJs.t.sol
+++ b/test/script/toy/MangroveJs.t.sol
@@ -8,17 +8,6 @@ import {MangroveTest} from "mgv_test/lib/MangroveTest.sol";
 import "forge-std/console.sol";
 
 contract MangroveJsDeployTest is MangroveTest {
-  function test_somefoo() public {
-    this.test_runs(
-      0x257A9A2C5a7Cb791165a580bdD8eFc81973D1E1b,
-      44566091758772537392099623289872258789475110185694143407000399511060737909642,
-      1117384713810346522239161599483756589296041293890,
-      0x89cc65A219E651Bb0db1B805107eD94663847f78,
-      890163712994538631907798187850391801921009753035,
-      102462659576709094466902874625942507586384897682649685070626246935815539699467
-    );
-  }
-
   function test_runs(address chief, uint gasprice, uint gasmax, address gasbot, uint mintA, uint mintB) public {
     vm.assume(chief != address(0));
     gasprice = bound(gasprice, 0, type(uint16).max);

--- a/test/script/toy/MangroveJs.t.sol
+++ b/test/script/toy/MangroveJs.t.sol
@@ -8,6 +8,17 @@ import {MangroveTest} from "mgv_test/lib/MangroveTest.sol";
 import "forge-std/console.sol";
 
 contract MangroveJsDeployTest is MangroveTest {
+  function test_somefoo() public {
+    this.test_runs(
+      0x257A9A2C5a7Cb791165a580bdD8eFc81973D1E1b,
+      44566091758772537392099623289872258789475110185694143407000399511060737909642,
+      1117384713810346522239161599483756589296041293890,
+      0x89cc65A219E651Bb0db1B805107eD94663847f78,
+      890163712994538631907798187850391801921009753035,
+      102462659576709094466902874625942507586384897682649685070626246935815539699467
+    );
+  }
+
   function test_runs(address chief, uint gasprice, uint gasmax, address gasbot, uint mintA, uint mintB) public {
     vm.assume(chief != address(0));
     gasprice = bound(gasprice, 0, type(uint16).max);


### PR DESCRIPTION
Based on https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ (more details in our context in https://github.com/mangrovedao/mangrove-ts/issues/691 ) pull_request_target can be used if fork PRs must access secrets or write to repository:
> Due to the dangers inherent to automatic processing of PRs, GitHub’s standard pull_request workflow trigger by default prevents write permissions and secrets access to the target repository. However, in some scenarios such access is needed to properly process the PR. To this end the pull_request_target workflow trigger was introduced.

Standard pull_request is much safer and along with that we can remove a lot of old workarounds.
Additionally, our old pull_request_target workflow had a flaw that you could make a forked PR that is innocent, wait for someone to add labels, and then push extra code to extract secrets after the safe label had been added.

Note, RPC node urls are still referenced in the workflow - for our own PRs it has access to our secrets and use those. For fork-PRs those are empty, and instead we now default to llamarpc which has a free demo endpoint. This is probably not as stable as alchemy, but for now we do not have a lot of PR traffic from Forks so this seems like a simple solution.