### PR TITLE
feat: permit2: write a permit2 router

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "lib/permit2"]
+	path = lib/permit2
+	url = https://github.com/Uniswap/permit2

--- a/addresses/context/goerli.json
+++ b/addresses/context/goerli.json
@@ -10,5 +10,9 @@
   {
     "address": "0xd77b79be3e85351ff0cbe78f1b58cf8d1064047c",
     "name": "DAI"
+  },
+  {
+    "address": "0x000000000022d473030f116ddee9f6b43ac78ba3",
+    "name": "Permit2"
   }
 ]

--- a/addresses/context/matic.json
+++ b/addresses/context/matic.json
@@ -30,5 +30,9 @@
   {
     "address": "0x59a424169526ECae25856038598F862043DCeDf7",
     "name": "MgvGovernance"
+  },
+  {
+    "address": "0x000000000022d473030f116ddee9f6b43ac78ba3",
+    "name": "Permit2"
   }
 ]

--- a/addresses/context/maticmum.json
+++ b/addresses/context/maticmum.json
@@ -14,5 +14,9 @@
   {
     "address": "0x47897EE61498D02B18794601Ed3A71896A1Ff894",
     "name": "MgvGovernance"
+  },
+  {
+    "address": "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+    "name": "Permit2"
   }
 ]

--- a/script/strategies/mangroveOrder/deployers/MangroveOrderDeployer.s.sol
+++ b/script/strategies/mangroveOrder/deployers/MangroveOrderDeployer.s.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.13;
 
+import {IPermit2} from "lib/permit2/src/interfaces/IPermit2.sol";
 import {Script, console} from "forge-std/Script.sol";
 import {MangroveOrder, IERC20, IMangrove} from "mgv_src/strategies/MangroveOrder.sol";
 import {Deployer} from "mgv_script/lib/Deployer.sol";
