### PR TITLE
Feat/ticks snipes

### DIFF
--- a/src/IMangrove.sol
+++ b/src/IMangrove.sol
@@ -203,29 +203,13 @@ interface IMangrove {
 
   function setUseOracle(bool useOracle) external;
 
-  function snipesByVolume(address outbound_tkn, address inbound_tkn, uint[4][] memory targets, bool fillWants)
+  function snipes(address outbound_tkn, address inbound_tkn, uint[4][] memory targets, bool fillWants)
     external
     returns (uint successes, uint takerGot, uint takerGave, uint bounty, uint fee);
 
-  function snipesByTick(address outbound_tkn, address inbound_tkn, uint[4][] memory targets, bool fillWants)
+  function snipesFor(address outbound_tkn, address inbound_tkn, uint[4][] memory targets, bool fillWants, address taker)
     external
     returns (uint successes, uint takerGot, uint takerGave, uint bounty, uint fee);
-
-  function snipesForByTick(
-    address outbound_tkn,
-    address inbound_tkn,
-    uint[4][] memory targets,
-    bool fillWants,
-    address taker
-  ) external returns (uint successes, uint takerGot, uint takerGave, uint bounty, uint fee);
-
-  function snipesForByVolume(
-    address outbound_tkn,
-    address inbound_tkn,
-    uint[4][] memory targets,
-    bool fillWants,
-    address taker
-  ) external returns (uint successes, uint takerGot, uint takerGave, uint bounty, uint fee);
 
   function updateOffer(
     address outbound_tkn,

--- a/src/IMangrove.sol
+++ b/src/IMangrove.sol
@@ -203,13 +203,29 @@ interface IMangrove {
 
   function setUseOracle(bool useOracle) external;
 
-  function snipes(address outbound_tkn, address inbound_tkn, uint[4][] memory targets, bool fillWants)
+  function snipesByVolume(address outbound_tkn, address inbound_tkn, uint[4][] memory targets, bool fillWants)
     external
     returns (uint successes, uint takerGot, uint takerGave, uint bounty, uint fee);
 
-  function snipesFor(address outbound_tkn, address inbound_tkn, uint[4][] memory targets, bool fillWants, address taker)
+  function snipesByTick(address outbound_tkn, address inbound_tkn, uint[4][] memory targets, bool fillWants)
     external
     returns (uint successes, uint takerGot, uint takerGave, uint bounty, uint fee);
+
+  function snipesForByTick(
+    address outbound_tkn,
+    address inbound_tkn,
+    uint[4][] memory targets,
+    bool fillWants,
+    address taker
+  ) external returns (uint successes, uint takerGot, uint takerGave, uint bounty, uint fee);
+
+  function snipesForByVolume(
+    address outbound_tkn,
+    address inbound_tkn,
+    uint[4][] memory targets,
+    bool fillWants,
+    address taker
+  ) external returns (uint successes, uint takerGot, uint takerGave, uint bounty, uint fee);
 
   function updateOffer(
     address outbound_tkn,

--- a/src/MgvHelpers.sol
+++ b/src/MgvHelpers.sol
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: Unlicense
 
-/* `MgvLib` contains data structures returned by external calls to Mangrove and the interfaces it uses for its own external calls. */
-
 pragma solidity ^0.8.10;
 
 import {IMangrove} from "mgv_src/IMangrove.sol";
 import "mgv_lib/TickLib.sol";
 
 library MgvHelpers {
-  // Converts snipe targets from volume-based [id,wants,gives,gasreq] tick-based [id,tick,volume,gasreq]. volume will be wants if fillWsants is true, volume will be gives otherwise.
+  // Converts snipe targets from volume-based [id,wants,gives,gasreq] tick-based [id,tick,volume,gasreq]. volume will be wants if fillWsants is true, volume will be gives otherwise. Note that `tick` is fundamentally an int but arrays are homogenous so must be typed as a uint in the call.
   function convertSnipeTargetsToTicks(uint[4][] memory targets, bool fillWants)
     internal
     pure

--- a/src/MgvHelpers.sol
+++ b/src/MgvHelpers.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Unlicense
+
+/* `MgvLib` contains data structures returned by external calls to Mangrove and the interfaces it uses for its own external calls. */
+
+pragma solidity ^0.8.10;
+
+import {IMangrove} from "mgv_src/IMangrove.sol";
+import "mgv_lib/TickLib.sol";
+
+library MgvHelpers {
+  // Converts snipe targets from volume-based [id,wants,gives,gasreq] tick-based [id,tick,volume,gasreq]. volume will be wants if fillWsants is true, volume will be gives otherwise.
+  function convertSnipeTargetsToTicks(uint[4][] memory targets, bool fillWants)
+    internal
+    pure
+    returns (uint[4][] memory)
+  {
+    uint[4][] memory newTargets = new uint[4][](targets.length);
+    // convert targets from [id,wants,gives,gasreq] to [id,tick,volume,gasreq]
+    uint volumeIndex = fillWants ? 1 : 2;
+    for (uint i = 0; i < targets.length; i++) {
+      newTargets[i][0] = targets[i][0];
+      newTargets[i][1] = uint(Tick.unwrap(TickLib.tickFromTakerVolumes(targets[i][2], targets[i][1])));
+      newTargets[i][2] = targets[i][volumeIndex];
+      newTargets[i][3] = targets[i][3];
+    }
+    return newTargets;
+  }
+
+  function snipesForByVolume(
+    address mgv,
+    address outbound_tkn,
+    address inbound_tkn,
+    uint[4][] memory targets,
+    bool fillWants,
+    address taker
+  ) internal returns (uint, uint, uint, uint, uint) {
+    uint[4][] memory newTargets = convertSnipeTargetsToTicks(targets, fillWants);
+    return IMangrove(payable(mgv)).snipesFor(outbound_tkn, inbound_tkn, newTargets, fillWants, taker);
+  }
+
+  function snipesByVolume(
+    address mgv,
+    address outbound_tkn,
+    address inbound_tkn,
+    uint[4][] calldata targets,
+    bool fillWants
+  ) external returns (uint, uint, uint, uint, uint) {
+    unchecked {
+      uint[4][] memory newTargets = convertSnipeTargetsToTicks(targets, fillWants);
+      return IMangrove(payable(mgv)).snipes(outbound_tkn, inbound_tkn, newTargets, fillWants);
+    }
+  }
+}

--- a/src/MgvOfferMaking.sol
+++ b/src/MgvOfferMaking.sol
@@ -69,9 +69,6 @@ contract MgvOfferMaking is MgvHasOffers {
 
       ofp.outbound_tkn = outbound_tkn;
       ofp.inbound_tkn = inbound_tkn;
-      console.log("offer id", ofp.id);
-      console.log("newOffer:");
-      console.log("gives", gives);
       ofp.wants = wants;
       ofp.gives = gives;
       ofp.gasreq = gasreq;

--- a/src/MgvOfferMaking.sol
+++ b/src/MgvOfferMaking.sol
@@ -69,6 +69,9 @@ contract MgvOfferMaking is MgvHasOffers {
 
       ofp.outbound_tkn = outbound_tkn;
       ofp.inbound_tkn = inbound_tkn;
+      console.log("offer id", ofp.id);
+      console.log("newOffer:");
+      console.log("gives", gives);
       ofp.wants = wants;
       ofp.gives = gives;
       ofp.gasreq = gasreq;

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -311,47 +311,10 @@ abstract contract MgvOfferTaking is MgvHasOffers {
   /* ## Snipes */
   //+clear+
 
-  // utility
-
-  function convertSnipeTargetsToTicks(uint[4][] calldata targets, bool fillWants)
-    internal
-    pure
-    returns (uint[4][] memory)
-  {
-    uint[4][] memory newTargets = new uint[4][](targets.length);
-    // convert targets from [id,wants,gives,gasreq] to [id,tick,volume,gasreq]
-    uint volumeIndex = fillWants ? 1 : 2;
-    for (uint i = 0; i < targets.length; i++) {
-      // console.log("Converting...");
-      // console.log("wants,gives",targets[i][1],targets[i][2]);
-      newTargets[i][0] = targets[i][0];
-      newTargets[i][1] = uint(Tick.unwrap(TickLib.tickFromTakerVolumes(targets[i][2], targets[i][1])));
-      newTargets[i][2] = targets[i][volumeIndex];
-      newTargets[i][3] = targets[i][3];
-      // console.log("tick,volume",newTargets[i][1],newTargets[i][2]);
-    }
-    return newTargets;
-  }
-
-  // struct SnipeTarget {
-  //   uint offerId;
-  //   int tick;
-  //   uint fillVolume;
-  //   uint offerGasreq;
-  // }
   /* `snipes` executes multiple offers. It takes a `uint[4][]` as penultimate argument, with each array element of the form `[offerId,tick,fillVolume,offerGasreq]`. The return parameters are of the form `(successes,snipesGot,snipesGave,bounty,feePaid)`. 
   Note that we do not distinguish further between mismatched arguments/offer fields on the one hand, and an execution failure on the other. Still, a failed offer has to pay a penalty, and ultimately transaction logs explicitly mention execution failures (see `MgvLib.sol`). */
-  function snipesByVolume(address outbound_tkn, address inbound_tkn, uint[4][] calldata targets, bool fillWants)
-    external
-    returns (uint, uint, uint, uint, uint)
-  {
-    unchecked {
-      return
-        generalSnipes(outbound_tkn, inbound_tkn, convertSnipeTargetsToTicks(targets, fillWants), fillWants, msg.sender);
-    }
-  }
 
-  function snipesByTick(address outbound_tkn, address inbound_tkn, uint[4][] calldata targets, bool fillWants)
+  function snipes(address outbound_tkn, address inbound_tkn, uint[4][] calldata targets, bool fillWants)
     external
     returns (uint, uint, uint, uint, uint)
   {

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -330,7 +330,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
   function generalSnipes(
     address outbound_tkn,
     address inbound_tkn,
-    uint[4][] memory targets,
+    uint[4][] calldata targets,
     bool fillWants,
     address taker
   ) internal returns (uint successCount, uint snipesGot, uint snipesGave, uint totalPenalty, uint feePaid) {
@@ -374,7 +374,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
     Pair storage pair,
     MultiOrder memory mor,
     MgvLib.SingleOrder memory sor,
-    uint[4][] memory targets
+    uint[4][] calldata targets
   ) internal returns (uint successCount, uint snipesGot, uint snipesGave) {
     unchecked {
       for (uint i = 0; i < targets.length; ++i) {

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -6,7 +6,6 @@ import {
 } from "./MgvLib.sol";
 import {MgvHasOffers} from "./MgvHasOffers.sol";
 import {TickLib} from "./../lib/TickLib.sol";
-import "mgv_lib/Debug.sol";
 
 abstract contract MgvOfferTaking is MgvHasOffers {
   /* # MultiOrder struct */
@@ -324,7 +323,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
   }
 
   /*
-     From an array of _n_ `[offerId, tick,volume,gasreq]` elements, execute each snipe in sequence. Returns `(successes, takerGot, takerGave, bounty, feePaid)`. 
+     From an array of _n_ `[offerId, tick,fillVolume,gasreq]` elements, execute each snipe in sequence. Returns `(successes, takerGot, takerGave, bounty, feePaid)`. 
 
      Note that if this function is not internal, anyone can make anyone use Mangrove.
      Note that unlike general market order, the returned total values are _not_ `mor.totalGot` and `mor.totalGave`, since those are reset at every iteration of the `targets` array. Instead, accumulators `snipesGot` and `snipesGave` are used. */
@@ -405,9 +404,9 @@ abstract contract MgvOfferTaking is MgvHasOffers {
             mor.maxTick = tick;
           }
           {
-            uint volume = targets[i][2];
-            require(uint96(volume) == volume, "mgv/snipes/volume/96bits");
-            mor.fillVolume = volume;
+            uint fillVolume = targets[i][2];
+            require(uint96(fillVolume) == fillVolume, "mgv/snipes/volume/96bits");
+            mor.fillVolume = fillVolume;
           }
 
           /* We start be enabling the reentrancy lock for this (`outbound_tkn`,`inbound_tkn`) pair. */

--- a/src/MgvOfferTakingWithPermit.sol
+++ b/src/MgvOfferTakingWithPermit.sol
@@ -5,7 +5,6 @@ import {HasMgvEvents, Tick} from "./MgvLib.sol";
 
 import {MgvOfferTaking} from "./MgvOfferTaking.sol";
 import {TickLib} from "./../lib/TickLib.sol";
-import "mgv_lib/Debug.sol";
 
 abstract contract MgvOfferTakingWithPermit is MgvOfferTaking {
   /* Takers may provide allowances on specific pairs, so other addresses can execute orders in their name. Allowance may be set using the usual `approve` function, or through an [EIP712](https://eips.ethereum.org/EIPS/eip-712) `permit`.
@@ -125,7 +124,7 @@ abstract contract MgvOfferTakingWithPermit is MgvOfferTaking {
     }
   }
 
-  /* The delegate version of `snipesByTick` is `snipesForByTick`, which takes a `taker` address as additional argument. */
+  /* The delegate version of `snipes` is `snipesFor`, which takes a `taker` address as additional argument. */
   function snipesFor(
     address outbound_tkn,
     address inbound_tkn,

--- a/src/MgvOfferTakingWithPermit.sol
+++ b/src/MgvOfferTakingWithPermit.sol
@@ -5,6 +5,7 @@ import {HasMgvEvents, Tick} from "./MgvLib.sol";
 
 import {MgvOfferTaking} from "./MgvOfferTaking.sol";
 import {TickLib} from "./../lib/TickLib.sol";
+import "mgv_lib/Debug.sol";
 
 abstract contract MgvOfferTakingWithPermit is MgvOfferTaking {
   /* Takers may provide allowances on specific pairs, so other addresses can execute orders in their name. Allowance may be set using the usual `approve` function, or through an [EIP712](https://eips.ethereum.org/EIPS/eip-712) `permit`.
@@ -125,7 +126,7 @@ abstract contract MgvOfferTakingWithPermit is MgvOfferTaking {
   }
 
   /* The delegate version of `snipesByTick` is `snipesForByTick`, which takes a `taker` address as additional argument. */
-  function snipesForByTick(
+  function snipesFor(
     address outbound_tkn,
     address inbound_tkn,
     uint[4][] calldata targets,
@@ -135,24 +136,6 @@ abstract contract MgvOfferTakingWithPermit is MgvOfferTaking {
     unchecked {
       (successes, takerGot, takerGave, bounty, feePaid) =
         generalSnipes(outbound_tkn, inbound_tkn, targets, fillWants, taker);
-      /* The sender's allowance is verified after the order complete so that the actual amounts are checked against the allowance, instead of the declared `takerGives`. The former may be lower.
-    
-    An immediate consequence is that any funds available to Mangrove through `approve` can be used to clean offers. After a `snipesFor` where all offers have failed, all token transfers have been reverted, so `takerGave=0` and the check will succeed -- but the sender will still have received the bounty of the failing offers. */
-      deductSenderAllowance(outbound_tkn, inbound_tkn, taker, takerGave);
-    }
-  }
-
-  /* The delegate version of `snipesByVolume` is `snipesForByVolume`, which takes a `taker` address as additional argument. */
-  function snipesForByVolume(
-    address outbound_tkn,
-    address inbound_tkn,
-    uint[4][] calldata targets,
-    bool fillWants,
-    address taker
-  ) external returns (uint successes, uint takerGot, uint takerGave, uint bounty, uint feePaid) {
-    unchecked {
-      (successes, takerGot, takerGave, bounty, feePaid) =
-        generalSnipes(outbound_tkn, inbound_tkn, convertSnipeTargetsToTicks(targets, fillWants), fillWants, taker);
       /* The sender's allowance is verified after the order complete so that the actual amounts are checked against the allowance, instead of the declared `takerGives`. The former may be lower.
     
     An immediate consequence is that any funds available to Mangrove through `approve` can be used to clean offers. After a `snipesFor` where all offers have failed, all token transfers have been reverted, so `takerGave=0` and the check will succeed -- but the sender will still have received the bounty of the failing offers. */

--- a/src/MgvOfferTakingWithPermit.sol
+++ b/src/MgvOfferTakingWithPermit.sol
@@ -124,8 +124,8 @@ abstract contract MgvOfferTakingWithPermit is MgvOfferTaking {
     }
   }
 
-  /* The delegate version of `snipes` is `snipesFor`, which takes a `taker` address as additional argument. */
-  function snipesFor(
+  /* The delegate version of `snipesByTick` is `snipesForByTick`, which takes a `taker` address as additional argument. */
+  function snipesForByTick(
     address outbound_tkn,
     address inbound_tkn,
     uint[4][] calldata targets,
@@ -135,6 +135,24 @@ abstract contract MgvOfferTakingWithPermit is MgvOfferTaking {
     unchecked {
       (successes, takerGot, takerGave, bounty, feePaid) =
         generalSnipes(outbound_tkn, inbound_tkn, targets, fillWants, taker);
+      /* The sender's allowance is verified after the order complete so that the actual amounts are checked against the allowance, instead of the declared `takerGives`. The former may be lower.
+    
+    An immediate consequence is that any funds available to Mangrove through `approve` can be used to clean offers. After a `snipesFor` where all offers have failed, all token transfers have been reverted, so `takerGave=0` and the check will succeed -- but the sender will still have received the bounty of the failing offers. */
+      deductSenderAllowance(outbound_tkn, inbound_tkn, taker, takerGave);
+    }
+  }
+
+  /* The delegate version of `snipesByVolume` is `snipesForByVolume`, which takes a `taker` address as additional argument. */
+  function snipesForByVolume(
+    address outbound_tkn,
+    address inbound_tkn,
+    uint[4][] calldata targets,
+    bool fillWants,
+    address taker
+  ) external returns (uint successes, uint takerGot, uint takerGave, uint bounty, uint feePaid) {
+    unchecked {
+      (successes, takerGot, takerGave, bounty, feePaid) =
+        generalSnipes(outbound_tkn, inbound_tkn, convertSnipeTargetsToTicks(targets, fillWants), fillWants, taker);
       /* The sender's allowance is verified after the order complete so that the actual amounts are checked against the allowance, instead of the declared `takerGives`. The former may be lower.
     
     An immediate consequence is that any funds available to Mangrove through `approve` can be used to clean offers. After a `snipesFor` where all offers have failed, all token transfers have been reverted, so `takerGave=0` and the check will succeed -- but the sender will still have received the bounty of the failing offers. */

--- a/src/periphery/MgvCleaner.sol
+++ b/src/periphery/MgvCleaner.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.10;
 
-import {MgvLib, MgvStructs} from "../MgvLib.sol";
+import {MgvLib, MgvStructs} from "mgv_src/MgvLib.sol";
 import {IMangrove} from "mgv_src/IMangrove.sol";
+import "mgv_src/MgvHelpers.sol";
 import "mgv_lib/Debug.sol";
 
 /* The purpose of the Cleaner contract is to execute failing offers and collect
@@ -31,7 +32,8 @@ contract MgvCleaner {
     returns (uint bal)
   {
     unchecked {
-      (uint successes,,,,) = MGV.snipesForByVolume(outbound_tkn, inbound_tkn, targets, fillWants, msg.sender);
+      (uint successes,,,,) =
+        MgvHelpers.snipesForByVolume(address(MGV), outbound_tkn, inbound_tkn, targets, fillWants, msg.sender);
       require(successes == 0, "mgvCleaner/anOfferDidNotFail");
       bal = address(this).balance;
       bool noRevert;
@@ -51,7 +53,8 @@ contract MgvCleaner {
     address takerToImpersonate
   ) external returns (uint bal) {
     unchecked {
-      (uint successes,,,,) = MGV.snipesForByVolume(outbound_tkn, inbound_tkn, targets, fillWants, takerToImpersonate);
+      (uint successes,,,,) =
+        MgvHelpers.snipesForByVolume(address(MGV), outbound_tkn, inbound_tkn, targets, fillWants, takerToImpersonate);
       require(successes == 0, "mgvCleaner/anOfferDidNotFail");
       bal = address(this).balance;
       bool noRevert;

--- a/src/periphery/MgvCleaner.sol
+++ b/src/periphery/MgvCleaner.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.10;
 
 import {MgvLib, MgvStructs} from "../MgvLib.sol";
 import {IMangrove} from "mgv_src/IMangrove.sol";
+import "mgv_lib/Debug.sol";
 
 /* The purpose of the Cleaner contract is to execute failing offers and collect
  * their associated bounty. It takes an array of offers with same definition as
@@ -30,7 +31,7 @@ contract MgvCleaner {
     returns (uint bal)
   {
     unchecked {
-      (uint successes,,,,) = MGV.snipesFor(outbound_tkn, inbound_tkn, targets, fillWants, msg.sender);
+      (uint successes,,,,) = MGV.snipesForByVolume(outbound_tkn, inbound_tkn, targets, fillWants, msg.sender);
       require(successes == 0, "mgvCleaner/anOfferDidNotFail");
       bal = address(this).balance;
       bool noRevert;
@@ -50,7 +51,7 @@ contract MgvCleaner {
     address takerToImpersonate
   ) external returns (uint bal) {
     unchecked {
-      (uint successes,,,,) = MGV.snipesFor(outbound_tkn, inbound_tkn, targets, fillWants, takerToImpersonate);
+      (uint successes,,,,) = MGV.snipesForByVolume(outbound_tkn, inbound_tkn, targets, fillWants, takerToImpersonate);
       require(successes == 0, "mgvCleaner/anOfferDidNotFail");
       bal = address(this).balance;
       bool noRevert;

--- a/src/periphery/MgvCleaner.sol
+++ b/src/periphery/MgvCleaner.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.10;
 import {MgvLib, MgvStructs} from "mgv_src/MgvLib.sol";
 import {IMangrove} from "mgv_src/IMangrove.sol";
 import "mgv_src/MgvHelpers.sol";
-import "mgv_lib/Debug.sol";
 
 /* The purpose of the Cleaner contract is to execute failing offers and collect
  * their associated bounty. It takes an array of offers with same definition as

--- a/test/core/Gas.t.sol
+++ b/test/core/Gas.t.sol
@@ -85,14 +85,14 @@ contract GasTest is MangroveTest, IMaker {
   function test_take_offer() public {
     (AbstractMangrove mgv, TestTaker tkr, address base, address quote,) = getStored();
     _gas();
-    tkr.snipe(mgv, base, quote, 1, 1 ether, 1 ether, 100_000);
+    tkr.snipeByVolume(mgv, base, quote, 1, 1 ether, 100_000);
     gas_();
   }
 
   function test_partial_take_offer() public {
     (AbstractMangrove mgv, TestTaker tkr, address base, address quote,) = getStored();
     _gas();
-    tkr.snipe(mgv, base, quote, 1, 0.5 ether, 0.5 ether, 100_000);
+    tkr.snipeByVolume(mgv, base, quote, 1, 0.5 ether, 100_000);
     gas_();
   }
 

--- a/test/core/Gatekeeping.t.sol
+++ b/test/core/Gatekeeping.t.sol
@@ -300,18 +300,19 @@ contract GatekeepingTest is IMaker, MangroveTest {
     tkr.marketOrder(0, 2 ** 160);
   }
 
-  function test_takerWants_above_96bits_fails_snipes() public {
+  //FIXME Should add similar tests that make sure volume*price is not too big.
+  function test_gives_volume_above_96bits_fails_snipes() public {
     uint ofr = mkr.newOffer(1 ether, 1 ether, 100_000);
-    uint[4][] memory targets = wrap_dynamic([ofr, uint(type(uint96).max) + 1, type(uint96).max, type(uint).max]);
-    vm.expectRevert("mgv/snipes/takerWants/96bits");
-    mgv.snipes($(base), $(quote), targets, true);
+    uint[4][] memory targets = wrap_dynamic([ofr, 0, 1 << 96, type(uint).max]);
+    vm.expectRevert("mgv/snipes/volume/96bits");
+    mgv.snipesByTick($(base), $(quote), targets, true);
   }
 
-  function test_takerGives_above_96bits_fails_snipes() public {
+  function test_wants_volume_above_96bits_fails_snipes() public {
     uint ofr = mkr.newOffer(1 ether, 1 ether, 100_000);
-    uint[4][] memory targets = wrap_dynamic([ofr, type(uint96).max, uint(type(uint96).max) + 1, type(uint).max]);
-    vm.expectRevert("mgv/snipes/takerGives/96bits");
-    mgv.snipes($(base), $(quote), targets, true);
+    uint[4][] memory targets = wrap_dynamic([ofr, 0, 1 << 96, type(uint).max]);
+    vm.expectRevert("mgv/snipes/volume/96bits");
+    mgv.snipesByTick($(base), $(quote), targets, false);
   }
 
   function test_initial_allowance_is_zero() public {
@@ -324,7 +325,7 @@ contract GatekeepingTest is IMaker, MangroveTest {
     uint ofr = mkr.newOffer(1 ether, 1 ether, 100_000);
 
     vm.expectRevert("mgv/lowAllowance");
-    mgv.snipesFor($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 300_000]), true, address(tkr));
+    mgv.snipesForByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 300_000]), true, address(tkr));
   }
 
   function test_cannot_marketOrderFor_for_without_allowance() public {
@@ -603,7 +604,7 @@ contract GatekeepingTest is IMaker, MangroveTest {
   function snipesKO(uint id) external {
     uint[4][] memory targets = wrap_dynamic([id, 1 ether, type(uint96).max, type(uint48).max]);
     vm.expectRevert("mgv/reentrancyLocked");
-    mgv.snipes($(base), $(quote), targets, true);
+    mgv.snipesByVolume($(base), $(quote), targets, true);
   }
 
   function test_snipe_on_reentrancy_fails() public {
@@ -616,7 +617,7 @@ contract GatekeepingTest is IMaker, MangroveTest {
 
   function snipesOK(address _base, address _quote, uint id) external {
     uint[4][] memory targets = wrap_dynamic([id, 1 ether, type(uint96).max, type(uint48).max]);
-    mgv.snipes(_base, _quote, targets, true);
+    mgv.snipesByVolume(_base, _quote, targets, true);
   }
 
   function test_snipes_on_reentrancy_succeeds() public {

--- a/test/core/Gatekeeping.t.sol
+++ b/test/core/Gatekeeping.t.sol
@@ -315,7 +315,6 @@ contract GatekeepingTest is IMaker, MangroveTest {
 
   function test_wants_volume_above_96bits_fails_snipes() public {
     uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 100_000);
-    uint ofr = mkr.newOffer(1 ether, 1 ether, 100_000);
     uint[4][] memory targets = wrap_dynamic([ofr, 0, 1 << 96, type(uint).max]);
     vm.expectRevert("mgv/snipes/volume/96bits");
     mgv.snipes($(base), $(quote), targets, false);

--- a/test/core/InvertedTakerOperations.t.sol
+++ b/test/core/InvertedTakerOperations.t.sol
@@ -100,7 +100,7 @@ contract InvertedTakerOperationsTest is ITaker, MangroveTest {
     uint ofr = mkr.newOffer(1 ether, 1 ether, 50_000, 0);
     uint mgvQuoteBal = quote.balanceOf(address(mgv));
 
-    (uint successes,,,,) = mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
+    (uint successes,,,,) = mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
     assertTrue(successes == 1, "Trade should succeed");
     assertEq(quote.balanceOf(address(mgv)) - mgvQuoteBal, 1 ether, "Mgv balance should have increased");
   }
@@ -111,7 +111,7 @@ contract InvertedTakerOperationsTest is ITaker, MangroveTest {
     _takerTrade = noop;
     skipCheck = true;
     (uint successes, uint totalGot, uint totalGave,,) =
-      mgv.snipes(_base, _quote, wrap_dynamic([uint(2), 0.1 ether, 0.1 ether, 100_000]), true);
+      mgv.snipesByVolume(_base, _quote, wrap_dynamic([uint(2), 0.1 ether, 0.1 ether, 100_000]), true);
     assertTrue(successes == 1, "Snipe on reentrancy should succeed");
     assertEq(totalGot, 0.1 ether, "Incorrect totalGot");
     assertEq(totalGave, 0.1 ether, "Incorrect totalGave");
@@ -134,7 +134,7 @@ contract InvertedTakerOperationsTest is ITaker, MangroveTest {
     uint ofr = mkr.newOffer(0.1 ether, 0.1 ether, 100_000, 0);
     uint bal = quote.balanceOf($(this));
     _takerTrade = noop;
-    mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 0.05 ether, 0.05 ether, 100_000]), true);
+    mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 0.05 ether, 0.05 ether, 100_000]), true);
     assertEq(quote.balanceOf($(this)), bal - 0.05 ether, "wrong taker balance");
   }
 
@@ -142,7 +142,7 @@ contract InvertedTakerOperationsTest is ITaker, MangroveTest {
     uint ofr = mkr.newOffer(0.1 ether, 0.1 ether, 100_000, 0);
     uint bal = quote.balanceOf($(this));
     _takerTrade = noop;
-    mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 0.02 ether, 0.02 ether, 100_000]), true);
+    mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 0.02 ether, 0.02 ether, 100_000]), true);
     assertEq(quote.balanceOf($(this)), bal - 0.02 ether, "wrong taker balance");
   }
 }

--- a/test/core/InvertedTakerOperations.t.sol
+++ b/test/core/InvertedTakerOperations.t.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.10;
 
 import "mgv_test/lib/MangroveTest.sol";
+import {MgvHelpers} from "mgv_src/MgvHelpers.sol";
 
 /* The following constructs an ERC20 with a transferFrom callback method,
    and a TestTaker which throws away any funds received upon getting
@@ -100,7 +101,8 @@ contract InvertedTakerOperationsTest is ITaker, MangroveTest {
     uint ofr = mkr.newOffer(1 ether, 1 ether, 50_000, 0);
     uint mgvQuoteBal = quote.balanceOf(address(mgv));
 
-    (uint successes,,,,) = mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
+    (uint successes,,,,) =
+      MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
     assertTrue(successes == 1, "Trade should succeed");
     assertEq(quote.balanceOf(address(mgv)) - mgvQuoteBal, 1 ether, "Mgv balance should have increased");
   }
@@ -111,7 +113,7 @@ contract InvertedTakerOperationsTest is ITaker, MangroveTest {
     _takerTrade = noop;
     skipCheck = true;
     (uint successes, uint totalGot, uint totalGave,,) =
-      mgv.snipesByVolume(_base, _quote, wrap_dynamic([uint(2), 0.1 ether, 0.1 ether, 100_000]), true);
+      MgvHelpers.snipesByVolume($(mgv), _base, _quote, wrap_dynamic([uint(2), 0.1 ether, 0.1 ether, 100_000]), true);
     assertTrue(successes == 1, "Snipe on reentrancy should succeed");
     assertEq(totalGot, 0.1 ether, "Incorrect totalGot");
     assertEq(totalGave, 0.1 ether, "Incorrect totalGave");
@@ -134,7 +136,7 @@ contract InvertedTakerOperationsTest is ITaker, MangroveTest {
     uint ofr = mkr.newOffer(0.1 ether, 0.1 ether, 100_000, 0);
     uint bal = quote.balanceOf($(this));
     _takerTrade = noop;
-    mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 0.05 ether, 0.05 ether, 100_000]), true);
+    MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 0.05 ether, 0.05 ether, 100_000]), true);
     assertEq(quote.balanceOf($(this)), bal - 0.05 ether, "wrong taker balance");
   }
 
@@ -142,7 +144,7 @@ contract InvertedTakerOperationsTest is ITaker, MangroveTest {
     uint ofr = mkr.newOffer(0.1 ether, 0.1 ether, 100_000, 0);
     uint bal = quote.balanceOf($(this));
     _takerTrade = noop;
-    mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 0.02 ether, 0.02 ether, 100_000]), true);
+    MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 0.02 ether, 0.02 ether, 100_000]), true);
     assertEq(quote.balanceOf($(this)), bal - 0.02 ether, "wrong taker balance");
   }
 }

--- a/test/core/MakerPosthook.t.sol
+++ b/test/core/MakerPosthook.t.sol
@@ -221,7 +221,7 @@ contract MakerPosthookTest is MangroveTest, IMaker {
 
     ofr = mgv.newOffer($(base), $(quote), 1 ether, 1 ether, gasreq, _gasprice);
 
-    bool success = tkr.snipe(mgv, $(base), $(quote), ofr, 1 ether, 1 ether, gasreq - 1);
+    bool success = tkr.snipeByVolume(mgv, $(base), $(quote), ofr, 1 ether, gasreq - 1);
     assertTrue(!called, "PostHook was called");
     assertTrue(!success, "Snipe should fail");
   }
@@ -230,7 +230,7 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     executeReturnData = "NOK2";
     ofr = mgv.newOffer($(base), $(quote), 1 ether, 1 ether, gasreq, _gasprice);
 
-    bool success = tkr.snipe(mgv, $(base), $(quote), ofr, 1 ether, 1 ether, gasreq - 1);
+    bool success = tkr.snipeByVolume(mgv, $(base), $(quote), ofr, 1 ether, gasreq - 1);
     // using asserts in makerPosthook here
     assertTrue(!called, "PostHook was called");
     assertTrue(!success, "Snipe should fail");
@@ -239,7 +239,9 @@ contract MakerPosthookTest is MangroveTest, IMaker {
   function test_posthook_of_skipped_offer_wrong_price_should_not_be_called() public {
     _posthook = failer_posthook;
     ofr = mgv.newOffer($(base), $(quote), 1 ether, 1 ether, gasreq, _gasprice);
-    bool success = tkr.snipe(mgv, $(base), $(quote), ofr, 1.1 ether, 1 ether, gasreq);
+    Tick offerTick = mgv.offers($(base), $(quote), ofr).tick();
+    Tick snipeTick = Tick.wrap(Tick.unwrap(offerTick) - 1); // Snipe at a lower price tick
+    bool success = tkr.snipeByTick(mgv, $(base), $(quote), ofr, snipeTick, 1 ether, gasreq);
     assertTrue(!success, "Snipe should fail");
     assertTrue(!called, "PostHook was called");
   }

--- a/test/core/MakerPosthook.t.sol
+++ b/test/core/MakerPosthook.t.sol
@@ -241,7 +241,7 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, gasreq, _gasprice);
     Tick offerTick = mgv.offers($(base), $(quote), ofr).tick();
     Tick snipeTick = Tick.wrap(Tick.unwrap(offerTick) - 1); // Snipe at a lower price tick
-    bool success = tkr.snipe(mgv, $(base), $(quote), ofr, 1.1 ether, 1 ether, gasreq);
+    bool success = tkr.snipeByTick(mgv, $(base), $(quote), ofr, snipeTick, 1 ether, gasreq);
     assertTrue(!success, "Snipe should fail");
     assertTrue(!called, "PostHook was called");
   }

--- a/test/core/Monitor.t.sol
+++ b/test/core/Monitor.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.10;
 
 import "mgv_test/lib/MangroveTest.sol";
 import {MgvLib, MgvStructs, Tick, DensityLib} from "mgv_src/MgvLib.sol";
+import {MgvHelpers} from "mgv_src/MgvHelpers.sol";
 
 contract MonitorTest is MangroveTest {
   TestMaker mkr;
@@ -114,7 +115,7 @@ contract MonitorTest is MangroveTest {
 
     expectToMockCall(monitor, abi.encodeCall(IMgvMonitor.notifySuccess, (order, $(this))), bytes(""));
 
-    (uint successes,,,,) = mgv.snipesByVolume($(base), $(quote), targets, true);
+    (uint successes,,,,) = MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), targets, true);
     assertTrue(successes == 1, "snipe should succeed");
   }
 
@@ -146,7 +147,7 @@ contract MonitorTest is MangroveTest {
 
     expectToMockCall(monitor, abi.encodeCall(IMgvMonitor.notifyFail, (order, $(this))), bytes(""));
 
-    (uint successes,,,,) = mgv.snipesByVolume($(base), $(quote), targets, true);
+    (uint successes,,,,) = MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), targets, true);
     assertTrue(successes == 0, "snipe should fail");
   }
 }

--- a/test/core/Monitor.t.sol
+++ b/test/core/Monitor.t.sol
@@ -114,7 +114,7 @@ contract MonitorTest is MangroveTest {
 
     expectToMockCall(monitor, abi.encodeCall(IMgvMonitor.notifySuccess, (order, $(this))), bytes(""));
 
-    (uint successes,,,,) = mgv.snipes($(base), $(quote), targets, true);
+    (uint successes,,,,) = mgv.snipesByVolume($(base), $(quote), targets, true);
     assertTrue(successes == 1, "snipe should succeed");
   }
 
@@ -146,7 +146,7 @@ contract MonitorTest is MangroveTest {
 
     expectToMockCall(monitor, abi.encodeCall(IMgvMonitor.notifyFail, (order, $(this))), bytes(""));
 
-    (uint successes,,,,) = mgv.snipes($(base), $(quote), targets, true);
+    (uint successes,,,,) = mgv.snipesByVolume($(base), $(quote), targets, true);
     assertTrue(successes == 0, "snipe should fail");
   }
 }

--- a/test/core/Permit.t.sol
+++ b/test/core/Permit.t.sol
@@ -46,6 +46,7 @@ import {TrivialTestMaker, TestMaker} from "mgv_test/lib/agents/TestMaker.sol";
 import {Vm} from "forge-std/Vm.sol";
 import {console2, StdStorage, stdStorage} from "forge-std/Test.sol";
 import {AbstractMangrove} from "mgv_src/AbstractMangrove.sol";
+import {MgvHelpers} from "mgv_src/MgvHelpers.sol";
 
 contract PermitTest is MangroveTest, TrivialTestMaker {
   using stdStorage for StdStorage;
@@ -83,7 +84,8 @@ contract PermitTest is MangroveTest, TrivialTestMaker {
   }
 
   function snipeFor(uint value, address who) internal returns (uint, uint, uint, uint, uint) {
-    return mgv.snipesForByVolume($(base), $(quote), wrap_dynamic([uint(1), value, value, 300_000]), true, who);
+    return
+      MgvHelpers.snipesForByVolume($(mgv), $(base), $(quote), wrap_dynamic([uint(1), value, value, 300_000]), true, who);
   }
 
   function newOffer(uint amount) internal {

--- a/test/core/Permit.t.sol
+++ b/test/core/Permit.t.sol
@@ -46,7 +46,7 @@ import {TrivialTestMaker, TestMaker} from "mgv_test/lib/agents/TestMaker.sol";
 import {Vm} from "forge-std/Vm.sol";
 import {console2, StdStorage, stdStorage} from "forge-std/Test.sol";
 import {AbstractMangrove} from "mgv_src/AbstractMangrove.sol";
-import {MgvHelpers} from "mgv_src/MgvHelpers.sol";
+import {TickLib, Tick} from "mgv_lib/TickLib.sol";
 
 contract PermitTest is MangroveTest, TrivialTestMaker {
   using stdStorage for StdStorage;
@@ -84,8 +84,8 @@ contract PermitTest is MangroveTest, TrivialTestMaker {
   }
 
   function snipeFor(uint value, address who) internal returns (uint, uint, uint, uint, uint) {
-    return
-      MgvHelpers.snipesForByVolume($(mgv), $(base), $(quote), wrap_dynamic([uint(1), value, value, 300_000]), true, who);
+    Tick tick = TickLib.tickFromPrice_e18(1 ether);
+    return mgv.snipesFor($(base), $(quote), wrap_dynamic([uint(1), uint(Tick.unwrap(tick)), value, 300_000]), true, who);
   }
 
   function newOffer(uint amount) internal {

--- a/test/core/Permit.t.sol
+++ b/test/core/Permit.t.sol
@@ -83,7 +83,7 @@ contract PermitTest is MangroveTest, TrivialTestMaker {
   }
 
   function snipeFor(uint value, address who) internal returns (uint, uint, uint, uint, uint) {
-    return mgv.snipesFor($(base), $(quote), wrap_dynamic([uint(1), value, value, 300_000]), true, who);
+    return mgv.snipesForByVolume($(base), $(quote), wrap_dynamic([uint(1), value, value, 300_000]), true, who);
   }
 
   function newOffer(uint amount) internal {

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -56,7 +56,7 @@ contract TakerOperationsTest is MangroveTest {
     quote.blacklists($(this));
 
     vm.expectRevert("mgv/takerTransferFail");
-    mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
+    mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
     assertEq(weiBalanceBefore, mgv.balanceOf($(this)), "Taker should not take bounty");
   }
 
@@ -68,7 +68,7 @@ contract TakerOperationsTest is MangroveTest {
     base.blacklists($(this));
 
     vm.expectRevert("mgv/MgvFailToPayTaker");
-    mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
+    mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
     assertEq(weiBalanceBefore, mgv.balanceOf($(this)), "Taker should not take bounty");
   }
 
@@ -78,7 +78,7 @@ contract TakerOperationsTest is MangroveTest {
     mkr.expect("mgv/tradeSuccess"); // trade should be OK on the maker side
     quote.approve($(mgv), 1 ether);
     (uint successes, uint got, uint gave,,) =
-      mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 1 ether, 0.5 ether, 100_000]), false);
+      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 0.5 ether, 100_000]), false);
     assertTrue(successes == 0, "Snipe should fail");
     assertEq(weiBalanceBefore, mgv.balanceOf($(this)), "Taker should not take bounty");
     assertTrue((got == gave && gave == 0), "Taker should not give or take anything");
@@ -89,7 +89,7 @@ contract TakerOperationsTest is MangroveTest {
     quote.approve($(mgv), 1 ether);
     uint ofr = mkr.newOffer(9, 10, 100_000, 0);
     uint oldBal = quote.balanceOf($(this));
-    mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 1, 15 ether, 100_000]), true);
+    mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1, 15 ether, 100_000]), true);
     uint newBal = quote.balanceOf($(this));
     assertGt(oldBal, newBal, "oldBal should be strictly higher");
   }
@@ -99,7 +99,7 @@ contract TakerOperationsTest is MangroveTest {
     mkr.expect("mgv/tradeSuccess"); // trade should be OK on the maker side
     quote.approve($(mgv), 1 ether);
     (uint successes, uint got, uint gave,,) =
-      mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 0.5 ether, 1 ether, 100_000]), true);
+      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 0.5 ether, 1 ether, 100_000]), true);
     assertTrue(successes == 1, "Snipe should not fail");
     assertEq(got, 0.5 ether, "Taker did not get correct amount");
     assertEq(gave, 0.5 ether, "Taker did not give correct amount");
@@ -127,7 +127,7 @@ contract TakerOperationsTest is MangroveTest {
     expectFrom($(mgv));
     emit OrderComplete($(base), $(quote), $(this), 2.3 ether, 2.3 ether, 0, 0);
 
-    (uint successes, uint got, uint gave,,) = mgv.snipes($(base), $(quote), targets, true);
+    (uint successes, uint got, uint gave,,) = mgv.snipesByVolume($(base), $(quote), targets, true);
     assertTrue(successes == 3, "Snipes should not fail");
     assertEq(got, 2.3 ether, "Taker did not get correct amount");
     assertEq(gave, 2.3 ether, "Taker did not give correct amount");
@@ -146,7 +146,8 @@ contract TakerOperationsTest is MangroveTest {
     expectFrom($(quote));
     emit Transfer($(mgv), address(mkr), 0);
 
-    (uint successes, uint got, uint gave,,) = mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 0, 0, 100_000]), true);
+    (uint successes, uint got, uint gave,,) =
+      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 0, 0, 100_000]), true);
     assertTrue(successes == 1, "Snipe should not fail");
     assertEq(got, 0 ether, "Taker had too much");
     assertEq(gave, 0 ether, "Taker gave too much");
@@ -164,7 +165,7 @@ contract TakerOperationsTest is MangroveTest {
        We should still only receive 0.1 eth */
 
     (uint successes, uint got, uint gave,,) =
-      mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 0.1 ether, 1, 100_000]), true);
+      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 0.1 ether, 1, 100_000]), true);
     assertTrue(successes == 1, "Snipe should not fail");
     assertApproxEqRel(got, 0.1 ether, relError(10), "Wrong got value");
     assertApproxEqRel(gave, 1, relError(10), "Wrong gave value");
@@ -182,7 +183,7 @@ contract TakerOperationsTest is MangroveTest {
        Here despite asking for .1eth the offer gives 1eth for 0 so we should receive 1eth. */
 
     (uint successes, uint got, uint gave,,) =
-      mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 0.1 ether, 0.01 ether, 100_000]), false);
+      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 0.1 ether, 0.01 ether, 100_000]), false);
     assertTrue(successes == 1, "Snipe should not fail");
     assertApproxEqRel(got, 1 ether, relError(10), "Wrong got value");
     assertApproxEqRel(gave, 0.01 ether, relError(10), "Wrong gave value");
@@ -195,7 +196,8 @@ contract TakerOperationsTest is MangroveTest {
     mkr.expect("mgv/tradeSuccess"); // trade should be OK on the maker side
     quote.approve($(mgv), 1 ether);
 
-    (uint successes, uint got, uint gave,,) = mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 0, 0, 100_000]), false);
+    (uint successes, uint got, uint gave,,) =
+      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 0, 0, 100_000]), false);
     assertTrue(successes == 1, "Snipe should not fail");
     assertEq(got, 0 ether, "Taker had too much");
     assertEq(gave, 0 ether, "Taker gave too much");
@@ -208,7 +210,7 @@ contract TakerOperationsTest is MangroveTest {
     quote.approve($(mgv), 1 ether);
 
     (uint successes, uint got, uint gave,,) =
-      mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 0.5 ether, 1 ether, 100_000]), false);
+      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 0.5 ether, 1 ether, 100_000]), false);
     assertTrue(successes == 1, "Snipe should not fail");
     assertEq(got, 1 ether, "Taker did not get correct amount");
     assertEq(gave, 1 ether, "Taker did not get correct amount");
@@ -274,7 +276,7 @@ contract TakerOperationsTest is MangroveTest {
     expectFrom($(mgv));
     emit OfferFail($(base), $(quote), ofr, $(this), 1 ether, 1 ether, "mgv/makerTransferFail");
     (uint successes, uint takerGot, uint takerGave,,) =
-      mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
+      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
     assertTrue(successes == 0, "Snipe should fail");
@@ -289,7 +291,7 @@ contract TakerOperationsTest is MangroveTest {
     quote.approve($(mgv), 1 ether);
 
     vm.expectRevert("mgv/sendPenaltyReverted");
-    mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
+    mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
   }
 
   function test_taker_reimbursed_if_maker_is_blacklisted_for_base() public {
@@ -305,7 +307,7 @@ contract TakerOperationsTest is MangroveTest {
     expectFrom($(mgv));
     emit OfferFail($(base), $(quote), ofr, $(this), 1 ether, 1 ether, "mgv/makerTransferFail");
     (uint successes, uint takerGot, uint takerGave,,) =
-      mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
+      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
     assertTrue(successes == 0, "Snipe should fail");
@@ -328,7 +330,7 @@ contract TakerOperationsTest is MangroveTest {
 
     emit OfferFail($(base), $(quote), ofr, $(this), 1 ether, 1 ether, "mgv/makerReceiveFail");
     (uint successes, uint takerGot, uint takerGave,,) =
-      mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
+      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
     assertTrue(successes == 0, "Snipe should fail");
@@ -343,7 +345,7 @@ contract TakerOperationsTest is MangroveTest {
     uint beforeWei = $(this).balance;
 
     (uint successes, uint takerGot, uint takerGave,,) =
-      mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 0, 0, 100_000]), true);
+      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 0, 0, 100_000]), true);
     assertTrue(successes == 0, "Snipe should fail");
     assertTrue(takerGot == takerGave && takerGave == 0, "Transaction data should be 0");
     assertTrue($(this).balance > beforeWei, "Taker was not compensated");
