### PR TITLE
refactor: Simplify offer price match flow

### DIFF
--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -208,7 +208,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
       `mgvData` should not be exploitable by the maker! */
         bytes32 mgvData;
 
-        /* Load additional information about the offer. We don't do it earlier to save one storage read in case `proceed` was false. */
+        /* Load additional information about the offer. */
         sor.offerDetail = pair.offerData[sor.offerId].detail;
 
         /* `execute` will adjust `sor.wants`,`sor.gives`, and may attempt to execute the offer if its price is low enough. It is crucial that an error due to `taker` triggers a revert. That way, [`mgvData`](#MgvOfferTaking/statusCodes) not in `["mgv/notExecuted","mgv/tradeSuccess"]` means the failure is the maker's fault. */
@@ -251,7 +251,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
         postExecute(mor, sor, gasused, makerData, mgvData);
 
         /* #### Case 2 : End of market order */
-        /* If `proceed` is false, the taker has gotten its requested volume, no more offers match, or we have reached the end of the book, we conclude the market order. */
+        /* The taker has gotten its requested volume, no more offers match, or we have reached the end of the book, we conclude the market order. */
       } else {
         /* During the market order, all executed offers have been removed from the book. We end by stitching together the `best` offer pointer and the new best offer. */
 

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -238,7 +238,6 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
         sor.offer = pair.offerData[sor.offerId].offer;
 
-        /* note that internalMarketOrder may be called twice with same offerId, but in that case `proceed` will be false! */
         internalMarketOrder(pair, mor, sor);
 
         /* Restore `sor` values from before recursive call */


### PR DESCRIPTION
Previously, `execute` checked that the offer to be executed had a sufficiently low price. If this wasn't the case, `"mgv/notExecuted"` was returned and used to tell the next recursive call to `internalMarketOrder` that the order was finished.

This flow was somewhat convoluted: The decision on which offers to execute was distributed between multiple functions, despite only the outermost of those actually needing it. And because of this, the execute-offer path of `internalMarketOrder` had two if-stmts just to make sure it **did not** handle an offer that shouldn't be executed.

This commit instead moves the check out one level to `internalMarketOrder` and `clean`. This simplifies the code of all involved functions and reduces gas usage.

The tradeoff is that the price check code is duplicated and that the caller of `execute` must ensure that the taker is not matched with an offer that is too expensive. However, this is seems acceptable as the duplicated code is a trivial function call and `execute` is `internal`.