@@ -17,6 +18,7 @@ contract MangroveOrderDeployer is Deployer {
   function run() public {
     innerRun({
       mgv: IMangrove(envAddressOrName("MGV", "Mangrove")),
+      permit2: IPermit2(envAddressOrName("PERMIT2", "Permit2")),
       admin: envAddressOrName("MGV_GOVERNANCE", broadcaster())
     });
     outputDeployment();
@@ -26,7 +28,7 @@ contract MangroveOrderDeployer is Deployer {
    * @param mgv The Mangrove that MangroveOrder should operate on
    * @param admin address of the admin on MangroveOrder after deployment
    */
-  function innerRun(IMangrove mgv, address admin) public {
+  function innerRun(IMangrove mgv, IPermit2 permit2, address admin) public {
     MangroveOrder mgvOrder;
     // Bug workaround: Foundry has a bug where the nonce is not incremented when MangroveOrder is deployed.
     //                 We therefore ensure that this happens.
@@ -36,9 +38,9 @@ contract MangroveOrderDeployer is Deployer {
     // so setting offer logic's gasreq to 35K is enough
     // we use 60K here in order to allow partial fills to repost on top of up to 5 identical offers.
     if (forMultisig) {
-      mgvOrder = new MangroveOrder{salt:salt}(mgv, admin, 60_000);
+      mgvOrder = new MangroveOrder{salt:salt}(mgv, permit2, admin, 60_000);
     } else {
-      mgvOrder = new MangroveOrder(mgv, admin, 60_000);
+      mgvOrder = new MangroveOrder(mgv, permit2, admin, 60_000);
     }
     // Bug workaround: See comment above `nonce` further up
     if (nonce == vm.getNonce(broadcaster())) {

--- a/script/strategies/mangroveOrder/deployers/MangroveOrderDeployer.s.sol
+++ b/script/strategies/mangroveOrder/deployers/MangroveOrderDeployer.s.sol
@@ -18,7 +18,7 @@ contract MangroveOrderDeployer is Deployer {
   function run() public {
     innerRun({
       mgv: IMangrove(envAddressOrName("MGV", "Mangrove")),
-      permit2: IPermit2(envAddressOrName("PERMIT2", "Permit2")),
+      permit2: IPermit2(envAddressOrName("Permit2", "Permit2")),
       admin: envAddressOrName("MGV_GOVERNANCE", broadcaster())
     });
     outputDeployment();

--- a/script/strategies/mangroveOrder/deployers/MumbaiMangroveOrderDeployer.s.sol
+++ b/script/strategies/mangroveOrder/deployers/MumbaiMangroveOrderDeployer.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {Script, console} from "forge-std/Script.sol";
+import {IPermit2} from "lib/permit2/src/interfaces/IPermit2.sol";
 import {MangroveOrder, IERC20, IMangrove} from "mgv_src/strategies/MangroveOrder.sol";
 
 import {Deployer} from "mgv_script/lib/Deployer.sol";
@@ -19,6 +20,7 @@ contract MumbaiMangroveOrderDeployer is Deployer {
   function runWithChainSpecificParams() public {
     new MangroveOrderDeployer().innerRun({
       mgv: IMangrove(envAddressOrName("MGV", "Mangrove")),
+      permit2: IPermit2(envAddressOrName("PERMIT2", "Permit2")),
       admin: envAddressOrName("MGV_GOVERNANCE", broadcaster())
     });
   }

--- a/script/strategies/mangroveOrder/deployers/MumbaiMangroveOrderDeployer.s.sol
+++ b/script/strategies/mangroveOrder/deployers/MumbaiMangroveOrderDeployer.s.sol
@@ -20,7 +20,7 @@ contract MumbaiMangroveOrderDeployer is Deployer {
   function runWithChainSpecificParams() public {
     new MangroveOrderDeployer().innerRun({
       mgv: IMangrove(envAddressOrName("MGV", "Mangrove")),
-      permit2: IPermit2(envAddressOrName("PERMIT2", "Permit2")),
+      permit2: IPermit2(envAddressOrName("Permit2", "Permit2")),
       admin: envAddressOrName("MGV_GOVERNANCE", broadcaster())
     });
   }

--- a/script/strategies/mangroveOrder/deployers/PolygonMangroveOrderDeployer.s.sol
+++ b/script/strategies/mangroveOrder/deployers/PolygonMangroveOrderDeployer.s.sol
@@ -23,7 +23,7 @@ contract PolygonMangroveOrderDeployer is Deployer {
     mangroveOrderDeployer = new MangroveOrderDeployer();
     mangroveOrderDeployer.innerRun({
       mgv: IMangrove(fork.get("Mangrove")),
-      permit2: IPermit2(envAddressOrName("PERMIT2", "Permit2")),
+      permit2: IPermit2(envAddressOrName("Permit2", "Permit2")),
       admin: fork.get("MgvGovernance")
     });
   }

--- a/script/strategies/mangroveOrder/deployers/PolygonMangroveOrderDeployer.s.sol
+++ b/script/strategies/mangroveOrder/deployers/PolygonMangroveOrderDeployer.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {Script, console} from "forge-std/Script.sol";
+import {IPermit2} from "lib/permit2/src/interfaces/IPermit2.sol";
 import {MangroveOrder, IERC20, IMangrove} from "mgv_src/strategies/MangroveOrder.sol";
 
 import {Deployer} from "mgv_script/lib/Deployer.sol";
@@ -20,6 +21,10 @@ contract PolygonMangroveOrderDeployer is Deployer {
 
   function runWithChainSpecificParams() public {
     mangroveOrderDeployer = new MangroveOrderDeployer();
-    mangroveOrderDeployer.innerRun({mgv: IMangrove(fork.get("Mangrove")), admin: fork.get("MgvGovernance")});
+    mangroveOrderDeployer.innerRun({
+      mgv: IMangrove(fork.get("Mangrove")),
+      permit2: IPermit2(envAddressOrName("PERMIT2", "Permit2")),
+      admin: fork.get("MgvGovernance")
+    });
   }
 }

--- a/src/strategies/MangroveOrder.sol
+++ b/src/strategies/MangroveOrder.sol
@@ -22,8 +22,6 @@ contract MangroveOrder is Forwarder, IOrderLogic {
   ///@dev 0 means no expiry.
   mapping(IERC20 => mapping(IERC20 => mapping(uint => uint))) public expiring;
 
-  Permit2Router permit2Router;
-
   ///@notice MangroveOrder is a Forwarder logic with a simple router.
   ///@param mgv The mangrove contract on which this logic will run taker and maker orders.
   ///@param deployer The address of the admin of `this` at the end of deployment
@@ -34,7 +32,6 @@ contract MangroveOrder is Forwarder, IOrderLogic {
     // adding `this` contract to authorized makers of the router before setting admin rights of the router to deployer
     router().bind(address(this));
     router().setAdmin(deployer);
-    permit2Router = Permit2Router(address(router()));
     // if `msg.sender` is not `deployer`, setting admin of `this` to `deployer`.
     // `deployer` will thus be able to call `activate` on `this` to enable trading on particular assets.
     if (msg.sender != deployer) {

--- a/src/strategies/MangroveOrder.sol
+++ b/src/strategies/MangroveOrder.sol
@@ -7,7 +7,6 @@ import {Forwarder, MangroveOffer} from "mgv_src/strategies/offer_forwarder/abstr
 import {IOrderLogic} from "mgv_src/strategies/interfaces/IOrderLogic.sol";
 import {Permit2Router} from "mgv_src/strategies/routers/Permit2Router.sol";
 import {TransferLib} from "mgv_src/strategies/utils/TransferLib.sol";
-import {ISignatureTransfer} from "lib/permit2/src/interfaces/ISignatureTransfer.sol";
 import {MgvLib, IERC20} from "mgv_src/MgvLib.sol";
 
 ///@title MangroveOrder. A periphery contract to Mangrove protocol that implements "Good till cancelled" (GTC) orders as well as "Fill or kill" (FOK) orders.
@@ -123,41 +122,23 @@ contract MangroveOrder is Forwarder, IOrderLogic {
     }
   }
 
-  function takerWithPermit2(
-    TakerOrder calldata tko,
-    ISignatureTransfer.PermitTransferFrom calldata permit,
-    bytes calldata signature
-  ) external payable returns (TakerOrderResult memory res) {
-    // Checking whether order is expired
-    require(tko.expiryDate == 0 || block.timestamp <= tko.expiryDate, "mgvOrder/expired");
-
-    Permit2Router router = Permit2Router(address(router()));
-    uint pulled = router.pull(tko.inbound_tkn, msg.sender, tko.takerGives, true, permit, signature);
-    return __take__(tko, pulled);
-  }
-
-  // Notations:
-  // NAT_USER: initial value of `msg.sender.balance` (native balance of user)
-  // OUT/IN_USER: initial value of `tko.[out|in]bound_tkn.balanceOf(reserve(msg.sender))` (user's reserve balance of tokens)
-  // NAT_THIS: initial value of `address(this).balance` (native balance of `this`)
-  // OUT/IN_THIS: initial value of `tko.[out|in]bound_tkn.balanceOf(address(this))` (`this` balance of tokens)
-
-  // PRE:
-  // * User balances: (NAT_USER -`msg.value`, OUT_USER, IN_USER)
-  // * `this` balances: (NAT_THIS +`msg.value`, OUT_THIS, IN_THIS)
-
   ///@inheritdoc IOrderLogic
   function take(TakerOrder calldata tko) external payable returns (TakerOrderResult memory res) {
     // Checking whether order is expired
     require(tko.expiryDate == 0 || block.timestamp <= tko.expiryDate, "mgvOrder/expired");
 
+    // Notations:
+    // NAT_USER: initial value of `msg.sender.balance` (native balance of user)
+    // OUT/IN_USER: initial value of `tko.[out|in]bound_tkn.balanceOf(reserve(msg.sender))` (user's reserve balance of tokens)
+    // NAT_THIS: initial value of `address(this).balance` (native balance of `this`)
+    // OUT/IN_THIS: initial value of `tko.[out|in]bound_tkn.balanceOf(address(this))` (`this` balance of tokens)
+
+    // PRE:
+    // * User balances: (NAT_USER -`msg.value`, OUT_USER, IN_USER)
+    // * `this` balances: (NAT_THIS +`msg.value`, OUT_THIS, IN_THIS)
+
     // Pulling funds from `msg.sender`'s reserve
     uint pulled = router().pull(tko.inbound_tkn, msg.sender, tko.takerGives, true);
-
-    return __take__(tko, pulled);
-  }
-
-  function __take__(TakerOrder calldata tko, uint pulled) internal returns (TakerOrderResult memory res) {
     require(pulled == tko.takerGives, "mgvOrder/transferInFail");
 
     // POST:

--- a/src/strategies/MangroveOrder.sol
+++ b/src/strategies/MangroveOrder.sol
@@ -26,6 +26,7 @@ contract MangroveOrder is Forwarder, IOrderLogic {
 
   ///@notice MangroveOrder is a Forwarder logic with a simple router.
   ///@param mgv The mangrove contract on which this logic will run taker and maker orders.
+  ///@param permit2 The permit2 contract
   ///@param deployer The address of the admin of `this` at the end of deployment
   ///@param gasreq The gas required for `this` to execute `makerExecute` and `makerPosthook` when called by mangrove for a resting order.
   constructor(IMangrove mgv, IPermit2 permit2, address deployer, uint gasreq)
@@ -125,8 +126,17 @@ contract MangroveOrder is Forwarder, IOrderLogic {
   }
 
   //@notice pull inbound_tkn from the msg.sender with permit and then the forward market order to MGV
+  //@param outbound_tkn outbound_tkn
+  //@param inbound_tkn inbound_tkn
+  //@param takerWants Amount of outbound_tkn taker wants
+  //@param takerGives Amount of inbound_tkn taker gives
+  //@param fillWants isBid
   //@param permit The permit data signed over by the owner
   //@param signature The signature to verify
+  //@return totalGot Amount of outbound_tkn received
+  //@return totalGave Amount of inbound_tkn received
+  //@return totalPenalty Penalty received
+  //@return feePaid Fee paid
   function marketOrderWithTransferApproval(
     IERC20 outbound_tkn,
     IERC20 inbound_tkn,
@@ -150,7 +160,6 @@ contract MangroveOrder is Forwarder, IOrderLogic {
     }
   }
 
-  //@inheritdoc IOrderLogic
   //@param tko TakerOrder struct
   function __take__(TakerOrder calldata tko) internal returns (TakerOrderResult memory res) {
     // Checking whether order is expired
@@ -261,7 +270,7 @@ contract MangroveOrder is Forwarder, IOrderLogic {
     return __take__(tko);
   }
 
-  //@inheritdoc IOrderLogic
+  //@notice call permit2 permit and then call take, this can be used to first approve and then take
   //@param tko TakerOrder struct
   //@param permit The permit data signed over by the owner
   //@param signature The signature to verify

--- a/src/strategies/MangroveOrder.sol
+++ b/src/strategies/MangroveOrder.sol
@@ -125,18 +125,18 @@ contract MangroveOrder is Forwarder, IOrderLogic {
     }
   }
 
-  //@notice pull inbound_tkn from the msg.sender with permit and then the forward market order to MGV
-  //@param outbound_tkn outbound_tkn
-  //@param inbound_tkn inbound_tkn
-  //@param takerWants Amount of outbound_tkn taker wants
-  //@param takerGives Amount of inbound_tkn taker gives
-  //@param fillWants isBid
-  //@param permit The permit data signed over by the owner
-  //@param signature The signature to verify
-  //@return totalGot Amount of outbound_tkn received
-  //@return totalGave Amount of inbound_tkn received
-  //@return totalPenalty Penalty received
-  //@return feePaid Fee paid
+  ///@notice pull inbound_tkn from the msg.sender with permit and then the forward market order to MGV
+  ///@param outbound_tkn outbound_tkn
+  ///@param inbound_tkn inbound_tkn
+  ///@param takerWants Amount of outbound_tkn taker wants
+  ///@param takerGives Amount of inbound_tkn taker gives
+  ///@param fillWants isBid
+  ///@param permit The permit data signed over by the owner
+  ///@param signature The signature to verify
+  ///@return totalGot Amount of outbound_tkn received
+  ///@return totalGave Amount of inbound_tkn received
+  ///@return totalPenalty Penalty received
+  ///@return feePaid Fee paid
   function marketOrderWithTransferApproval(
     IERC20 outbound_tkn,
     IERC20 inbound_tkn,
@@ -160,7 +160,9 @@ contract MangroveOrder is Forwarder, IOrderLogic {
     }
   }
 
-  //@param tko TakerOrder struct
+  ///@notice take implementation
+  ///@param tko TakerOrder struct
+  ///@return res TakerOrderResult Order result
   function __take__(TakerOrder calldata tko) internal returns (TakerOrderResult memory res) {
     // Checking whether order is expired
     require(tko.expiryDate == 0 || block.timestamp <= tko.expiryDate, "mgvOrder/expired");
@@ -263,18 +265,18 @@ contract MangroveOrder is Forwarder, IOrderLogic {
     return res;
   }
 
-  //@inheritdoc IOrderLogic
-  //@param tko TakerOrder struct
-  //@return TakerOrderResult Result of the take call
+  ///@inheritdoc IOrderLogic
+  ///@param tko TakerOrder struct
+  ///@return TakerOrderResult Result of the take call
   function take(TakerOrder calldata tko) external payable returns (TakerOrderResult memory) {
     return __take__(tko);
   }
 
-  //@notice call permit2 permit and then call take, this can be used to first approve and then take
-  //@param tko TakerOrder struct
-  //@param permit The permit data signed over by the owner
-  //@param signature The signature to verify
-  //@return TakerOrderResult Result of the take call
+  ///@notice call permit2 permit and then call take, this can be used to first approve and then take
+  ///@param tko TakerOrder struct
+  ///@param permit The permit data signed over by the owner
+  ///@param signature The signature to verify
+  ///@return TakerOrderResult Result of the take call
   function takeWithPermit(
     TakerOrder calldata tko,
     IAllowanceTransfer.PermitSingle memory permit,

--- a/src/strategies/offer_forwarder/OfferForwarder.sol
+++ b/src/strategies/offer_forwarder/OfferForwarder.sol
@@ -3,7 +3,8 @@ pragma solidity ^0.8.10;
 
 import {Forwarder, IMangrove, IERC20} from "mgv_src/strategies/offer_forwarder/abstract/Forwarder.sol";
 import {ILiquidityProvider} from "mgv_src/strategies/interfaces/ILiquidityProvider.sol";
-import {SimpleRouter, AbstractRouter} from "mgv_src/strategies/routers/SimpleRouter.sol";
+import {SimpleRouter} from "mgv_src/strategies/routers/SimpleRouter.sol";
+import {AbstractRouter} from "mgv_src/strategies/routers/AbstractRouter.sol";
 import {MgvLib} from "mgv_src/MgvLib.sol";
 
 contract OfferForwarder is ILiquidityProvider, Forwarder {

--- a/src/strategies/routers/AbstractRouter.sol
+++ b/src/strategies/routers/AbstractRouter.sol
@@ -75,49 +75,6 @@ abstract contract AbstractRouter is AccessControlled {
   ///@return pulled The amount pulled if successful; otherwise, 0.
   function __pull__(IERC20 token, address reserveId, uint amount, bool strict) internal virtual returns (uint);
 
-  ///@notice pulls liquidity from the reserve and sends it to the calling maker contract.
-  ///@param token is the ERC20 managing the pulled asset
-  ///@param reserveId identifies the fund owner (router implementation dependent).
-  ///@param amount of `token` the maker contract wishes to pull from its reserve
-  ///@param strict when the calling maker contract accepts to receive more funds from reserve than required (this may happen for gas optimization)
-  ///@param signature signature provided by user
-  ///@return pulled the amount that was successfully pulled.
-  function pull(
-    IERC20 token,
-    address reserveId,
-    uint amount,
-    bool strict,
-    ISignatureTransfer.PermitTransferFrom calldata permit,
-    bytes calldata signature
-  ) external onlyBound returns (uint pulled) {
-    if (strict && amount == 0) {
-      return 0;
-    }
-    pulled = __pull__({
-      token: token,
-      reserveId: reserveId,
-      amount: amount,
-      strict: strict,
-      permit: permit,
-      signature: signature
-    });
-  }
-
-  ///@notice router-dependent implementation of the `pull` function
-  ///@param token Token to be transferred
-  ///@param reserveId determines the location of the reserve (router implementation dependent).
-  ///@param amount The amount of tokens to be transferred
-  ///@param signature signature provided by user
-  ///@return pulled The amount pulled if successful; otherwise, 0.
-  function __pull__(
-    IERC20 token,
-    address reserveId,
-    uint amount,
-    bool strict,
-    ISignatureTransfer.PermitTransferFrom calldata permit,
-    bytes calldata signature
-  ) internal virtual returns (uint);
-
   ///@notice pushes assets from calling's maker contract to a reserve
   ///@param token is the asset the maker is pushing
   ///@param reserveId determines the location of the reserve (router implementation dependent).

--- a/src/strategies/routers/AbstractRouter.sol
+++ b/src/strategies/routers/AbstractRouter.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.10;
 
 import {AccessControlled} from "mgv_src/strategies/utils/AccessControlled.sol";
 import {IERC20} from "mgv_src/MgvLib.sol";
+import {ISignatureTransfer} from "lib/permit2/src/interfaces/ISignatureTransfer.sol";
 
 /// @title AbstractRouter
 /// @notice Partial implementation and requirements for liquidity routers.
@@ -73,6 +74,49 @@ abstract contract AbstractRouter is AccessControlled {
   ///@param strict wether the caller maker contract wishes to pull at most `amount` tokens of owner.
   ///@return pulled The amount pulled if successful; otherwise, 0.
   function __pull__(IERC20 token, address reserveId, uint amount, bool strict) internal virtual returns (uint);
+
+  ///@notice pulls liquidity from the reserve and sends it to the calling maker contract.
+  ///@param token is the ERC20 managing the pulled asset
+  ///@param reserveId identifies the fund owner (router implementation dependent).
+  ///@param amount of `token` the maker contract wishes to pull from its reserve
+  ///@param strict when the calling maker contract accepts to receive more funds from reserve than required (this may happen for gas optimization)
+  ///@param signature signature provided by user
+  ///@return pulled the amount that was successfully pulled.
+  function pull(
+    IERC20 token,
+    address reserveId,
+    uint amount,
+    bool strict,
+    ISignatureTransfer.PermitTransferFrom calldata permit,
+    bytes calldata signature
+  ) external onlyBound returns (uint pulled) {
+    if (strict && amount == 0) {
+      return 0;
+    }
+    pulled = __pull__({
+      token: token,
+      reserveId: reserveId,
+      amount: amount,
+      strict: strict,
+      permit: permit,
+      signature: signature
+    });
+  }
+
+  ///@notice router-dependent implementation of the `pull` function
+  ///@param token Token to be transferred
+  ///@param reserveId determines the location of the reserve (router implementation dependent).
+  ///@param amount The amount of tokens to be transferred
+  ///@param signature signature provided by user
+  ///@return pulled The amount pulled if successful; otherwise, 0.
+  function __pull__(
+    IERC20 token,
+    address reserveId,
+    uint amount,
+    bool strict,
+    ISignatureTransfer.PermitTransferFrom calldata permit,
+    bytes calldata signature
+  ) internal virtual returns (uint);
 
   ///@notice pushes assets from calling's maker contract to a reserve
   ///@param token is the asset the maker is pushing

--- a/src/strategies/routers/Permit2Router.sol
+++ b/src/strategies/routers/Permit2Router.sol
@@ -42,13 +42,34 @@ contract Permit2Router is SimpleRouter {
     bool strict,
     ISignatureTransfer.PermitTransferFrom calldata permit,
     bytes calldata signature
-  ) internal virtual override returns (uint pulled) {
+  ) internal returns (uint pulled) {
     amount = strict ? amount : token.balanceOf(owner);
     if (TransferLib.transferTokenFromWithPermit2Signature(permit2, owner, msg.sender, amount, permit, signature)) {
       return amount;
     } else {
       return 0;
     }
+  }
+
+  ///@notice pulls liquidity from the reserve and sends it to the calling maker contract.
+  ///@param token is the ERC20 managing the pulled asset
+  ///@param reserveId identifies the fund owner (router implementation dependent).
+  ///@param amount of `token` the maker contract wishes to pull from its reserve
+  ///@param strict when the calling maker contract accepts to receive more funds from reserve than required (this may happen for gas optimization)
+  ///@param signature signature provided by user
+  ///@return pulled the amount that was successfully pulled.
+  function pull(
+    IERC20 token,
+    address reserveId,
+    uint amount,
+    bool strict,
+    ISignatureTransfer.PermitTransferFrom calldata permit,
+    bytes calldata signature
+  ) external onlyBound returns (uint pulled) {
+    if (strict && amount == 0) {
+      return 0;
+    }
+    pulled = __pull__(token, reserveId, amount, strict, permit, signature);
   }
 
   ///@notice router-dependent implementation of the `checkList` function

--- a/src/strategies/routers/Permit2Router.sol
+++ b/src/strategies/routers/Permit2Router.sol
@@ -8,7 +8,7 @@ import {ISignatureTransfer} from "lib/permit2/src/interfaces/ISignatureTransfer.
 import {SimpleRouter} from "./SimpleRouter.sol";
 
 contract Permit2Router is SimpleRouter {
-  IPermit2 permit2;
+  IPermit2 public permit2;
 
   constructor(IPermit2 _permit2) SimpleRouter() {
     permit2 = _permit2;

--- a/src/strategies/routers/Permit2Router.sol
+++ b/src/strategies/routers/Permit2Router.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier:	BSD-2-Clause
+pragma solidity ^0.8.10;
+
+import {IERC20} from "mgv_src/MgvLib.sol";
+import {IPermit2} from "lib/permit2/src/interfaces/IPermit2.sol";
+import {TransferLib} from "mgv_src/strategies/utils/TransferLib.sol";
+import {SimpleRouter} from "./SimpleRouter.sol";
+
+contract Permit2Router is SimpleRouter {
+  IPermit2 permit2;
+
+  constructor(IPermit2 _permit2) SimpleRouter() {
+    permit2 = _permit2;
+  }
+
+  function __pull__(IERC20 token, address owner, uint amount, bool strict)
+    internal
+    virtual
+    override
+    returns (uint pulled)
+  {
+    amount = strict ? amount : token.balanceOf(owner);
+    if (TransferLib.transferTokenFromWithPermit2(permit2, token, owner, msg.sender, amount)) {
+      return amount;
+    } else {
+      return 0;
+    }
+  }
+}

--- a/src/strategies/routers/Permit2Router.sol
+++ b/src/strategies/routers/Permit2Router.sol
@@ -7,6 +7,8 @@ import {TransferLib} from "mgv_src/strategies/utils/TransferLib.sol";
 import {ISignatureTransfer} from "lib/permit2/src/interfaces/ISignatureTransfer.sol";
 import {SimpleRouterWithoutGasReq} from "./SimpleRouter.sol";
 
+//@title `Permit2Router` instances pull (push) liquidity directly from (to) the an offer owner's account using permit2 contract
+//@dev Maker contracts using this router must make sure that the reserve approves the permit2 for all asset that will be pulled (outbound tokens), and then the user needs either approve router inside permit2 or he can use just in time signature to authorize transfer
 contract Permit2Router is SimpleRouterWithoutGasReq {
   IPermit2 public permit2;
 

--- a/src/strategies/routers/Permit2Router.sol
+++ b/src/strategies/routers/Permit2Router.sol
@@ -5,12 +5,12 @@ import {IERC20} from "mgv_src/MgvLib.sol";
 import {IPermit2} from "lib/permit2/src/interfaces/IPermit2.sol";
 import {TransferLib} from "mgv_src/strategies/utils/TransferLib.sol";
 import {ISignatureTransfer} from "lib/permit2/src/interfaces/ISignatureTransfer.sol";
-import {SimpleRouter} from "./SimpleRouter.sol";
+import {SimpleRouterWithoutGasReq} from "./SimpleRouter.sol";
 
-contract Permit2Router is SimpleRouter {
+contract Permit2Router is SimpleRouterWithoutGasReq {
   IPermit2 public permit2;
 
-  constructor(IPermit2 _permit2) SimpleRouter() {
+  constructor(IPermit2 _permit2) SimpleRouterWithoutGasReq(74_000) {
     permit2 = _permit2;
   }
 

--- a/src/strategies/routers/Permit2Router.sol
+++ b/src/strategies/routers/Permit2Router.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.10;
 import {IERC20} from "mgv_src/MgvLib.sol";
 import {IPermit2} from "lib/permit2/src/interfaces/IPermit2.sol";
 import {TransferLib} from "mgv_src/strategies/utils/TransferLib.sol";
+import {ISignatureTransfer} from "lib/permit2/src/interfaces/ISignatureTransfer.sol";
 import {SimpleRouter} from "./SimpleRouter.sol";
 
 contract Permit2Router is SimpleRouter {
@@ -25,5 +26,38 @@ contract Permit2Router is SimpleRouter {
     } else {
       return 0;
     }
+  }
+
+  ///@notice router-dependent implementation of the `pull` function
+  ///@param token Token to be transferred
+  ///@param owner determines the location of the reserve (router implementation dependent).
+  ///@param amount The amount of tokens to be transferred
+  ///@param strict wether the caller maker contract wishes to pull at most `amount` tokens of owner.
+  ///@param permit provided by user
+  ///@return pulled The amount pulled if successful; otherwise, 0.
+  function __pull__(
+    IERC20 token,
+    address owner,
+    uint amount,
+    bool strict,
+    ISignatureTransfer.PermitTransferFrom calldata permit,
+    bytes calldata signature
+  ) internal virtual override returns (uint pulled) {
+    amount = strict ? amount : token.balanceOf(owner);
+    if (TransferLib.transferTokenFromWithPermit2Signature(permit2, owner, msg.sender, amount, permit, signature)) {
+      return amount;
+    } else {
+      return 0;
+    }
+  }
+
+  ///@notice router-dependent implementation of the `checkList` function
+  ///@notice verifies all required approval involving `this` router (either as a spender or owner)
+  ///@dev `checkList` returns normally if all needed approval are strictly positive. It reverts otherwise with a reason.
+  ///@param token is the asset whose approval must be checked
+  ///@param owner the account that requires asset pulling/pushing
+  function __checkList__(IERC20 token, address owner) internal view virtual override {
+    // verifying that `this` router can withdraw tokens from owner (required for `withdrawToken` and `pull`)
+    require(token.allowance(owner, address(permit2)) > 0, "SimpleRouter/NotApprovedByOwner");
   }
 }

--- a/src/strategies/routers/SimpleRouter.sol
+++ b/src/strategies/routers/SimpleRouter.sol
@@ -10,7 +10,7 @@ import {ISignatureTransfer} from "lib/permit2/src/interfaces/ISignatureTransfer.
 ///@dev Maker contracts using this router must make sure that the reserve approves the router for all asset that will be pulled (outbound tokens)
 /// Thus a maker contract using a vault that is not an EOA must make sure this vault has approval capacities.
 contract SimpleRouter is
-  AbstractRouter(70_000) // fails for < 70K with Direct strat
+  AbstractRouter(74_000) // fails for < 70K with Direct strat
 {
   /// @notice transfers an amount of tokens from the reserve to the maker.
   /// @param token Token to be transferred

--- a/src/strategies/routers/SimpleRouter.sol
+++ b/src/strategies/routers/SimpleRouter.sol
@@ -11,6 +11,7 @@ import {ISignatureTransfer} from "lib/permit2/src/interfaces/ISignatureTransfer.
 /// Thus a maker contract using a vault that is not an EOA must make sure this vault has approval capacities.
 contract SimpleRouterWithoutGasReq is AbstractRouter {
   constructor(uint gasreq) AbstractRouter(gasreq) {}
+
   /// @notice transfers an amount of tokens from the reserve to the maker.
   /// @param token Token to be transferred
   /// @param owner The account from which the tokens will be transferred.
@@ -18,7 +19,6 @@ contract SimpleRouterWithoutGasReq is AbstractRouter {
   /// @param strict wether the caller maker contract wishes to pull at most `amount` tokens of owner.
   /// @return pulled The amount pulled if successful (will be equal to `amount`); otherwise, 0.
   /// @dev requires approval from `owner` for `this` to transfer `token`.
-
   function __pull__(IERC20 token, address owner, uint amount, bool strict)
     internal
     virtual

--- a/src/strategies/routers/SimpleRouter.sol
+++ b/src/strategies/routers/SimpleRouter.sol
@@ -9,9 +9,8 @@ import {ISignatureTransfer} from "lib/permit2/src/interfaces/ISignatureTransfer.
 ///@title `SimpleRouter` instances pull (push) liquidity directly from (to) the an offer owner's account
 ///@dev Maker contracts using this router must make sure that the reserve approves the router for all asset that will be pulled (outbound tokens)
 /// Thus a maker contract using a vault that is not an EOA must make sure this vault has approval capacities.
-contract SimpleRouter is
-  AbstractRouter(74_000) // fails for < 70K with Direct strat
-{
+contract SimpleRouterWithoutGasReq is AbstractRouter {
+  constructor(uint gasreq) AbstractRouter(gasreq) {}
   /// @notice transfers an amount of tokens from the reserve to the maker.
   /// @param token Token to be transferred
   /// @param owner The account from which the tokens will be transferred.
@@ -19,6 +18,7 @@ contract SimpleRouter is
   /// @param strict wether the caller maker contract wishes to pull at most `amount` tokens of owner.
   /// @return pulled The amount pulled if successful (will be equal to `amount`); otherwise, 0.
   /// @dev requires approval from `owner` for `this` to transfer `token`.
+
   function __pull__(IERC20 token, address owner, uint amount, bool strict)
     internal
     virtual
@@ -55,4 +55,7 @@ contract SimpleRouter is
     // verifying that `this` router can withdraw tokens from owner (required for `withdrawToken` and `pull`)
     require(token.allowance(owner, address(this)) > 0, "SimpleRouter/NotApprovedByOwner");
   }
+}
+
+contract SimpleRouter is SimpleRouterWithoutGasReq(70_000) { // fails for < 70K with Direct strat
 }

--- a/src/strategies/routers/SimpleRouter.sol
+++ b/src/strategies/routers/SimpleRouter.sol
@@ -6,5 +6,10 @@ import {SimpleRouterWithoutGasReq} from "./SimpleRouterWithoutGasReq.sol";
 ///@title `SimpleRouter` instances pull (push) liquidity directly from (to) the an offer owner's account
 ///@dev Maker contracts using this router must make sure that the reserve approves the router for all asset that will be pulled (outbound tokens)
 /// Thus a maker contract using a vault that is not an EOA must make sure this vault has approval capacities.
-contract SimpleRouter is SimpleRouterWithoutGasReq(70_000) { // fails for < 70K with Direct strat
+
+contract SimpleRouter is
+  SimpleRouterWithoutGasReq // fails for < 70K with Direct strat
+{
+  ///@notice SimpleRouter empty constructor
+  constructor() SimpleRouterWithoutGasReq(70_000) {}
 }

--- a/src/strategies/routers/SimpleRouter.sol
+++ b/src/strategies/routers/SimpleRouter.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.10;
 import {IERC20} from "mgv_src/MgvLib.sol";
 import {TransferLib} from "mgv_src/strategies/utils/TransferLib.sol";
 import {AbstractRouter} from "./AbstractRouter.sol";
+import {ISignatureTransfer} from "lib/permit2/src/interfaces/ISignatureTransfer.sol";
 
 ///@title `SimpleRouter` instances pull (push) liquidity directly from (to) the an offer owner's account
 ///@dev Maker contracts using this router must make sure that the reserve approves the router for all asset that will be pulled (outbound tokens)
@@ -31,6 +32,19 @@ contract SimpleRouter is
     } else {
       return 0;
     }
+  }
+
+  ///@notice router-dependent implementation of the `pull` function
+  ///@return pulled The amount pulled if successful; otherwise, 0.
+  function __pull__(
+    IERC20, /*token*/
+    address, /*reserveId*/
+    uint, /*amount*/
+    bool, /*strict*/
+    ISignatureTransfer.PermitTransferFrom calldata, /*permit*/
+    bytes calldata /*signature*/
+  ) internal virtual override returns (uint) {
+    revert("SimpleRouter/DoNotSupportPullWithUArg");
   }
 
   /// @notice transfers an amount of tokens from the maker to the reserve.

--- a/src/strategies/routers/SimpleRouter.sol
+++ b/src/strategies/routers/SimpleRouter.sol
@@ -34,19 +34,6 @@ contract SimpleRouter is
     }
   }
 
-  ///@notice router-dependent implementation of the `pull` function
-  ///@return pulled The amount pulled if successful; otherwise, 0.
-  function __pull__(
-    IERC20, /*token*/
-    address, /*reserveId*/
-    uint, /*amount*/
-    bool, /*strict*/
-    ISignatureTransfer.PermitTransferFrom calldata, /*permit*/
-    bytes calldata /*signature*/
-  ) internal virtual override returns (uint) {
-    revert("SimpleRouter/DoNotSupportPullWithUArg");
-  }
-
   /// @notice transfers an amount of tokens from the maker to the reserve.
   /// @inheritdoc AbstractRouter
   function __push__(IERC20 token, address owner, uint amount) internal virtual override returns (uint) {

--- a/src/strategies/routers/SimpleRouter.sol
+++ b/src/strategies/routers/SimpleRouter.sol
@@ -1,61 +1,10 @@
 // SPDX-License-Identifier:	BSD-2-Clause
 pragma solidity ^0.8.10;
 
-import {IERC20} from "mgv_src/MgvLib.sol";
-import {TransferLib} from "mgv_src/strategies/utils/TransferLib.sol";
-import {AbstractRouter} from "./AbstractRouter.sol";
-import {ISignatureTransfer} from "lib/permit2/src/interfaces/ISignatureTransfer.sol";
+import {SimpleRouterWithoutGasReq} from "./SimpleRouterWithoutGasReq.sol";
 
 ///@title `SimpleRouter` instances pull (push) liquidity directly from (to) the an offer owner's account
 ///@dev Maker contracts using this router must make sure that the reserve approves the router for all asset that will be pulled (outbound tokens)
 /// Thus a maker contract using a vault that is not an EOA must make sure this vault has approval capacities.
-contract SimpleRouterWithoutGasReq is AbstractRouter {
-  constructor(uint gasreq) AbstractRouter(gasreq) {}
-
-  /// @notice transfers an amount of tokens from the reserve to the maker.
-  /// @param token Token to be transferred
-  /// @param owner The account from which the tokens will be transferred.
-  /// @param amount The amount of tokens to be transferred
-  /// @param strict wether the caller maker contract wishes to pull at most `amount` tokens of owner.
-  /// @return pulled The amount pulled if successful (will be equal to `amount`); otherwise, 0.
-  /// @dev requires approval from `owner` for `this` to transfer `token`.
-  function __pull__(IERC20 token, address owner, uint amount, bool strict)
-    internal
-    virtual
-    override
-    returns (uint pulled)
-  {
-    // if not strict, pulling all available tokens from reserve
-    amount = strict ? amount : token.balanceOf(owner);
-    if (TransferLib.transferTokenFrom(token, owner, msg.sender, amount)) {
-      return amount;
-    } else {
-      return 0;
-    }
-  }
-
-  /// @notice transfers an amount of tokens from the maker to the reserve.
-  /// @inheritdoc AbstractRouter
-  function __push__(IERC20 token, address owner, uint amount) internal virtual override returns (uint) {
-    bool success = TransferLib.transferTokenFrom(token, msg.sender, owner, amount);
-    return success ? amount : 0;
-  }
-
-  ///@inheritdoc AbstractRouter
-  function balanceOfReserve(IERC20 token, address owner) public view override returns (uint) {
-    return token.balanceOf(owner);
-  }
-
-  ///@notice router-dependent implementation of the `checkList` function
-  ///@notice verifies all required approval involving `this` router (either as a spender or owner)
-  ///@dev `checkList` returns normally if all needed approval are strictly positive. It reverts otherwise with a reason.
-  ///@param token is the asset whose approval must be checked
-  ///@param owner the account that requires asset pulling/pushing
-  function __checkList__(IERC20 token, address owner) internal view virtual override {
-    // verifying that `this` router can withdraw tokens from owner (required for `withdrawToken` and `pull`)
-    require(token.allowance(owner, address(this)) > 0, "SimpleRouter/NotApprovedByOwner");
-  }
-}
-
 contract SimpleRouter is SimpleRouterWithoutGasReq(70_000) { // fails for < 70K with Direct strat
 }

--- a/src/strategies/routers/SimpleRouterWithoutGasReq.sol
+++ b/src/strategies/routers/SimpleRouterWithoutGasReq.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier:	BSD-2-Clause
+pragma solidity ^0.8.10;
+
+import {IERC20} from "mgv_src/MgvLib.sol";
+import {TransferLib} from "mgv_src/strategies/utils/TransferLib.sol";
+import {AbstractRouter} from "./AbstractRouter.sol";
+import {ISignatureTransfer} from "lib/permit2/src/interfaces/ISignatureTransfer.sol";
+
+///@title `SimpleRouterWithoutGasReq` instances pull (push) liquidity directly from (to) the an offer owner's account
+///@dev Maker contracts using this router must make sure that the reserve approves the router for all asset that will be pulled (outbound tokens)
+/// Thus a maker contract using a vault that is not an EOA must make sure this vault has approval capacities.
+
+contract SimpleRouterWithoutGasReq is AbstractRouter {
+  constructor(uint gasreq) AbstractRouter(gasreq) {}
+
+  /// @notice transfers an amount of tokens from the reserve to the maker.
+  /// @param token Token to be transferred
+  /// @param owner The account from which the tokens will be transferred.
+  /// @param amount The amount of tokens to be transferred
+  /// @param strict wether the caller maker contract wishes to pull at most `amount` tokens of owner.
+  /// @return pulled The amount pulled if successful (will be equal to `amount`); otherwise, 0.
+  /// @dev requires approval from `owner` for `this` to transfer `token`.
+  function __pull__(IERC20 token, address owner, uint amount, bool strict)
+    internal
+    virtual
+    override
+    returns (uint pulled)
+  {
+    // if not strict, pulling all available tokens from reserve
+    amount = strict ? amount : token.balanceOf(owner);
+    if (TransferLib.transferTokenFrom(token, owner, msg.sender, amount)) {
+      return amount;
+    } else {
+      return 0;
+    }
+  }
+
+  /// @notice transfers an amount of tokens from the maker to the reserve.
+  /// @inheritdoc AbstractRouter
+  function __push__(IERC20 token, address owner, uint amount) internal virtual override returns (uint) {
+    bool success = TransferLib.transferTokenFrom(token, msg.sender, owner, amount);
+    return success ? amount : 0;
+  }
+
+  ///@inheritdoc AbstractRouter
+  function balanceOfReserve(IERC20 token, address owner) public view override returns (uint) {
+    return token.balanceOf(owner);
+  }
+
+  ///@notice router-dependent implementation of the `checkList` function
+  ///@notice verifies all required approval involving `this` router (either as a spender or owner)
+  ///@dev `checkList` returns normally if all needed approval are strictly positive. It reverts otherwise with a reason.
+  ///@param token is the asset whose approval must be checked
+  ///@param owner the account that requires asset pulling/pushing
+  function __checkList__(IERC20 token, address owner) internal view virtual override {
+    // verifying that `this` router can withdraw tokens from owner (required for `withdrawToken` and `pull`)
+    require(token.allowance(owner, address(this)) > 0, "SimpleRouter/NotApprovedByOwner");
+  }
+}

--- a/src/strategies/routers/SimpleRouterWithoutGasReq.sol
+++ b/src/strategies/routers/SimpleRouterWithoutGasReq.sol
@@ -11,6 +11,8 @@ import {ISignatureTransfer} from "lib/permit2/src/interfaces/ISignatureTransfer.
 /// Thus a maker contract using a vault that is not an EOA must make sure this vault has approval capacities.
 
 contract SimpleRouterWithoutGasReq is AbstractRouter {
+  ///@notice SimpleRouterWithoutGasReq constructor
+  ///@param gasreq Estimated gas req for router
   constructor(uint gasreq) AbstractRouter(gasreq) {}
 
   /// @notice transfers an amount of tokens from the reserve to the maker.

--- a/src/strategies/routers/integrations/AavePooledRouter.sol
+++ b/src/strategies/routers/integrations/AavePooledRouter.sol
@@ -5,6 +5,7 @@ import {AbstractRouter} from "../AbstractRouter.sol";
 import {TransferLib} from "mgv_src/strategies/utils/TransferLib.sol";
 import {HasAaveBalanceMemoizer} from "./HasAaveBalanceMemoizer.sol";
 import {IERC20} from "mgv_src/IERC20.sol";
+import {ISignatureTransfer} from "lib/permit2/src/interfaces/ISignatureTransfer.sol";
 
 ///@title Router acting as a liquidity reserve on AAVE for multiple depositors (possibly coming from different maker contracts).
 ///@notice maker contracts deposit/withdraw their user(s) fund(s) on this router, which maintains an accounting of shares attributed to each depositor
@@ -252,6 +253,19 @@ contract AavePooledRouter is HasAaveBalanceMemoizer, AbstractRouter {
     }
     redeemAndTransfer(token, reserveId, amount_, toRedeem, memoizer);
     return amount_;
+  }
+
+  ///@notice router-dependent implementation of the `pull` function
+  ///@return pulled The amount pulled if successful; otherwise, 0.
+  function __pull__(
+    IERC20, /*token*/
+    address, /*reserveId*/
+    uint, /*amount*/
+    bool, /*strict*/
+    ISignatureTransfer.PermitTransferFrom calldata, /*permit*/
+    bytes calldata /*signature*/
+  ) internal virtual override returns (uint) {
+    revert("AavePooledRouter/DoNotSupportPullWithUArg");
   }
 
   ///@notice redeems some funds from AAVE pool and transfer some amount to msg.sender.

--- a/src/strategies/routers/integrations/AavePooledRouter.sol
+++ b/src/strategies/routers/integrations/AavePooledRouter.sol
@@ -255,19 +255,6 @@ contract AavePooledRouter is HasAaveBalanceMemoizer, AbstractRouter {
     return amount_;
   }
 
-  ///@notice router-dependent implementation of the `pull` function
-  ///@return pulled The amount pulled if successful; otherwise, 0.
-  function __pull__(
-    IERC20, /*token*/
-    address, /*reserveId*/
-    uint, /*amount*/
-    bool, /*strict*/
-    ISignatureTransfer.PermitTransferFrom calldata, /*permit*/
-    bytes calldata /*signature*/
-  ) internal virtual override returns (uint) {
-    revert("AavePooledRouter/DoNotSupportPullWithUArg");
-  }
-
   ///@notice redeems some funds from AAVE pool and transfer some amount to msg.sender.
   ///@param token the asset to transfer
   ///@param reserveId the shares on which funds are being drawn

--- a/src/strategies/routers/integrations/AavePooledRouter.sol
+++ b/src/strategies/routers/integrations/AavePooledRouter.sol
@@ -5,7 +5,6 @@ import {AbstractRouter} from "../AbstractRouter.sol";
 import {TransferLib} from "mgv_src/strategies/utils/TransferLib.sol";
 import {HasAaveBalanceMemoizer} from "./HasAaveBalanceMemoizer.sol";
 import {IERC20} from "mgv_src/IERC20.sol";
-import {ISignatureTransfer} from "lib/permit2/src/interfaces/ISignatureTransfer.sol";
 
 ///@title Router acting as a liquidity reserve on AAVE for multiple depositors (possibly coming from different maker contracts).
 ///@notice maker contracts deposit/withdraw their user(s) fund(s) on this router, which maintains an accounting of shares attributed to each depositor

--- a/src/strategies/utils/TransferLib.sol
+++ b/src/strategies/utils/TransferLib.sol
@@ -60,6 +60,7 @@ library TransferLib {
   }
 
   ///@notice This transfer amount of token to recipient address from spender address
+  ///@param permit2 Permit2 contract
   ///@param token Token to be transferred
   ///@param spender Address of the spender, where the tokens will be transferred from
   ///@param recipient Address of the recipient, where the tokens will be transferred to
@@ -93,6 +94,8 @@ library TransferLib {
   ///@param spender Address of the spender, where the tokens will be transferred from
   ///@param recipient Address of the recipient, where the tokens will be transferred to
   ///@param amount The amount of tokens to be transferred spender, where the tokens will be transferred from
+  ///@param permit The permit data signed over by the owner
+  ///@param signature The signature to verify
   ///@return true if transfer was successful; otherwise, false.
   function transferTokenFromWithPermit2Signature(
     IPermit2 permit2,

--- a/src/strategies/utils/TransferLib.sol
+++ b/src/strategies/utils/TransferLib.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.10;
 
 import {IERC20} from "mgv_src/MgvLib.sol";
+import {IPermit2} from "lib/permit2/src/interfaces/IPermit2.sol";
 
 ///@title This library helps with safely interacting with ERC20 tokens
 ///@notice Transferring 0 or to self will be skipped.
@@ -55,6 +56,35 @@ library TransferLib {
       return _transferToken(token, recipient, amount);
     }
     return _transferTokenFrom(token, spender, recipient, amount);
+  }
+
+  ///@notice This transfer amount of token to recipient address from spender address
+  ///@param token Token to be transferred
+  ///@param spender Address of the spender, where the tokens will be transferred from
+  ///@param recipient Address of the recipient, where the tokens will be transferred to
+  ///@param amount The amount of tokens to be transferred
+  ///@return true if transfer was successful; otherwise, false.
+  function transferTokenFromWithPermit2(IPermit2 permit2, IERC20 token, address spender, address recipient, uint amount)
+    internal
+    returns (bool)
+  {
+    if (amount == 0) {
+      return true;
+    }
+    if (spender == recipient) {
+      return token.balanceOf(spender) >= amount;
+    }
+
+    (bool success,) = address(permit2).call(
+      abi.encodeWithSignature(
+        "transferFrom(address,address,uint160,address)",
+        address(spender),
+        address(recipient),
+        uint160(amount),
+        address(token)
+      )
+    );
+    return success;
   }
 
   ///@notice This transfer amount of token to recipient address from spender address

--- a/src/strategies/utils/TransferLib.sol
+++ b/src/strategies/utils/TransferLib.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.10;
 
 import {IERC20} from "mgv_src/MgvLib.sol";
 import {IPermit2} from "lib/permit2/src/interfaces/IPermit2.sol";
+import {ISignatureTransfer} from "lib/permit2/src/interfaces/ISignatureTransfer.sol";
 
 ///@title This library helps with safely interacting with ERC20 tokens
 ///@notice Transferring 0 or to self will be skipped.
@@ -82,6 +83,39 @@ library TransferLib {
         address(recipient),
         uint160(amount),
         address(token)
+      )
+    );
+    return success;
+  }
+
+  ///@notice This transfer amount of token to recipient address from spender address
+  ///@param permit2 Permit2 contract
+  ///@param spender Address of the spender, where the tokens will be transferred from
+  ///@param recipient Address of the recipient, where the tokens will be transferred to
+  ///@param amount The amount of tokens to be transferred spender, where the tokens will be transferred from
+  ///@return true if transfer was successful; otherwise, false.
+  function transferTokenFromWithPermit2Signature(
+    IPermit2 permit2,
+    address spender,
+    address recipient,
+    uint amount,
+    ISignatureTransfer.PermitTransferFrom calldata permit,
+    bytes calldata signature
+  ) internal returns (bool) {
+    if (amount == 0) {
+      return true;
+    }
+    if (spender == recipient) {
+      return IERC20(permit.permitted.token).balanceOf(spender) >= amount;
+    }
+
+    (bool success,) = address(permit2).call(
+      abi.encodeWithSignature(
+        "permitTransferFrom(((address,uint256),uint256,uint256),(address,uint256),address,bytes)",
+        permit,
+        ISignatureTransfer.SignatureTransferDetails({to: recipient, requestedAmount: amount}),
+        spender,
+        signature
       )
     );
     return success;

--- a/test/lib/permit2/permit2Helpers.sol
+++ b/test/lib/permit2/permit2Helpers.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier:	AGPL-3.0
+pragma solidity ^0.8.10;
+
+import "forge-std/Test.sol";
+import {ISignatureTransfer} from "lib/permit2/src/interfaces/ISignatureTransfer.sol";
+import {IAllowanceTransfer} from "lib/permit2/src/interfaces/IAllowanceTransfer.sol";
+import {PermitSignature} from "lib/permit2/test/utils/PermitSignature.sol";
+
+contract Permit2Helpers is Test, PermitSignature {
+  function getPermitTransferSignatureWithSpecifiedAddress(
+    ISignatureTransfer.PermitTransferFrom memory permit,
+    uint privateKey,
+    bytes32 domainSeparator,
+    address addr
+  ) internal pure returns (bytes memory sig) {
+    bytes32 tokenPermissions = keccak256(abi.encode(_TOKEN_PERMISSIONS_TYPEHASH, permit.permitted));
+    bytes32 msgHash = keccak256(
+      abi.encodePacked(
+        "\x19\x01",
+        domainSeparator,
+        keccak256(abi.encode(_PERMIT_TRANSFER_FROM_TYPEHASH, tokenPermissions, addr, permit.nonce, permit.deadline))
+      )
+    );
+
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, msgHash);
+    return bytes.concat(r, s, bytes1(v));
+  }
+
+  function getPermitTransferFrom(address token, uint amount, uint nonce, uint deadline)
+    internal
+    pure
+    returns (ISignatureTransfer.PermitTransferFrom memory)
+  {
+    return ISignatureTransfer.PermitTransferFrom({
+      permitted: ISignatureTransfer.TokenPermissions({token: token, amount: amount}),
+      nonce: nonce,
+      deadline: deadline
+    });
+  }
+
+  function getPermit(address token, uint160 amount, uint48 expiration, uint48 nonce, address spender)
+    internal
+    pure
+    returns (IAllowanceTransfer.PermitSingle memory)
+  {
+    IAllowanceTransfer.PermitDetails memory permitDetails =
+      IAllowanceTransfer.PermitDetails({token: address(token), amount: amount, expiration: expiration, nonce: nonce});
+    IAllowanceTransfer.PermitSingle memory permit =
+      IAllowanceTransfer.PermitSingle({details: permitDetails, spender: address(spender), sigDeadline: expiration});
+
+    return permit;
+  }
+}

--- a/test/script/core/deployers/PolygonMangroveDeployer.t.sol
+++ b/test/script/core/deployers/PolygonMangroveDeployer.t.sol
@@ -14,9 +14,14 @@ import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
 import {MgvCleaner} from "mgv_src/periphery/MgvCleaner.sol";
 import {MgvOracle} from "mgv_src/periphery/MgvOracle.sol";
 import {IMangrove} from "mgv_src/IMangrove.sol";
+import {DeployPermit2} from "permit2/test/utils/DeployPermit2.sol";
 
 contract PolygonMangroveDeployerTest is BaseMangroveDeployerTest {
   function setUp() public {
+    DeployPermit2 deployPermit2 = new DeployPermit2();
+    address permit2 = deployPermit2.deployPermit2();
+    fork.set("Permit2", permit2);
+
     chief = freshAddress("MgvGovernance");
     fork.set("MgvGovernance", chief);
     gasbot = freshAddress("Gasbot");

--- a/test/script/strategies/mangroveOrder/deployers/BaseMangroveOrderDeployer.t.sol
+++ b/test/script/strategies/mangroveOrder/deployers/BaseMangroveOrderDeployer.t.sol
@@ -5,6 +5,7 @@ import {Deployer} from "mgv_script/lib/Deployer.sol";
 import {MangroveDeployer} from "mgv_script/core/deployers/MangroveDeployer.s.sol";
 
 import {Test2, Test} from "mgv_lib/Test2.sol";
+import {IPermit2} from "permit2/src/interfaces/IPermit2.sol";
 
 import {MgvStructs} from "mgv_src/MgvLib.sol";
 import {Mangrove} from "mgv_src/Mangrove.sol";
@@ -28,7 +29,8 @@ abstract contract BaseMangroveOrderDeployerTest is Deployer, Test2 {
   function test_normal_deploy() public {
     // MangroveOrder - verify mgv is used and admin is chief
     address mgv = fork.get("Mangrove");
-    mgoDeployer.innerRun(IMangrove(payable(mgv)), chief);
+    address permit2 = fork.get("Permit2");
+    mgoDeployer.innerRun(IMangrove(payable(mgv)), IPermit2(permit2), chief);
     MangroveOrder mgoe = MangroveOrder(fork.get("MangroveOrder"));
     address mgvOrderRouter = fork.get("MangroveOrder-Router");
 

--- a/test/script/strategies/mangroveOrder/deployers/BaseMangroveOrderDeployer.t.sol
+++ b/test/script/strategies/mangroveOrder/deployers/BaseMangroveOrderDeployer.t.sol
@@ -19,6 +19,9 @@ import {
   MangroveOrder
 } from "mgv_script/strategies/mangroveOrder/deployers/MangroveOrderDeployer.s.sol";
 
+import {IPermit2} from "permit2/src/interfaces/IPermit2.sol";
+import {DeployPermit2} from "permit2/test/utils/DeployPermit2.sol";
+
 /**
  * Base test suite for [Chain]MangroveOrderDeployer scripts
  */
@@ -29,7 +32,7 @@ abstract contract BaseMangroveOrderDeployerTest is Deployer, Test2 {
   function test_normal_deploy() public {
     // MangroveOrder - verify mgv is used and admin is chief
     address mgv = fork.get("Mangrove");
-    address permit2 = fork.get("Permit2");
+    IPermit2 permit2 = IPermit2(fork.get("Permit2"));
     mgoDeployer.innerRun(IMangrove(payable(mgv)), IPermit2(permit2), chief);
     MangroveOrder mgoe = MangroveOrder(fork.get("MangroveOrder"));
     address mgvOrderRouter = fork.get("MangroveOrder-Router");

--- a/test/script/strategies/mangroveOrder/deployers/MangroveOrderDeployer.t.sol
+++ b/test/script/strategies/mangroveOrder/deployers/MangroveOrderDeployer.t.sol
@@ -19,9 +19,14 @@ import {MgvCleaner} from "mgv_src/periphery/MgvCleaner.sol";
 import {MgvOracle} from "mgv_src/periphery/MgvOracle.sol";
 import {IMangrove} from "mgv_src/IMangrove.sol";
 import {AbstractRouter} from "mgv_src/strategies/routers/AbstractRouter.sol";
+import {DeployPermit2} from "permit2/test/utils/DeployPermit2.sol";
 
 contract MangroveOrderDeployerTest is BaseMangroveOrderDeployerTest {
   function setUp() public {
+    DeployPermit2 deployPermit2 = new DeployPermit2();
+    address permit2 = deployPermit2.deployPermit2();
+    fork.set("Permit2", permit2);
+
     chief = freshAddress("admin");
 
     address gasbot = freshAddress("gasbot");

--- a/test/script/strategies/mangroveOrder/deployers/PolygonMangroveOrderDeployer.t.sol
+++ b/test/script/strategies/mangroveOrder/deployers/PolygonMangroveOrderDeployer.t.sol
@@ -19,9 +19,14 @@ import {
   PolygonMangroveOrderDeployer,
   MangroveOrder
 } from "mgv_script/strategies/mangroveOrder/deployers/PolygonMangroveOrderDeployer.s.sol";
+import {DeployPermit2} from "permit2/test/utils/DeployPermit2.sol";
 
 contract PolygonMangroveOrderDeployerTest is BaseMangroveOrderDeployerTest {
   function setUp() public {
+    DeployPermit2 deployPermit2 = new DeployPermit2();
+    address permit2 = deployPermit2.deployPermit2();
+    fork.set("Permit2", permit2);
+
     chief = freshAddress("chief");
     fork.set("MgvGovernance", chief);
 

--- a/test/strategies/unit/AavePooledRouter.t.sol
+++ b/test/strategies/unit/AavePooledRouter.t.sol
@@ -574,7 +574,7 @@ contract AavePooledRouterTest is OfferLogicTest {
     deal($(dai), maker2, 1 * 10 ** 18);
     args.allowed = dynamic([address(maker1), maker2]);
     checkAuth(args, abi.encodeCall(pooledRouter.push, (dai, maker1, 1000)));
-    checkAuth(args, abi.encodeWithSignature("__pull__(IERC20,address,uint,bool)", dai, maker1, 100, true));
+    checkAuth(args, abi.encodeCall(pooledRouter.pull, (dai, maker1, 100, true)));
     checkAuth(args, abi.encodeCall(pooledRouter.flush, (new IERC20[](0), owner)));
     checkAuth(args, abi.encodeCall(pooledRouter.pushAndSupply, (dai, 0, dai, 0, owner)));
     checkAuth(args, abi.encodeCall(pooledRouter.withdraw, (dai, maker1, 100)));

--- a/test/strategies/unit/AavePooledRouter.t.sol
+++ b/test/strategies/unit/AavePooledRouter.t.sol
@@ -574,7 +574,7 @@ contract AavePooledRouterTest is OfferLogicTest {
     deal($(dai), maker2, 1 * 10 ** 18);
     args.allowed = dynamic([address(maker1), maker2]);
     checkAuth(args, abi.encodeCall(pooledRouter.push, (dai, maker1, 1000)));
-    checkAuth(args, abi.encodeCall(pooledRouter.pull, (dai, maker1, 100, true)));
+    checkAuth(args, abi.encodeWithSignature("__pull__(IERC20,address,uint,bool)", dai, maker1, 100, true));
     checkAuth(args, abi.encodeCall(pooledRouter.flush, (new IERC20[](0), owner)));
     checkAuth(args, abi.encodeCall(pooledRouter.pushAndSupply, (dai, 0, dai, 0, owner)));
     checkAuth(args, abi.encodeCall(pooledRouter.withdraw, (dai, maker1, 100)));

--- a/test/strategies/unit/MangroveOffer.t.sol
+++ b/test/strategies/unit/MangroveOffer.t.sol
@@ -3,7 +3,8 @@ pragma solidity ^0.8.10;
 
 import "mgv_test/lib/MangroveTest.sol";
 import {DirectTester, IMangrove, IERC20} from "mgv_src/strategies/offer_maker/DirectTester.sol";
-import {SimpleRouter, AbstractRouter} from "mgv_src/strategies/routers/SimpleRouter.sol";
+import {SimpleRouter} from "mgv_src/strategies/routers/SimpleRouter.sol";
+import {AbstractRouter} from "mgv_src/strategies/routers/AbstractRouter.sol";
 
 contract MangroveOfferTest is MangroveTest {
   TestToken weth;

--- a/test/strategies/unit/routers/Permit2Router.t.sol
+++ b/test/strategies/unit/routers/Permit2Router.t.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier:	AGPL-3.0
+pragma solidity ^0.8.10;
+
+import "../OfferLogic.t.sol";
+import "mgv_src/strategies/routers/Permit2Router.sol";
+import {IPermit2} from "lib/permit2/src/interfaces/IPermit2.sol";
+import {DeployPermit2} from "permit2/test/utils/DeployPermit2.sol";
+
+contract Permit2RouterTest is OfferLogicTest, DeployPermit2 {
+  Permit2Router router;
+
+  IPermit2 permit2;
+
+  function setupLiquidityRouting() internal override {
+    // OfferMaker has no router, replacing 0x router by a Permit2Router
+    permit2 = IPermit2(deployPermit2());
+    router = new Permit2Router(permit2);
+    router.bind(address(makerContract));
+    // maker must approve router
+    vm.prank(deployer);
+    makerContract.setRouter(router);
+
+    vm.startPrank(owner);
+    weth.approve(address(permit2), type(uint).max);
+    usdc.approve(address(permit2), type(uint).max);
+    permit2.approve(address(weth), address(router), type(uint160).max, type(uint48).max);
+    permit2.approve(address(usdc), address(router), type(uint160).max, type(uint48).max);
+    vm.stopPrank();
+  }
+
+  function fundStrat() internal virtual override {
+    deal($(weth), owner, 1 ether);
+    deal($(usdc), owner, cash(usdc, 2000));
+  }
+
+  event MakerBind(address indexed maker);
+  event MakerUnbind(address indexed maker);
+
+  function test_admin_can_unbind() public {
+    expectFrom(address(router));
+    emit MakerUnbind(address(makerContract));
+    router.unbind(address(makerContract));
+  }
+
+  function test_maker_can_unbind() public {
+    expectFrom(address(router));
+    emit MakerUnbind(address(makerContract));
+    vm.prank(address(makerContract));
+    router.unbind();
+  }
+}

--- a/test/strategies/unit/routers/Permit2Router.t.sol
+++ b/test/strategies/unit/routers/Permit2Router.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.10;
 
 import "../OfferLogic.t.sol";
-import "mgv_src/strategies/routers/Permit2Router.sol";
+import {Permit2Router} from "mgv_src/strategies/routers/Permit2Router.sol";
 import {IPermit2} from "lib/permit2/src/interfaces/IPermit2.sol";
 import {DeployPermit2} from "permit2/test/utils/DeployPermit2.sol";
 

--- a/test/strategies/unit/routers/Permit2RouterSignature.t.sol
+++ b/test/strategies/unit/routers/Permit2RouterSignature.t.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier:	AGPL-3.0
+pragma solidity ^0.8.10;
+
+import {TestToken} from "mgv_test/lib/tokens/TestToken.sol";
+import {MangroveTest} from "mgv_test/lib/MangroveTest.sol";
+import {Permit2Router} from "mgv_src/strategies/routers/Permit2Router.sol";
+import {ISignatureTransfer} from "lib/permit2/src/interfaces/ISignatureTransfer.sol";
+import {IPermit2} from "lib/permit2/src/interfaces/IPermit2.sol";
+import {PermitSignature} from "lib/permit2/test/utils/PermitSignature.sol";
+import {DeployPermit2} from "permit2/test/utils/DeployPermit2.sol";
+
+contract Permit2RouterSignatureTest is MangroveTest, DeployPermit2, PermitSignature {
+  address owner;
+  uint ownerPrivateKey;
+  TestToken weth;
+  TestToken usdc;
+  uint NONCE = 0;
+
+  bytes32 DOMAIN_SEPARATOR;
+  uint48 EXPIRATION;
+  uint AMOUNT = 25;
+
+  Permit2Router router;
+  IPermit2 permit2;
+
+  function setUp() public virtual override {
+    super.setUp();
+    ownerPrivateKey = 0x12341234;
+    owner = vm.addr(ownerPrivateKey);
+
+    weth = new TestToken(owner, "WETH", "WETH", 18);
+    usdc = new TestToken(owner, "USDC", "USDC", 18);
+    permit2 = IPermit2(deployPermit2());
+    DOMAIN_SEPARATOR = permit2.DOMAIN_SEPARATOR();
+
+    router = new Permit2Router(permit2);
+
+    EXPIRATION = uint48(block.timestamp + 1000);
+
+    router.bind(address(this));
+
+    deal($(weth), owner, cash(weth, 50));
+
+    vm.startPrank(owner);
+    weth.approve(address(permit2), type(uint).max);
+    usdc.approve(address(permit2), type(uint).max);
+    permit2.approve(address(weth), address(router), type(uint160).max, type(uint48).max);
+    permit2.approve(address(usdc), address(router), type(uint160).max, type(uint48).max);
+    vm.stopPrank();
+  }
+
+  function getPermitTransferSignatureWithSpecifiedAddress(
+    ISignatureTransfer.PermitTransferFrom memory permit,
+    uint privateKey,
+    bytes32 domainSeparator,
+    address addr
+  ) internal pure returns (bytes memory sig) {
+    bytes32 tokenPermissions = keccak256(abi.encode(_TOKEN_PERMISSIONS_TYPEHASH, permit.permitted));
+    bytes32 msgHash = keccak256(
+      abi.encodePacked(
+        "\x19\x01",
+        domainSeparator,
+        keccak256(abi.encode(_PERMIT_TRANSFER_FROM_TYPEHASH, tokenPermissions, addr, permit.nonce, permit.deadline))
+      )
+    );
+
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, msgHash);
+    return bytes.concat(r, s, bytes1(v));
+  }
+
+  function test_pull_with_permit() public {
+    ISignatureTransfer.PermitTransferFrom memory permit = defaultERC20PermitTransfer(address(weth), NONCE);
+    bytes memory sig =
+      getPermitTransferSignatureWithSpecifiedAddress(permit, ownerPrivateKey, DOMAIN_SEPARATOR, address(router));
+
+    uint startBalanceFrom = weth.balanceOf(owner);
+    uint startBalanceTo = weth.balanceOf(address(this));
+
+    router.pull(weth, owner, AMOUNT, true, permit, sig);
+
+    assertEq(weth.balanceOf(owner), startBalanceFrom - AMOUNT);
+    assertEq(weth.balanceOf(address(this)), startBalanceTo + AMOUNT);
+  }
+}


### PR DESCRIPTION
In this pull request (PR), I integrated the [Permit2](https://github.com/Uniswap/permit2) contract from Uniswap into our `MangroveOrder` contract. To achieve this, I created a new contract called `Permit2Router`, which inherits from the `SimpleRouter` implementation. The primary change is in the `pull` function. Within the `pull` function, I utilized `Permit2` to facilitate fund transfers using the Permit2 contract. To enable this functionality, users' EOAs must call the `approve` function on the Permit2 contract to grant permission to the `Permit2Router` to withdraw funds on their behalf. Additionally, users have the option to generate an off-chain Transfer signature that authorizes the contract specified in the signature to perform a one-time fund withdrawal from their EOA instead of calling `approve.`

The new use cases of `MangroveOrder` are as follows:

1. `MarketOrder`: This type of order utilizes the `marketOrderWithTransferApproval` function. In this scenario, the `MangroveOrder` contract pulls the specified amount of `inbound_tkn` from the `msg.sender` using just-in-time one-time approval. Subsequently, it executes a market order and returns any unused funds back to the user.

2. `LimitOrder` with `takeWithPermit`: When using this function, a user initiates an off-chain permit signature, which is sent to the Permit2 contract to authorize the `MangroveOrder` router to withdraw funds from the Permit2 contract. After this, the function call `take` and initiate a limit order.

3. `LimitOrder` with `take`: Similar to the previous case, the user calls `permit` or `approve` to the Permit2 contract beforehand. After this, they can do a `LimitOrder` by calling `take`.

These modifications expand the functionalities of `MangroveOrder` to permit the users to approve once by token by chain the permit2 contract, instead of approving once by token by contract that needs to pull the funds.