@@ -359,7 +361,7 @@ contract TakerOperationsTest is MangroveTest {
     expectFrom($(mgv));
     emit OfferFail($(base), $(quote), ofr, $(this), 1 ether, 1 ether, "mgv/makerRevert");
     (uint successes, uint takerGot, uint takerGave,,) =
-      mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
+      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
     assertTrue(successes == 0, "Snipe should fail");
@@ -375,7 +377,7 @@ contract TakerOperationsTest is MangroveTest {
     uint ofr = mkr.newOffer(1 ether, 1 ether, 50_000, 0);
     quote.approve($(mgv), 1 ether);
     uint shouldGet = reader.minusFee($(base), $(quote), 1 ether);
-    mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
+    mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
     assertEq(base.balanceOf($(this)) - balTaker, shouldGet, "Incorrect delivered amount");
   }
 
@@ -383,7 +385,7 @@ contract TakerOperationsTest is MangroveTest {
     uint balTaker = base.balanceOf($(this));
     uint ofr = mkr.newOffer(1 ether, 1 ether, 50_000, 0);
     quote.approve($(mgv), 1 ether);
-    mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
+    mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
     assertEq(base.balanceOf($(this)) - balTaker, 1 ether, "Incorrect delivered amount");
   }
 
@@ -392,7 +394,7 @@ contract TakerOperationsTest is MangroveTest {
     base.approve($(mgv), 1 ether);
 
     vm.expectRevert("mgv/takerTransferFail");
-    mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
+    mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
   }
 
   function test_simple_snipe() public {
@@ -406,7 +408,7 @@ contract TakerOperationsTest is MangroveTest {
     expectFrom($(mgv));
     emit OfferSuccess($(base), $(quote), ofr, $(this), 1 ether, offer.tick().inboundFromOutbound(1 ether));
     (uint successes, uint takerGot, uint takerGave,,) =
-      mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1.1 ether, 50_000]), true);
+      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1.1 ether, 50_000]), true);
     assertTrue(successes == 1, "Snipe should succeed");
     assertApproxEqRel(base.balanceOf($(this)) - balTaker, 1 ether, relError(10), "Incorrect delivered amount (taker)");
     assertApproxEqRel(
@@ -463,7 +465,7 @@ contract TakerOperationsTest is MangroveTest {
     quote.approve($(mgv), 10 ether);
 
     (uint successes, uint takerGot, uint takerGave,,) =
-      mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 2 ether, 10, 300_000]), false);
+      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 2 ether, 10, 300_000]), false);
     assertEq(successes, 1, "snipe should succeed");
     // console.log("offer wants",pair.offers(ofr).wants());
     // console.log("offer tick",pair.offers(ofr).tick().toString());
