### PR TITLE
feat: read addresses from node_modules/mangrovedao/mangrove-core

### DIFF
--- a/script/lib/Deployer.sol
+++ b/script/lib/Deployer.sol
@@ -206,10 +206,10 @@ abstract contract Deployer is Script2 {
       line(end ? "  }" : "  },");
     }
     line("]");
-    string memory latestBackupFile = fork.addressesFile("deployed.backup", "-latest");
+    string memory latestBackupFile = fork.addressesFileRoot("deployed.backup", "-latest");
     string memory timestampedBackupFile =
-      fork.addressesFile("deployed.backup", string.concat("-", vm.toString(block.timestamp), ".backup"));
-    string memory mainFile = fork.addressesFile("deployed");
+      fork.addressesFileRoot("deployed.backup", string.concat("-", vm.toString(block.timestamp), ".backup"));
+    string memory mainFile = fork.addressesFileRoot("deployed");
     vm.writeFile(latestBackupFile, out);
     vm.writeFile(timestampedBackupFile, out);
     if (writeDeploy) {


### PR DESCRIPTION
At the moment we are only able to read addresses from root/addresses/(context/deployed), but when using the mangrove-core package, like in bot arbitrage, then the addresses are no longer in that path. So ATM we have just copied the addresses to the same path, so that it reads the addresses, but this is not very nice and we have to copy addresses very time new addresses gets released, and keeping track of “core” addresses vs your own addresses, can be a mess. Because of this, i’ve added this path root/node_modules/@mangrovedao/mangrove-core/addresses/(deployed/context) so that we can also read the addresses directly from the mangrove-core package. This makes it a lot easier to use the mangrove-core package and its addresses, with your own addresses. 