@@ -499,7 +501,7 @@ contract TakerOperationsTest is MangroveTest {
     base.approve($(mgv), 1 ether); // not necessary since no fee
 
     vm.expectRevert("mgv/takerTransferFail");
-    mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 2 ether, 100 ether, 100_000]), true);
+    mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 2 ether, 100 ether, 100_000]), true);
   }
 
   function test_maker_has_not_enough_base_fails_order() public {
@@ -515,7 +517,8 @@ contract TakerOperationsTest is MangroveTest {
     emit OfferFail(
       $(base), $(quote), ofr, $(this), takerWants, offer.tick().inboundFromOutbound(takerWants), "mgv/makerTransferFail"
     );
-    (uint successes,,,,) = mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 50 ether, 0.5 ether, 100_000]), true);
+    (uint successes,,,,) =
+      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 50 ether, 0.5 ether, 100_000]), true);
     assertTrue(successes == 0, "order should fail");
   }
 
@@ -587,7 +590,7 @@ contract TakerOperationsTest is MangroveTest {
     quote.approve($(mgv), type(uint).max);
 
     (uint successes, uint takerGot,,,) =
-      mgv.snipes($(base), $(quote), wrap_dynamic([ofr, takerWants, takerGives, 100_000]), true);
+      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, takerWants, takerGives, 100_000]), true);
     assertEq(successes, 1, "order should succeed");
     assertEq(takerGot, takerWants, "wrong takerGot");
     // Taker does not give all it has since it overestimates price - assertEq(takerGave, takerGives, "wrong takerGave");
@@ -600,14 +603,14 @@ contract TakerOperationsTest is MangroveTest {
     quote.approve($(mgv), 1 ether);
     expectFrom($(mgv));
     emit OfferFail($(base), $(quote), ofr, $(this), 1 ether, 1 ether, "mgv/makerRevert");
-    mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
+    mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
   }
 
   function test_snipe_on_higher_price_fails() public {
     uint ofr = mkr.newOffer(1 ether, 1 ether, 100_000, 0);
     quote.approve($(mgv), 0.5 ether);
 
-    (uint successes,,,,) = mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 1 ether, 0.5 ether, 100_000]), true);
+    (uint successes,,,,) = mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 0.5 ether, 100_000]), true);
     assertTrue(successes == 0, "Order should fail when order price is higher than offer");
   }
 
@@ -615,7 +618,7 @@ contract TakerOperationsTest is MangroveTest {
     uint ofr = mkr.newOffer(1 ether, 1 ether, 100_000, 0);
     quote.approve($(mgv), 1 ether);
 
-    (uint successes,,,,) = mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
+    (uint successes,,,,) = mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
     assertTrue(successes == 0, "Order should fail when order gas is higher than offer");
   }
 
@@ -624,7 +627,7 @@ contract TakerOperationsTest is MangroveTest {
     quote.approve($(mgv), 100 ether);
 
     bytes memory cd = abi.encodeWithSelector(
-      mgv.snipes.selector, $(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true
+      mgv.snipesByVolume.selector, $(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true
     );
 
     (bool noRevert, bytes memory data) = $(mgv).call{gas: 130000}(cd);
@@ -641,7 +644,7 @@ contract TakerOperationsTest is MangroveTest {
     uint balTaker = base.balanceOf($(this));
     uint balMaker = quote.balanceOf(address(mkr));
 
-    (uint successes,,,,) = mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 1 ether, 2 ether, 100_000]), true);
+    (uint successes,,,,) = mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 2 ether, 100_000]), true);
     assertTrue(successes == 1, "Order should succeed when order price is lower than offer");
     // checking order was executed at Maker's price
     assertEq(base.balanceOf($(this)) - balTaker, 1 ether, "Incorrect delivered amount (taker)");
@@ -717,7 +720,7 @@ contract TakerOperationsTest is MangroveTest {
     uint mkrBal = base.balanceOf(address(mkr));
     uint ofr = mkr.newOffer(0.1 ether, 0.1 ether, 50_000, 0);
 
-    (uint successes,,,,) = mgv.snipes($(base), $(quote), wrap_dynamic([ofr, 0, 1 ether, 50_000]), true);
+    (uint successes,,,,) = mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 0, 1 ether, 50_000]), true);
     assertTrue(successes == 1, "snipe should succeed");
     assertEq(mgv.best($(base), $(quote)), 0, "offer should be gone");
     assertEq(base.balanceOf(address(mkr)), mkrBal, "mkr balance should not change");
@@ -728,7 +731,7 @@ contract TakerOperationsTest is MangroveTest {
     quote.approve($(mgv), 1 ether);
     uint ofr = mkr.newOffer(1 ether, 1 ether, 120_000, 0);
     vm.expectRevert("mgv/notEnoughGasForMakerTrade");
-    mgv.snipes{gas: 120_000}($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 120_000]), true);
+    mgv.snipesByVolume{gas: 120_000}($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 120_000]), true);
   }
 
   function test_unsafe_gas_left_fails_posthook() public {
@@ -736,7 +739,7 @@ contract TakerOperationsTest is MangroveTest {
     quote.approve($(mgv), 1 ether);
     uint ofr = mkr.newOffer(1 ether, 1 ether, 120_000, 0);
     vm.expectRevert("mgv/notEnoughGasForMakerPosthook");
-    mgv.snipes{gas: 280_000}($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 120_000]), true);
+    mgv.snipesByVolume{gas: 280_000}($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 120_000]), true);
   }
 
   // FIXME Make a token that goes out of gas on transfer to taker
@@ -746,7 +749,7 @@ contract TakerOperationsTest is MangroveTest {
   //   quote.approve($(mgv), 1 ether);
   //   uint ofr = mkr.newOffer(1 ether, 1 ether, 220_000, 0);
   //   vm.expectRevert("mgv/MgvFailToPayTaker");
-  //   mgv.snipes{gas: 240_000}($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 220_000]), true);
+  //   mgv.snipesByVolume{gas: 240_000}($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 220_000]), true);
   // }
 
   function test_marketOrder_on_empty_book_does_not_revert() public {

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.10;
 
 import "mgv_test/lib/MangroveTest.sol";
+import {MgvHelpers} from "mgv_src/MgvHelpers.sol";
 
 /* The following constructs an ERC20 with a transferFrom callback method,
    and a TestTaker which throws away any funds received upon getting
@@ -56,7 +57,7 @@ contract TakerOperationsTest is MangroveTest {
     quote.blacklists($(this));
 
     vm.expectRevert("mgv/takerTransferFail");
-    mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
+    MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
     assertEq(weiBalanceBefore, mgv.balanceOf($(this)), "Taker should not take bounty");
   }
 
@@ -68,7 +69,7 @@ contract TakerOperationsTest is MangroveTest {
     base.blacklists($(this));
 
     vm.expectRevert("mgv/MgvFailToPayTaker");
-    mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
+    MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
     assertEq(weiBalanceBefore, mgv.balanceOf($(this)), "Taker should not take bounty");
   }
 
@@ -78,7 +79,7 @@ contract TakerOperationsTest is MangroveTest {
     mkr.expect("mgv/tradeSuccess"); // trade should be OK on the maker side
     quote.approve($(mgv), 1 ether);
     (uint successes, uint got, uint gave,,) =
-      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 0.5 ether, 100_000]), false);
+      MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 1 ether, 0.5 ether, 100_000]), false);
     assertTrue(successes == 0, "Snipe should fail");
     assertEq(weiBalanceBefore, mgv.balanceOf($(this)), "Taker should not take bounty");
     assertTrue((got == gave && gave == 0), "Taker should not give or take anything");
@@ -89,7 +90,7 @@ contract TakerOperationsTest is MangroveTest {
     quote.approve($(mgv), 1 ether);
     uint ofr = mkr.newOffer(9, 10, 100_000, 0);
     uint oldBal = quote.balanceOf($(this));
-    mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1, 15 ether, 100_000]), true);
+    MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 1, 15 ether, 100_000]), true);
     uint newBal = quote.balanceOf($(this));
     assertGt(oldBal, newBal, "oldBal should be strictly higher");
   }
@@ -99,7 +100,7 @@ contract TakerOperationsTest is MangroveTest {
     mkr.expect("mgv/tradeSuccess"); // trade should be OK on the maker side
     quote.approve($(mgv), 1 ether);
     (uint successes, uint got, uint gave,,) =
-      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 0.5 ether, 1 ether, 100_000]), true);
+      MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 0.5 ether, 1 ether, 100_000]), true);
     assertTrue(successes == 1, "Snipe should not fail");
     assertEq(got, 0.5 ether, "Taker did not get correct amount");
     assertEq(gave, 0.5 ether, "Taker did not give correct amount");
@@ -127,7 +128,7 @@ contract TakerOperationsTest is MangroveTest {
     expectFrom($(mgv));
     emit OrderComplete($(base), $(quote), $(this), 2.3 ether, 2.3 ether, 0, 0);
 
-    (uint successes, uint got, uint gave,,) = mgv.snipesByVolume($(base), $(quote), targets, true);
+    (uint successes, uint got, uint gave,,) = MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), targets, true);
     assertTrue(successes == 3, "Snipes should not fail");
     assertEq(got, 2.3 ether, "Taker did not get correct amount");
     assertEq(gave, 2.3 ether, "Taker did not give correct amount");
@@ -147,7 +148,7 @@ contract TakerOperationsTest is MangroveTest {
     emit Transfer($(mgv), address(mkr), 0);
 
     (uint successes, uint got, uint gave,,) =
-      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 0, 0, 100_000]), true);
+      MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 0, 0, 100_000]), true);
     assertTrue(successes == 1, "Snipe should not fail");
     assertEq(got, 0 ether, "Taker had too much");
     assertEq(gave, 0 ether, "Taker gave too much");
@@ -165,7 +166,7 @@ contract TakerOperationsTest is MangroveTest {
        We should still only receive 0.1 eth */
 
     (uint successes, uint got, uint gave,,) =
-      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 0.1 ether, 1, 100_000]), true);
+      MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 0.1 ether, 1, 100_000]), true);
     assertTrue(successes == 1, "Snipe should not fail");
     assertApproxEqRel(got, 0.1 ether, relError(10), "Wrong got value");
     assertApproxEqRel(gave, 1, relError(10), "Wrong gave value");
@@ -183,7 +184,7 @@ contract TakerOperationsTest is MangroveTest {
        Here despite asking for .1eth the offer gives 1eth for 0 so we should receive 1eth. */
 
     (uint successes, uint got, uint gave,,) =
-      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 0.1 ether, 0.01 ether, 100_000]), false);
+      MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 0.1 ether, 0.01 ether, 100_000]), false);
     assertTrue(successes == 1, "Snipe should not fail");
     assertApproxEqRel(got, 1 ether, relError(10), "Wrong got value");
     assertApproxEqRel(gave, 0.01 ether, relError(10), "Wrong gave value");
@@ -197,7 +198,7 @@ contract TakerOperationsTest is MangroveTest {
     quote.approve($(mgv), 1 ether);
 
     (uint successes, uint got, uint gave,,) =
-      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 0, 0, 100_000]), false);
+      MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 0, 0, 100_000]), false);
     assertTrue(successes == 1, "Snipe should not fail");
     assertEq(got, 0 ether, "Taker had too much");
     assertEq(gave, 0 ether, "Taker gave too much");
@@ -210,7 +211,7 @@ contract TakerOperationsTest is MangroveTest {
     quote.approve($(mgv), 1 ether);
 
     (uint successes, uint got, uint gave,,) =
-      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 0.5 ether, 1 ether, 100_000]), false);
+      MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 0.5 ether, 1 ether, 100_000]), false);
     assertTrue(successes == 1, "Snipe should not fail");
     assertEq(got, 1 ether, "Taker did not get correct amount");
     assertEq(gave, 1 ether, "Taker did not get correct amount");
@@ -276,7 +277,7 @@ contract TakerOperationsTest is MangroveTest {
     expectFrom($(mgv));
     emit OfferFail($(base), $(quote), ofr, $(this), 1 ether, 1 ether, "mgv/makerTransferFail");
     (uint successes, uint takerGot, uint takerGave,,) =
-      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
+      MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
     assertTrue(successes == 0, "Snipe should fail");
@@ -291,7 +292,7 @@ contract TakerOperationsTest is MangroveTest {
     quote.approve($(mgv), 1 ether);
 
     vm.expectRevert("mgv/sendPenaltyReverted");
-    mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
+    MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
   }
 
   function test_taker_reimbursed_if_maker_is_blacklisted_for_base() public {
@@ -307,7 +308,7 @@ contract TakerOperationsTest is MangroveTest {
     expectFrom($(mgv));
     emit OfferFail($(base), $(quote), ofr, $(this), 1 ether, 1 ether, "mgv/makerTransferFail");
     (uint successes, uint takerGot, uint takerGave,,) =
-      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
+      MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
     assertTrue(successes == 0, "Snipe should fail");
@@ -330,7 +331,7 @@ contract TakerOperationsTest is MangroveTest {
 
     emit OfferFail($(base), $(quote), ofr, $(this), 1 ether, 1 ether, "mgv/makerReceiveFail");
     (uint successes, uint takerGot, uint takerGave,,) =
-      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
+      MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
     assertTrue(successes == 0, "Snipe should fail");
@@ -345,7 +346,7 @@ contract TakerOperationsTest is MangroveTest {
     uint beforeWei = $(this).balance;
 
     (uint successes, uint takerGot, uint takerGave,,) =
-      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 0, 0, 100_000]), true);
+      MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 0, 0, 100_000]), true);
     assertTrue(successes == 0, "Snipe should fail");
     assertTrue(takerGot == takerGave && takerGave == 0, "Transaction data should be 0");
     assertTrue($(this).balance > beforeWei, "Taker was not compensated");
@@ -361,7 +362,7 @@ contract TakerOperationsTest is MangroveTest {
     expectFrom($(mgv));
     emit OfferFail($(base), $(quote), ofr, $(this), 1 ether, 1 ether, "mgv/makerRevert");
     (uint successes, uint takerGot, uint takerGave,,) =
-      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
+      MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
     assertTrue(successes == 0, "Snipe should fail");
@@ -377,7 +378,7 @@ contract TakerOperationsTest is MangroveTest {
     uint ofr = mkr.newOffer(1 ether, 1 ether, 50_000, 0);
     quote.approve($(mgv), 1 ether);
     uint shouldGet = reader.minusFee($(base), $(quote), 1 ether);
-    mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
+    MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
     assertEq(base.balanceOf($(this)) - balTaker, shouldGet, "Incorrect delivered amount");
   }
 
@@ -385,7 +386,7 @@ contract TakerOperationsTest is MangroveTest {
     uint balTaker = base.balanceOf($(this));
     uint ofr = mkr.newOffer(1 ether, 1 ether, 50_000, 0);
     quote.approve($(mgv), 1 ether);
-    mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
+    MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
     assertEq(base.balanceOf($(this)) - balTaker, 1 ether, "Incorrect delivered amount");
   }
 
@@ -394,7 +395,7 @@ contract TakerOperationsTest is MangroveTest {
     base.approve($(mgv), 1 ether);
 
     vm.expectRevert("mgv/takerTransferFail");
-    mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
+    MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
   }
 
   function test_simple_snipe() public {
@@ -408,7 +409,7 @@ contract TakerOperationsTest is MangroveTest {
     expectFrom($(mgv));
     emit OfferSuccess($(base), $(quote), ofr, $(this), 1 ether, offer.tick().inboundFromOutbound(1 ether));
     (uint successes, uint takerGot, uint takerGave,,) =
-      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1.1 ether, 50_000]), true);
+      MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 1 ether, 1.1 ether, 50_000]), true);
     assertTrue(successes == 1, "Snipe should succeed");
     assertApproxEqRel(base.balanceOf($(this)) - balTaker, 1 ether, relError(10), "Incorrect delivered amount (taker)");
     assertApproxEqRel(
@@ -465,7 +466,7 @@ contract TakerOperationsTest is MangroveTest {
     quote.approve($(mgv), 10 ether);
 
     (uint successes, uint takerGot, uint takerGave,,) =
-      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 2 ether, 10, 300_000]), false);
+      MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 2 ether, 10, 300_000]), false);
     assertEq(successes, 1, "snipe should succeed");
     // console.log("offer wants",pair.offers(ofr).wants());
     // console.log("offer tick",pair.offers(ofr).tick().toString());
@@ -501,7 +502,7 @@ contract TakerOperationsTest is MangroveTest {
     base.approve($(mgv), 1 ether); // not necessary since no fee
 
     vm.expectRevert("mgv/takerTransferFail");
-    mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 2 ether, 100 ether, 100_000]), true);
+    MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 2 ether, 100 ether, 100_000]), true);
   }
 
   function test_maker_has_not_enough_base_fails_order() public {
@@ -518,7 +519,7 @@ contract TakerOperationsTest is MangroveTest {
       $(base), $(quote), ofr, $(this), takerWants, offer.tick().inboundFromOutbound(takerWants), "mgv/makerTransferFail"
     );
     (uint successes,,,,) =
-      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 50 ether, 0.5 ether, 100_000]), true);
+      MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 50 ether, 0.5 ether, 100_000]), true);
     assertTrue(successes == 0, "order should fail");
   }
 
@@ -590,7 +591,7 @@ contract TakerOperationsTest is MangroveTest {
     quote.approve($(mgv), type(uint).max);
 
     (uint successes, uint takerGot,,,) =
-      mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, takerWants, takerGives, 100_000]), true);
+      MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, takerWants, takerGives, 100_000]), true);
     assertEq(successes, 1, "order should succeed");
     assertEq(takerGot, takerWants, "wrong takerGot");
     // Taker does not give all it has since it overestimates price - assertEq(takerGave, takerGives, "wrong takerGave");
@@ -603,14 +604,15 @@ contract TakerOperationsTest is MangroveTest {
     quote.approve($(mgv), 1 ether);
     expectFrom($(mgv));
     emit OfferFail($(base), $(quote), ofr, $(this), 1 ether, 1 ether, "mgv/makerRevert");
-    mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
+    MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
   }
 
   function test_snipe_on_higher_price_fails() public {
     uint ofr = mkr.newOffer(1 ether, 1 ether, 100_000, 0);
     quote.approve($(mgv), 0.5 ether);
 
-    (uint successes,,,,) = mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 0.5 ether, 100_000]), true);
+    (uint successes,,,,) =
+      MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 1 ether, 0.5 ether, 100_000]), true);
     assertTrue(successes == 0, "Order should fail when order price is higher than offer");
   }
 
@@ -618,7 +620,8 @@ contract TakerOperationsTest is MangroveTest {
     uint ofr = mkr.newOffer(1 ether, 1 ether, 100_000, 0);
     quote.approve($(mgv), 1 ether);
 
-    (uint successes,,,,) = mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
+    (uint successes,,,,) =
+      MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 50_000]), true);
     assertTrue(successes == 0, "Order should fail when order gas is higher than offer");
   }
 
@@ -626,9 +629,9 @@ contract TakerOperationsTest is MangroveTest {
     uint ofr = mkr.newOffer(1 ether, 1 ether, 100_000, 0);
     quote.approve($(mgv), 100 ether);
 
-    bytes memory cd = abi.encodeWithSelector(
-      mgv.snipesByVolume.selector, $(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true
-    );
+    uint[4][] memory targets =
+      MgvHelpers.convertSnipeTargetsToTicks(wrap_dynamic([ofr, 1 ether, 1 ether, 100_000]), true);
+    bytes memory cd = abi.encodeCall(mgv.snipes, ($(base), $(quote), targets, true));
 
     (bool noRevert, bytes memory data) = $(mgv).call{gas: 130000}(cd);
     if (noRevert) {
@@ -644,7 +647,8 @@ contract TakerOperationsTest is MangroveTest {
     uint balTaker = base.balanceOf($(this));
     uint balMaker = quote.balanceOf(address(mkr));
 
-    (uint successes,,,,) = mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 1 ether, 2 ether, 100_000]), true);
+    (uint successes,,,,) =
+      MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 1 ether, 2 ether, 100_000]), true);
     assertTrue(successes == 1, "Order should succeed when order price is lower than offer");
     // checking order was executed at Maker's price
     assertEq(base.balanceOf($(this)) - balTaker, 1 ether, "Incorrect delivered amount (taker)");
@@ -720,7 +724,8 @@ contract TakerOperationsTest is MangroveTest {
     uint mkrBal = base.balanceOf(address(mkr));
     uint ofr = mkr.newOffer(0.1 ether, 0.1 ether, 50_000, 0);
 
-    (uint successes,,,,) = mgv.snipesByVolume($(base), $(quote), wrap_dynamic([ofr, 0, 1 ether, 50_000]), true);
+    (uint successes,,,,) =
+      MgvHelpers.snipesByVolume($(mgv), $(base), $(quote), wrap_dynamic([ofr, 0, 1 ether, 50_000]), true);
     assertTrue(successes == 1, "snipe should succeed");
     assertEq(mgv.best($(base), $(quote)), 0, "offer should be gone");
     assertEq(base.balanceOf(address(mkr)), mkrBal, "mkr balance should not change");
@@ -730,16 +735,21 @@ contract TakerOperationsTest is MangroveTest {
     mgv.setGasbase($(base), $(quote), 1);
     quote.approve($(mgv), 1 ether);
     uint ofr = mkr.newOffer(1 ether, 1 ether, 120_000, 0);
+    uint[4][] memory targets =
+      MgvHelpers.convertSnipeTargetsToTicks(wrap_dynamic([ofr, 1 ether, 1 ether, 120_000]), true);
     vm.expectRevert("mgv/notEnoughGasForMakerTrade");
-    mgv.snipesByVolume{gas: 120_000}($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 120_000]), true);
+    mgv.snipes{gas: 120_000}($(base), $(quote), targets, true);
   }
 
   function test_unsafe_gas_left_fails_posthook() public {
     mgv.setGasbase($(base), $(quote), 1);
     quote.approve($(mgv), 1 ether);
     uint ofr = mkr.newOffer(1 ether, 1 ether, 120_000, 0);
+
+    uint[4][] memory targets =
+      MgvHelpers.convertSnipeTargetsToTicks(wrap_dynamic([ofr, 1 ether, 1 ether, 120_000]), true);
     vm.expectRevert("mgv/notEnoughGasForMakerPosthook");
-    mgv.snipesByVolume{gas: 280_000}($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 120_000]), true);
+    mgv.snipes{gas: 280_000}($(base), $(quote), targets, true);
   }
 
   // FIXME Make a token that goes out of gas on transfer to taker
@@ -749,7 +759,7 @@ contract TakerOperationsTest is MangroveTest {
   //   quote.approve($(mgv), 1 ether);
   //   uint ofr = mkr.newOffer(1 ether, 1 ether, 220_000, 0);
   //   vm.expectRevert("mgv/MgvFailToPayTaker");
-  //   mgv.snipesByVolume{gas: 240_000}($(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 220_000]), true);
+  //   MgvHelpers.snipesByVolume{gas: 240_000}($(mgv), $(base), $(quote), wrap_dynamic([ofr, 1 ether, 1 ether, 220_000]), true);
   // }
 
   function test_marketOrder_on_empty_book_does_not_revert() public {

--- a/test/lib/agents/TestTaker.sol
+++ b/test/lib/agents/TestTaker.sol
@@ -6,6 +6,7 @@ import {AbstractMangrove} from "mgv_src/AbstractMangrove.sol";
 import {IERC20, ITaker} from "mgv_src/MgvLib.sol";
 import {Script2} from "mgv_lib/Script2.sol";
 import {TransferLib} from "mgv_lib/TransferLib.sol";
+import {MgvHelpers} from "mgv_src/MgvHelpers.sol";
 
 contract TestTaker is ITaker, Script2 {
   AbstractMangrove _mgv;
@@ -41,7 +42,7 @@ contract TestTaker is ITaker, Script2 {
   function takeWithInfo(uint offerId, uint takerWants) external returns (bool, uint, uint, uint, uint) {
     uint[4][] memory targets = wrap_dynamic([offerId, takerWants, type(uint96).max, type(uint48).max]);
     (uint successes, uint got, uint gave, uint totalPenalty, uint feePaid) =
-      _mgv.snipesByVolume(_base, _quote, targets, true);
+      MgvHelpers.snipesByVolume(address(_mgv), _base, _quote, targets, true);
     return (successes == 1, got, gave, totalPenalty, feePaid);
     //return taken;
   }
@@ -56,7 +57,7 @@ contract TestTaker is ITaker, Script2 {
     uint gasreq
   ) external returns (bool) {
     uint[4][] memory targets = wrap_dynamic([offerId, takerWants, takerGives, gasreq]);
-    (uint successes,,,,) = __mgv.snipesByVolume(__base, __quote, targets, true);
+    (uint successes,,,,) = MgvHelpers.snipesByVolume(address(__mgv), __base, __quote, targets, true);
     return successes == 1;
   }
 

--- a/test/lib/agents/TestTaker.sol
+++ b/test/lib/agents/TestTaker.sol
@@ -40,7 +40,8 @@ contract TestTaker is ITaker, Script2 {
 
   function takeWithInfo(uint offerId, uint takerWants) external returns (bool, uint, uint, uint, uint) {
     uint[4][] memory targets = wrap_dynamic([offerId, takerWants, type(uint96).max, type(uint48).max]);
-    (uint successes, uint got, uint gave, uint totalPenalty, uint feePaid) = _mgv.snipes(_base, _quote, targets, true);
+    (uint successes, uint got, uint gave, uint totalPenalty, uint feePaid) =
+      _mgv.snipesByVolume(_base, _quote, targets, true);
     return (successes == 1, got, gave, totalPenalty, feePaid);
     //return taken;
   }
@@ -55,7 +56,7 @@ contract TestTaker is ITaker, Script2 {
     uint gasreq
   ) external returns (bool) {
     uint[4][] memory targets = wrap_dynamic([offerId, takerWants, takerGives, gasreq]);
-    (uint successes,,,,) = __mgv.snipes(__base, __quote, targets, true);
+    (uint successes,,,,) = __mgv.snipesByVolume(__base, __quote, targets, true);
     return successes == 1;
   }
 

--- a/test/script/core/deployers/BaseMangroveDeployer.t.sol
+++ b/test/script/core/deployers/BaseMangroveDeployer.t.sol
@@ -13,7 +13,6 @@ import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
 import {MgvCleaner} from "mgv_src/periphery/MgvCleaner.sol";
 import {MgvOracle} from "mgv_src/periphery/MgvOracle.sol";
 import {IMangrove} from "mgv_src/IMangrove.sol";
-import "mgv_lib/Debug.sol";
 
 /**
  * Base test suite for [Chain]MangroveDeployer scripts

--- a/test/script/core/deployers/BaseMangroveDeployer.t.sol
+++ b/test/script/core/deployers/BaseMangroveDeployer.t.sol
@@ -7,11 +7,13 @@ import {MangroveDeployer} from "mgv_script/core/deployers/MangroveDeployer.s.sol
 import {Test2, Test} from "mgv_lib/Test2.sol";
 
 import {MgvStructs, Density} from "mgv_src/MgvLib.sol";
+import {MgvHelpers} from "mgv_src/MgvHelpers.sol";
 import {Mangrove} from "mgv_src/Mangrove.sol";
 import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
 import {MgvCleaner} from "mgv_src/periphery/MgvCleaner.sol";
 import {MgvOracle} from "mgv_src/periphery/MgvOracle.sol";
 import {IMangrove} from "mgv_src/IMangrove.sol";
+import "mgv_lib/Debug.sol";
 
 /**
  * Base test suite for [Chain]MangroveDeployer scripts
@@ -62,8 +64,10 @@ abstract contract BaseMangroveDeployerTest is Deployer, Test2 {
     // Cleaner - verify mgv is used
     MgvCleaner cleaner = mgvDeployer.cleaner();
     uint[4][] memory targets = wrap_dynamic([uint(0), 0, 0, 0]);
+    uint[4][] memory convertedTargets = MgvHelpers.convertSnipeTargetsToTicks(targets, true);
+
     vm.expectCall(
-      address(mgv), abi.encodeCall(mgv.snipesForByVolume, (outbound_tkn, inbound_tkn, targets, true, address(this)))
+      address(mgv), abi.encodeCall(mgv.snipesFor, (outbound_tkn, inbound_tkn, convertedTargets, true, address(this)))
     );
     vm.expectRevert("mgv/inactive");
     cleaner.collect(outbound_tkn, inbound_tkn, targets, true);

--- a/test/script/core/deployers/BaseMangroveDeployer.t.sol
+++ b/test/script/core/deployers/BaseMangroveDeployer.t.sol
@@ -63,7 +63,7 @@ abstract contract BaseMangroveDeployerTest is Deployer, Test2 {
     MgvCleaner cleaner = mgvDeployer.cleaner();
     uint[4][] memory targets = wrap_dynamic([uint(0), 0, 0, 0]);
     vm.expectCall(
-      address(mgv), abi.encodeCall(mgv.snipesFor, (outbound_tkn, inbound_tkn, targets, true, address(this)))
+      address(mgv), abi.encodeCall(mgv.snipesForByVolume, (outbound_tkn, inbound_tkn, targets, true, address(this)))
     );
     vm.expectRevert("mgv/inactive");
     cleaner.collect(outbound_tkn, inbound_tkn, targets, true);


### PR DESCRIPTION
Snipes are now tick-based

New file: `MgvHelpers.sol` gives tools to call `snipesByVolume` or to manually convert a `targets` array to ticks. These utilities are now used by tests.