### PR TITLE
Migrate `snipes` and `snipesFor` in tests to `cleanByImpersonation` or `marketOrder*`

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -10,7 +10,7 @@ cache_path='cache'
 fs_permissions = [{ access = "read-write", path = "./addresses/"}, { access = "read-write", path = "./analytics/"}, { access = "read", path = "./out/" }]
 solc_version="0.8.18"
 ffi=true
-# optimizer=true
+# optimizer=false
 # optimizer_runs=200
 # via_ir=true
 

--- a/src/IMangrove.sol
+++ b/src/IMangrove.sol
@@ -216,7 +216,7 @@ interface IMangrove {
     address inbound_tkn,
     MgvLib.CleanTarget[] calldata targets,
     address taker
-  ) external returns (uint successes, uint bal);
+  ) external returns (uint successes, uint bounty);
 
   function updateOfferByVolume(
     address outbound_tkn,

--- a/test/core/Gatekeeping.t.sol
+++ b/test/core/Gatekeeping.t.sol
@@ -7,11 +7,12 @@ import {MgvStructs, MAX_TICK, MIN_TICK} from "mgv_src/MgvLib.sol";
 import {DensityLib} from "mgv_lib/DensityLib.sol";
 
 // In these tests, the testing contract is the market maker.
-contract GatekeepingTest is IMaker, MangroveTest {
+contract GatekeepingTest is MangroveTest {
   receive() external payable {}
 
   TestTaker tkr;
   TestMaker mkr;
+  TestMaker other_mkr;
   TestMaker dual_mkr;
   address notAdmin;
 
@@ -21,14 +22,17 @@ contract GatekeepingTest is IMaker, MangroveTest {
 
     tkr = setupTaker($(base), $(quote), "taker[$(A),$(B)]");
     mkr = setupMaker($(base), $(quote), "maker[$(A),$(B)]");
+    other_mkr = setupMaker($(base), $(quote), "other_maker[$(A),$(B)]");
     dual_mkr = setupMaker($(quote), $(base), "maker[$(B),$(A)]");
 
     mkr.provisionMgv(5 ether);
+    other_mkr.provisionMgv(5 ether);
     dual_mkr.provisionMgv(5 ether);
 
     deal($(quote), address(tkr), 1 ether);
     deal($(quote), address(mkr), 1 ether);
     deal($(base), address(dual_mkr), 1 ether);
+    deal($(quote), $(other_mkr), 1 ether);
 
     tkr.approveMgv(quote, 1 ether);
 
@@ -329,65 +333,51 @@ contract GatekeepingTest is IMaker, MangroveTest {
     );
   }
 
-  /* # Internal IMaker setup */
-
-  bytes trade_cb;
-  bytes posthook_cb;
-
-  // maker's trade fn for the mgv
-  function makerExecute(MgvLib.SingleOrder calldata) external override returns (bytes32 ret) {
-    ret; // silence unused function parameter
-    bool success;
-    if (trade_cb.length > 0) {
-      (success,) = $(this).call(trade_cb);
-      assertTrue(success, "makerExecute callback must work");
-    }
-    return "";
-  }
-
-  function makerPosthook(MgvLib.SingleOrder calldata order, MgvLib.OrderResult calldata result) external override {
-    bool success;
-    order; // silence compiler warning
-    if (posthook_cb.length > 0) {
-      (success,) = $(this).call(posthook_cb);
-      bool tradeResult = (result.mgvData == "mgv/tradeSuccess");
-      assertTrue(success == tradeResult, "makerPosthook callback must work");
-    }
-  }
-
   /* # Reentrancy */
 
   /* New Offer failure */
 
   function newOfferKO() external {
     vm.expectRevert("mgv/reentrancyLocked");
-    mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 30_000, 0);
+    mkr.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 30_000);
   }
 
   function test_newOffer_on_reentrancy_fails() public {
-    mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 100_000, 0);
-    trade_cb = abi.encodeCall(this.newOfferKO, ());
+    mkr.approveMgv(base, 1 ether);
+    deal($(base), $(mkr), 1 ether);
+
+    uint ofr = mkr.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 100_000);
+    mkr.setTradeCallback($(this), abi.encodeCall(this.newOfferKO, ()));
     assertTrue(tkr.marketOrderWithSuccess(1 ether), "take must succeed or test is void");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
   }
 
   /* New Offer success */
 
   // ! may be called with inverted _base and _quote
   function newOfferOK(address _base, address _quote) external {
-    mgv.newOfferByVolume(_base, _quote, 1 ether, 1 ether, 30_000, 0);
+    mkr.newOfferByVolume(_base, _quote, 1 ether, 1 ether, 30_000);
   }
 
   function test_newOffer_on_reentrancy_succeeds() public {
-    mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 200_000, 0);
-    trade_cb = abi.encodeCall(this.newOfferOK, ($(quote), $(base)));
+    mkr.approveMgv(base, 1 ether);
+    deal($(base), $(mkr), 1 ether);
+
+    uint ofr = mkr.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 200_000);
+    mkr.setTradeCallback($(this), abi.encodeCall(this.newOfferOK, ($(quote), $(base))));
     assertTrue(tkr.marketOrderWithSuccess(1 ether), "take must succeed or test is void");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertTrue(mgv.best($(quote), $(base)) == 1, "newOfferByVolume on swapped pair must work");
   }
 
   function test_newOffer_on_posthook_succeeds() public {
-    mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 200_000, 0);
-    posthook_cb = abi.encodeCall(this.newOfferOK, ($(base), $(quote)));
+    mkr.approveMgv(base, 1 ether);
+    deal($(base), $(mkr), 1 ether);
+
+    uint ofr = mkr.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 200_000);
+    mkr.setPosthookCallback($(this), abi.encodeCall(this.newOfferOK, ($(base), $(quote))));
     assertTrue(tkr.marketOrderWithSuccess(1 ether), "take must succeed or test is void");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertTrue(mgv.best($(base), $(quote)) == 2, "newOfferByVolume on posthook must work");
   }
 
@@ -395,76 +385,99 @@ contract GatekeepingTest is IMaker, MangroveTest {
 
   function updateOfferKO(uint ofr) external {
     vm.expectRevert("mgv/reentrancyLocked");
-    mgv.updateOfferByVolume($(base), $(quote), 1 ether, 2 ether, 35_000, 0, ofr);
+    mkr.updateOfferByVolume($(base), $(quote), 1 ether, 2 ether, 35_000, ofr);
   }
 
   function test_updateOffer_on_reentrancy_fails() public {
-    uint ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 100_000, 0);
-    trade_cb = abi.encodeCall(this.updateOfferKO, (ofr));
+    mkr.approveMgv(base, 1 ether);
+    deal($(base), $(mkr), 1 ether);
+
+    uint ofr = mkr.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 100_000);
+    mkr.setTradeCallback($(this), abi.encodeCall(this.updateOfferKO, (ofr)));
     assertTrue(tkr.marketOrderWithSuccess(1 ether), "take must succeed or test is void");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
   }
 
   /* Update offer success */
 
   // ! may be called with inverted _base and _quote
   function updateOfferOK(address _base, address _quote, uint ofr) external {
-    mgv.updateOfferByVolume(_base, _quote, 1 ether, 2 ether, 35_000, 0, ofr);
+    mkr.updateOfferByVolume(_base, _quote, 1 ether, 2 ether, 35_000, ofr);
   }
 
   function test_updateOffer_on_reentrancy_succeeds() public {
-    uint other_ofr = mgv.newOfferByVolume($(quote), $(base), 1 ether, 1 ether, 100_000, 0);
+    mkr.approveMgv(base, 1 ether);
+    deal($(base), $(mkr), 1 ether);
 
-    trade_cb = abi.encodeCall(this.updateOfferOK, ($(quote), $(base), other_ofr));
-    mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 400_000, 0);
-    assertTrue(tkr.marketOrderWithSuccess(1 ether), "take must succeed or test is void");
-    assertTrue(
-      mgv.offerDetails($(quote), $(base), other_ofr).gasreq() == 35_000, "updateOffer on swapped pair must work"
-    );
+    uint other_ofr = mkr.newOfferByVolume($(quote), $(base), 1 ether, 1 ether, 100_000);
+    mkr.setTradeCallback($(this), abi.encodeCall(this.updateOfferOK, ($(quote), $(base), other_ofr)));
+
+    uint ofr = mkr.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 400_000);
+    assertTrue(tkr.marketOrderWithSuccess(1 ether), "market order must succeed or test is void");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
+    assertEq(mgv.offerDetails($(quote), $(base), other_ofr).gasreq(), 35_000, "updateOffer on swapped pair must work");
   }
 
   function test_updateOffer_on_posthook_succeeds() public {
-    uint other_ofr = mgv.newOfferByTick($(base), $(quote), 1, 1 ether, 100_000, 0);
-    posthook_cb = abi.encodeCall(this.updateOfferOK, ($(base), $(quote), other_ofr));
-    mgv.newOfferByTick($(base), $(quote), 0, 1 ether, 300_000, 0);
-    tkr.marketOrderWithSuccess(1 ether);
-    assertTrue(mgv.offerDetails($(base), $(quote), other_ofr).gasreq() == 35_000, "updateOffer on posthook must work");
+    mkr.approveMgv(base, 1 ether);
+    deal($(base), $(mkr), 1 ether);
+
+    uint other_ofr = mkr.newOfferByTick($(base), $(quote), 1, 1 ether, 100_000);
+    mkr.setPosthookCallback($(this), abi.encodeCall(this.updateOfferOK, ($(base), $(quote), other_ofr)));
+
+    uint ofr = mkr.newOfferByTick($(base), $(quote), 0, 1 ether, 300_000);
+    assertTrue(tkr.marketOrderWithSuccess(1 ether), "market order must succeed or test is void");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
+    assertEq(mgv.offerDetails($(base), $(quote), other_ofr).gasreq(), 35_000, "updateOffer on posthook must work");
   }
 
   /* Cancel Offer failure */
 
   function retractOfferKO(uint id) external {
     vm.expectRevert("mgv/reentrancyLocked");
-    mgv.retractOffer($(base), $(quote), id, false);
+    mkr.retractOffer(id);
   }
 
   function test_retractOffer_on_reentrancy_fails() public {
-    uint ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 100_000, 0);
-    trade_cb = abi.encodeCall(this.retractOfferKO, (ofr));
-    assertTrue(tkr.marketOrderWithSuccess(1 ether), "take must succeed or test is void");
+    mkr.approveMgv(base, 1 ether);
+    deal($(base), $(mkr), 1 ether);
+
+    uint ofr = mkr.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 100_000);
+    mkr.setTradeCallback($(this), abi.encodeCall(this.retractOfferKO, (ofr)));
+    assertTrue(tkr.marketOrderWithSuccess(1 ether), "market order must succeed or test is void");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
   }
 
   /* Cancel Offer success */
 
   function retractOfferOK(address _base, address _quote, uint id) external {
-    uint collected = mgv.retractOffer(_base, _quote, id, false);
+    uint collected = mkr.retractOffer(_base, _quote, id);
     assertEq(collected, 0, "Unexpected collected provision after retract w/o deprovision");
   }
 
   function test_retractOffer_on_reentrancy_succeeds() public {
-    uint other_ofr = mgv.newOfferByVolume($(quote), $(base), 1 ether, 1 ether, 90_000, 0);
-    trade_cb = abi.encodeCall(this.retractOfferOK, ($(quote), $(base), other_ofr));
+    mkr.approveMgv(base, 1 ether);
+    deal($(base), $(mkr), 1 ether);
 
-    mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 90_000, 0);
-    assertTrue(tkr.marketOrderWithSuccess(1 ether), "take must succeed or test is void");
+    uint other_ofr = mkr.newOfferByVolume($(quote), $(base), 1 ether, 1 ether, 90_000);
+    mkr.setTradeCallback($(this), abi.encodeCall(this.retractOfferOK, ($(quote), $(base), other_ofr)));
+
+    uint ofr = mkr.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 90_000);
+    assertTrue(tkr.marketOrderWithSuccess(1 ether), "market order must succeed or test is void");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertTrue(mgv.best($(quote), $(base)) == 0, "retractOffer on swapped pair must work");
   }
 
   function test_retractOffer_on_posthook_succeeds() public {
-    uint other_ofr = mgv.newOfferByTick($(base), $(quote), 1, 1 ether, 190_000, 0);
-    posthook_cb = abi.encodeCall(this.retractOfferOK, ($(base), $(quote), other_ofr));
+    mkr.approveMgv(base, 1 ether);
+    deal($(base), $(mkr), 1 ether);
 
-    mgv.newOfferByTick($(base), $(quote), 0, 1 ether, 90_000, 0);
-    tkr.marketOrderWithSuccess(1 ether);
+    uint other_ofr = mkr.newOfferByTick($(base), $(quote), 1, 1 ether, 190_000);
+    mkr.setPosthookCallback($(this), abi.encodeCall(this.retractOfferOK, ($(base), $(quote), other_ofr)));
+
+    uint ofr = mkr.newOfferByTick($(base), $(quote), 0, 1 ether, 90_000);
+    assertTrue(tkr.marketOrderWithSuccess(1 ether), "market order must succeed or test is void");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertEq(mgv.best($(base), $(quote)), 0, "retractOffer on posthook must work");
   }
 
@@ -472,62 +485,99 @@ contract GatekeepingTest is IMaker, MangroveTest {
 
   function marketOrderKO() external {
     vm.expectRevert("mgv/reentrancyLocked");
-    mgv.marketOrderByVolume($(base), $(quote), 0.2 ether, 0.2 ether, true);
+    mkr.marketOrderByVolume($(base), $(quote), 0.2 ether, 0.2 ether);
   }
 
   function test_marketOrder_on_reentrancy_fails() public {
-    mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 100_000, 0);
-    trade_cb = abi.encodeCall(this.marketOrderKO, ());
-    assertTrue(tkr.marketOrderWithSuccess(0.1 ether), "take must succeed or test is void");
+    mkr.approveMgv(base, 1 ether);
+    deal($(base), $(mkr), 1 ether);
+
+    uint ofr = mkr.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 100_000);
+    mkr.setTradeCallback($(this), abi.encodeCall(this.marketOrderKO, ()));
+    assertTrue(tkr.marketOrderWithSuccess(0.1 ether), "market order must succeed or test is void");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
   }
 
   /* Market Order Success */
 
   function marketOrderOK(address _base, address _quote) external {
-    mgv.marketOrderByVolume(_base, _quote, uint(0.5 ether), 0.5 ether, true);
+    (uint got,) = mkr.marketOrderByVolume(_base, _quote, 0.5 ether, 0.5 ether);
+    assertGt(got, 0, "market order should have succeeded");
   }
 
   function test_marketOrder_on_reentrancy_succeeds() public {
-    dual_mkr.newOfferByVolume(0.5 ether, 0.5 ether, 30_000, 0);
-    mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 392_000, 0);
-    trade_cb = abi.encodeCall(this.marketOrderOK, ($(quote), $(base)));
-    assertTrue(tkr.marketOrderWithSuccess(0.1 ether), "take must succeed or test is void");
+    mkr.approveMgv(base, 1 ether);
+    deal($(base), $(mkr), 1 ether);
+
+    dual_mkr.approveMgv(quote, 1 ether);
+    deal($(quote), $(dual_mkr), 1 ether);
+
+    uint dual_ofr = dual_mkr.newOfferByVolume(0.5 ether, 0.5 ether, 300_000);
+    uint ofr = mkr.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 1_000_000);
+    mkr.setTradeCallback($(this), abi.encodeCall(this.marketOrderOK, ($(quote), $(base))));
+
+    assertTrue(tkr.marketOrderWithSuccess(0.1 ether), "market order must succeed or test is void");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
+    assertTrue(dual_mkr.makerExecuteWasCalled(dual_ofr), "dual_ofr must be executed or test is void");
     assertTrue(mgv.best($(quote), $(base)) == 0, "2nd market order must have emptied mgv");
   }
 
   function test_marketOrder_on_posthook_succeeds() public {
+    mkr.approveMgv(base, 1 ether);
+    deal($(base), $(mkr), 1 ether);
+    mkr.approveMgv(quote, 1 ether);
+    other_mkr.approveMgv(base, 1 ether);
+    deal($(base), $(other_mkr), 1 ether);
+
     mgv.setGasmax(10_000_000);
-    mgv.newOfferByVolume($(base), $(quote), 0.5 ether, 0.5 ether, 3500_000, 0);
-    mgv.newOfferByVolume($(base), $(quote), 0.5 ether, 0.5 ether, 1800_000, 0);
-    posthook_cb = abi.encodeCall(this.marketOrderOK, ($(base), $(quote)));
-    assertTrue(tkr.marketOrderWithSuccess(0.6 ether), "take must succeed or test is void");
+    uint ofr = mkr.newOfferByVolume($(base), $(quote), 0.5 ether, 0.5 ether, 3_500_000);
+    uint ofr2 = other_mkr.newOfferByVolume($(base), $(quote), 0.5 ether, 0.5 ether, 1_800_000);
+    mkr.setPosthookCallback($(this), abi.encodeCall(this.marketOrderOK, ($(base), $(quote))));
+    assertTrue(tkr.marketOrderWithSuccess(0.5 ether), "market order must succeed or test is void");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
+    assertTrue(other_mkr.makerExecuteWasCalled(ofr2), "ofr2 must be executed or test is void");
     assertTrue(mgv.best($(base), $(quote)) == 0, "2nd market order must have emptied mgv");
   }
 
   // not gatekeeping! move me.
   function test_no_execution_keeps_ticktree_ok() public {
+    mkr.approveMgv(base, 1 ether);
+    deal($(base), $(mkr), 1 ether);
+
     mgv.setGasmax(10_000_000);
-    uint ofr = mgv.newOfferByVolume($(base), $(quote), 0.5 ether, 0.5 ether, 3500_000, 0);
+    uint ofr = mkr.newOfferByVolume($(base), $(quote), 0.5 ether, 0.5 ether, 3500_000);
+
     (uint takerGot, uint takerGave) = tkr.marketOrder(0.5 ether, 0.3 ether);
     // assertGt(takerGot,0,"mo should work");
     // should execute 0 offers due to price mismatch
     assertEq(takerGot, 0, "mo should fail");
-    assertTrue(pair.offers(ofr).gives() > 0, "offer should still be live");
+    assertTrue(pair.offers(ofr).isLive(), "offer should still be live");
+    assertFalse(mkr.makerExecuteWasCalled(ofr), "ofr must not be executed or test is void");
+
     (takerGot, takerGave) = tkr.marketOrder(0.5 ether, 0.6 ether);
     assertGt(takerGot, 0, "mo should work");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertTrue(mgv.best($(base), $(quote)) == 0, "2nd market order must have emptied mgv");
   }
 
   // not gatekeeping! move me.
   function test_only_one_exec_keeps_ticktree_ok() public {
+    mkr.approveMgv(base, 1 ether);
+    deal($(base), $(mkr), 1 ether);
+
     mgv.setGasmax(10_000_000);
-    mgv.newOfferByVolume($(base), $(quote), 0.05 ether, 0.05 ether, 3500_000, 0);
-    uint ofr2 = mgv.newOfferByVolume($(base), $(quote), 0.1 ether, 0.05 ether, 3500_000, 0);
+    uint ofr = mkr.newOfferByVolume($(base), $(quote), 0.05 ether, 0.05 ether, 3500_000);
+    uint ofr2 = mkr.newOfferByVolume($(base), $(quote), 0.1 ether, 0.05 ether, 3500_000);
+
     (uint takerGot, uint takerGave) = tkr.marketOrder(0.1 ether, 0.1 ether);
     assertEq(takerGot, 0.05 ether, "mo should only take ofr");
-    assertGt(pair.offers(ofr2).gives(), 0, "ofr2 should still be live");
+    assertTrue(pair.offers(ofr2).isLive(), "ofr2 should still be live");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
+    assertFalse(mkr.makerExecuteWasCalled(ofr2), "ofr2 must not be executed or test is void");
+
     (takerGot, takerGave) = tkr.marketOrder(0.06 ether, 0.2 ether);
     assertGt(takerGot, 0, "mo should work");
+    assertTrue(mkr.makerExecuteWasCalled(ofr2), "ofr2 must be executed or test is void");
     assertTrue(mgv.best($(base), $(quote)) == 0, "2nd market order must have emptied mgv");
   }
 
@@ -583,49 +633,51 @@ contract GatekeepingTest is IMaker, MangroveTest {
   /* Clean failure */
 
   function cleanKO(uint id) external {
-    Tick tick = pair.offers(id).tick();
-    (uint successes,) = mgv.cleanByImpersonation(
-      $(base),
-      $(quote),
-      wrap_dynamic(MgvLib.CleanTarget(id, Tick.unwrap(tick), type(uint48).max, type(uint96).max)),
-      $(this)
-    );
-    assertEq(successes, 0, "clean should fail");
+    assertFalse(mkr.clean(id, 1 ether), "clean should fail");
   }
 
   function test_clean_on_reentrancy_fails() public {
-    uint ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 60_000, 0);
-    trade_cb = abi.encodeCall(this.cleanKO, (ofr));
-    assertTrue(tkr.marketOrderWithSuccess(0.1 ether), "take must succeed or test is void");
+    mkr.approveMgv(base, 1 ether);
+    deal($(base), $(mkr), 1 ether);
+
+    uint ofr = mkr.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 60_000);
+    mkr.setTradeCallback($(this), abi.encodeCall(this.cleanKO, (ofr)));
+    assertTrue(tkr.marketOrderWithSuccess(0.1 ether), "market order must succeed or test is void");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
   }
 
   /* Clean success */
 
   function cleanOK(address _base, address _quote, uint id) external {
-    Tick tick = mgv.offers(_base, _quote, id).tick();
-    mgv.cleanByImpersonation(
-      _base,
-      _quote,
-      wrap_dynamic(MgvLib.CleanTarget(id, Tick.unwrap(tick), type(uint48).max, type(uint96).max)),
-      $(this)
-    );
+    assertTrue(mkr.clean(_base, _quote, id, 0.5 ether), "clean should succeed");
   }
 
   function test_clean_on_reentrancy_in_swapped_pair_succeeds() public {
-    uint other_ofr = dual_mkr.newOfferByVolume(1 ether, 1 ether, 30_000);
-    trade_cb = abi.encodeCall(this.cleanOK, ($(quote), $(base), other_ofr));
+    mkr.approveMgv(base, 1 ether);
+    deal($(base), $(mkr), 1 ether);
 
-    mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 190_000, 0);
-    assertTrue(tkr.marketOrderWithSuccess(0.1 ether), "take must succeed or test is void");
+    uint dual_ofr = dual_mkr.newOfferByVolume(1 ether, 1 ether, 100_000);
+
+    mkr.setTradeCallback($(this), abi.encodeCall(this.cleanOK, ($(quote), $(base), dual_ofr)));
+    uint ofr = mkr.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 350_000);
+
+    assertTrue(tkr.marketOrderWithSuccess(0.1 ether), "market order must succeed or test is void");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertTrue(mgv.best($(quote), $(base)) == 0, "clean in swapped pair must work");
   }
 
   function test_clean_on_posthook_succeeds() public {
-    uint other_ofr = dual_mkr.newOfferByVolume(1 ether, 1 ether, 30_000);
-    posthook_cb = abi.encodeCall(this.cleanOK, ($(quote), $(base), other_ofr));
+    mkr.approveMgv(base, 1 ether);
+    deal($(base), $(mkr), 1 ether);
+    mkr.approveMgv(quote, 1 ether);
 
-    mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 190_000, 0);
+    uint other_ofr = other_mkr.newOfferByVolume(2 ether, 1 ether, 200_000);
+
+    mkr.setPosthookCallback($(this), abi.encodeCall(this.cleanOK, ($(base), $(quote), other_ofr)));
+    uint ofr = mkr.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 450_000);
+
     assertTrue(tkr.marketOrderWithSuccess(1 ether), "take must succeed or test is void");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertTrue(mgv.best($(base), $(quote)) == 0, "clean in posthook must work");
   }
 

--- a/test/core/Gatekeeping.t.sol
+++ b/test/core/Gatekeeping.t.sol
@@ -309,18 +309,6 @@ contract GatekeepingTest is IMaker, MangroveTest {
     assertEq(mgv.allowances($(base), $(quote), address(tkr), $(this)), 0, "initial allowance should be 0");
   }
 
-  function test_cannot_snipesFor_for_without_allowance() public {
-    deal($(base), address(mkr), 1 ether);
-    mkr.approveMgv(base, 1 ether);
-    uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 100_000);
-    Tick offerTick = pair.offers(ofr).tick();
-
-    vm.expectRevert("mgv/lowAllowance");
-    testMgv.snipesForInTest(
-      $(base), $(quote), wrap_dynamic([ofr, uint(Tick.unwrap(offerTick)), 1 ether, 300_000]), true, address(tkr)
-    );
-  }
-
   function test_cannot_marketOrderFor_for_without_allowance() public {
     deal($(base), address(mkr), 1 ether);
     mkr.approveMgv(base, 1 ether);
@@ -689,12 +677,6 @@ contract GatekeepingTest is IMaker, MangroveTest {
   function test_clean_on_inactive_fails() public {
     mgv.deactivate($(base), $(quote));
     assertEq(tkr.clean(0, 1 ether), false, "clean should fail on closed market");
-  }
-
-  function test_snipe_on_closed_fails() public {
-    mgv.kill();
-    vm.expectRevert("mgv/dead");
-    tkr.marketOrderWithSuccess(1 ether);
   }
 
   function test_withdraw_on_closed_ok() public {

--- a/test/core/Gatekeeping.t.sol
+++ b/test/core/Gatekeeping.t.sol
@@ -392,9 +392,9 @@ contract GatekeepingTest is IMaker, MangroveTest {
   }
 
   function test_newOffer_on_reentrancy_fails() public {
-    uint ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 100_000, 0);
+    mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 100_000, 0);
     trade_cb = abi.encodeCall(this.newOfferKO, ());
-    assertTrue(tkr.take(ofr, 1 ether), "take must succeed or test is void");
+    assertTrue(tkr.marketOrderWithSuccess(1 ether), "take must succeed or test is void");
   }
 
   /* New Offer success */
@@ -405,16 +405,16 @@ contract GatekeepingTest is IMaker, MangroveTest {
   }
 
   function test_newOffer_on_reentrancy_succeeds() public {
-    uint ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 200_000, 0);
+    mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 200_000, 0);
     trade_cb = abi.encodeCall(this.newOfferOK, ($(quote), $(base)));
-    assertTrue(tkr.take(ofr, 1 ether), "take must succeed or test is void");
+    assertTrue(tkr.marketOrderWithSuccess(1 ether), "take must succeed or test is void");
     assertTrue(mgv.best($(quote), $(base)) == 1, "newOfferByVolume on swapped pair must work");
   }
 
   function test_newOffer_on_posthook_succeeds() public {
-    uint ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 200_000, 0);
+    mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 200_000, 0);
     posthook_cb = abi.encodeCall(this.newOfferOK, ($(base), $(quote)));
-    assertTrue(tkr.take(ofr, 1 ether), "take must succeed or test is void");
+    assertTrue(tkr.marketOrderWithSuccess(1 ether), "take must succeed or test is void");
     assertTrue(mgv.best($(base), $(quote)) == 2, "newOfferByVolume on posthook must work");
   }
 
@@ -428,7 +428,7 @@ contract GatekeepingTest is IMaker, MangroveTest {
   function test_updateOffer_on_reentrancy_fails() public {
     uint ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 100_000, 0);
     trade_cb = abi.encodeCall(this.updateOfferKO, (ofr));
-    assertTrue(tkr.take(ofr, 1 ether), "take must succeed or test is void");
+    assertTrue(tkr.marketOrderWithSuccess(1 ether), "take must succeed or test is void");
   }
 
   /* Update offer success */
@@ -442,18 +442,18 @@ contract GatekeepingTest is IMaker, MangroveTest {
     uint other_ofr = mgv.newOfferByVolume($(quote), $(base), 1 ether, 1 ether, 100_000, 0);
 
     trade_cb = abi.encodeCall(this.updateOfferOK, ($(quote), $(base), other_ofr));
-    uint ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 400_000, 0);
-    assertTrue(tkr.take(ofr, 1 ether), "take must succeed or test is void");
+    mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 400_000, 0);
+    assertTrue(tkr.marketOrderWithSuccess(1 ether), "take must succeed or test is void");
     assertTrue(
       mgv.offerDetails($(quote), $(base), other_ofr).gasreq() == 35_000, "updateOffer on swapped pair must work"
     );
   }
 
   function test_updateOffer_on_posthook_succeeds() public {
-    uint other_ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 100_000, 0);
+    uint other_ofr = mgv.newOfferByTick($(base), $(quote), 1, 1 ether, 100_000, 0);
     posthook_cb = abi.encodeCall(this.updateOfferOK, ($(base), $(quote), other_ofr));
-    uint ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 300_000, 0);
-    assertTrue(tkr.take(ofr, 1 ether), "take must succeed or test is void");
+    mgv.newOfferByTick($(base), $(quote), 0, 1 ether, 300_000, 0);
+    tkr.marketOrderWithSuccess(1 ether);
     assertTrue(mgv.offerDetails($(base), $(quote), other_ofr).gasreq() == 35_000, "updateOffer on posthook must work");
   }
 
@@ -467,7 +467,7 @@ contract GatekeepingTest is IMaker, MangroveTest {
   function test_retractOffer_on_reentrancy_fails() public {
     uint ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 100_000, 0);
     trade_cb = abi.encodeCall(this.retractOfferKO, (ofr));
-    assertTrue(tkr.take(ofr, 1 ether), "take must succeed or test is void");
+    assertTrue(tkr.marketOrderWithSuccess(1 ether), "take must succeed or test is void");
   }
 
   /* Cancel Offer success */
@@ -481,17 +481,17 @@ contract GatekeepingTest is IMaker, MangroveTest {
     uint other_ofr = mgv.newOfferByVolume($(quote), $(base), 1 ether, 1 ether, 90_000, 0);
     trade_cb = abi.encodeCall(this.retractOfferOK, ($(quote), $(base), other_ofr));
 
-    uint ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 90_000, 0);
-    assertTrue(tkr.take(ofr, 1 ether), "take must succeed or test is void");
+    mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 90_000, 0);
+    assertTrue(tkr.marketOrderWithSuccess(1 ether), "take must succeed or test is void");
     assertTrue(mgv.best($(quote), $(base)) == 0, "retractOffer on swapped pair must work");
   }
 
   function test_retractOffer_on_posthook_succeeds() public {
-    uint other_ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 190_000, 0);
+    uint other_ofr = mgv.newOfferByTick($(base), $(quote), 1, 1 ether, 190_000, 0);
     posthook_cb = abi.encodeCall(this.retractOfferOK, ($(base), $(quote), other_ofr));
 
-    uint ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 90_000, 0);
-    assertTrue(tkr.take(ofr, 1 ether), "take must succeed or test is void");
+    mgv.newOfferByTick($(base), $(quote), 0, 1 ether, 90_000, 0);
+    tkr.marketOrderWithSuccess(1 ether);
     assertEq(mgv.best($(base), $(quote)), 0, "retractOffer on posthook must work");
   }
 
@@ -503,9 +503,9 @@ contract GatekeepingTest is IMaker, MangroveTest {
   }
 
   function test_marketOrder_on_reentrancy_fails() public {
-    uint ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 100_000, 0);
+    mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 100_000, 0);
     trade_cb = abi.encodeCall(this.marketOrderKO, ());
-    assertTrue(tkr.take(ofr, 0.1 ether), "take must succeed or test is void");
+    assertTrue(tkr.marketOrderWithSuccess(0.1 ether), "take must succeed or test is void");
   }
 
   /* Market Order Success */
@@ -516,18 +516,18 @@ contract GatekeepingTest is IMaker, MangroveTest {
 
   function test_marketOrder_on_reentrancy_succeeds() public {
     dual_mkr.newOfferByVolume(0.5 ether, 0.5 ether, 30_000, 0);
-    uint ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 392_000, 0);
+    mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 392_000, 0);
     trade_cb = abi.encodeCall(this.marketOrderOK, ($(quote), $(base)));
-    assertTrue(tkr.take(ofr, 0.1 ether), "take must succeed or test is void");
+    assertTrue(tkr.marketOrderWithSuccess(0.1 ether), "take must succeed or test is void");
     assertTrue(mgv.best($(quote), $(base)) == 0, "2nd market order must have emptied mgv");
   }
 
   function test_marketOrder_on_posthook_succeeds() public {
     mgv.setGasmax(10_000_000);
-    uint ofr = mgv.newOfferByVolume($(base), $(quote), 0.5 ether, 0.5 ether, 3500_000, 0);
+    mgv.newOfferByVolume($(base), $(quote), 0.5 ether, 0.5 ether, 3500_000, 0);
     mgv.newOfferByVolume($(base), $(quote), 0.5 ether, 0.5 ether, 1800_000, 0);
     posthook_cb = abi.encodeCall(this.marketOrderOK, ($(base), $(quote)));
-    assertTrue(tkr.take(ofr, 0.6 ether), "take must succeed or test is void");
+    assertTrue(tkr.marketOrderWithSuccess(0.6 ether), "take must succeed or test is void");
     assertTrue(mgv.best($(base), $(quote)) == 0, "2nd market order must have emptied mgv");
   }
 
@@ -623,7 +623,7 @@ contract GatekeepingTest is IMaker, MangroveTest {
   function test_clean_on_reentrancy_fails() public {
     uint ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 60_000, 0);
     trade_cb = abi.encodeCall(this.cleanKO, (ofr));
-    assertTrue(tkr.take(ofr, 0.1 ether), "take must succeed or test is void");
+    assertTrue(tkr.marketOrderWithSuccess(0.1 ether), "take must succeed or test is void");
   }
 
   /* Clean success */
@@ -642,8 +642,8 @@ contract GatekeepingTest is IMaker, MangroveTest {
     uint other_ofr = dual_mkr.newOfferByVolume(1 ether, 1 ether, 30_000);
     trade_cb = abi.encodeCall(this.cleanOK, ($(quote), $(base), other_ofr));
 
-    uint ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 190_000, 0);
-    assertTrue(tkr.take(ofr, 0.1 ether), "take must succeed or test is void");
+    mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 190_000, 0);
+    assertTrue(tkr.marketOrderWithSuccess(0.1 ether), "take must succeed or test is void");
     assertTrue(mgv.best($(quote), $(base)) == 0, "clean in swapped pair must work");
   }
 
@@ -651,8 +651,8 @@ contract GatekeepingTest is IMaker, MangroveTest {
     uint other_ofr = mkr.newOfferByVolume(1 ether, 1 ether, 30_000);
     posthook_cb = abi.encodeCall(this.cleanOK, ($(base), $(quote), other_ofr));
 
-    uint ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 190_000, 0);
-    assertTrue(tkr.take(ofr, 1 ether), "take must succeed or test is void");
+    mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 190_000, 0);
+    assertTrue(tkr.marketOrderWithSuccess(1 ether), "take must succeed or test is void");
     assertTrue(mgv.best($(base), $(quote)) == 0, "snipe in posthook must work");
   }
 
@@ -668,7 +668,7 @@ contract GatekeepingTest is IMaker, MangroveTest {
   function test_snipe_on_reentrancy_fails() public {
     uint ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 60_000, 0);
     trade_cb = abi.encodeCall(this.snipesKO, (ofr));
-    assertTrue(tkr.take(ofr, 0.1 ether), "take must succeed or test is void");
+    assertTrue(tkr.marketOrderWithSuccess(0.1 ether), "take must succeed or test is void");
   }
 
   /* Snipe success */
@@ -683,8 +683,8 @@ contract GatekeepingTest is IMaker, MangroveTest {
     uint other_ofr = dual_mkr.newOfferByVolume(1 ether, 1 ether, 30_000);
     trade_cb = abi.encodeCall(this.snipesOK, ($(quote), $(base), other_ofr));
 
-    uint ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 190_000, 0);
-    assertTrue(tkr.take(ofr, 0.1 ether), "take must succeed or test is void");
+    mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 190_000, 0);
+    assertTrue(tkr.marketOrderWithSuccess(0.1 ether), "take must succeed or test is void");
     assertTrue(mgv.best($(quote), $(base)) == 0, "snipe in swapped pair must work");
   }
 
@@ -692,8 +692,8 @@ contract GatekeepingTest is IMaker, MangroveTest {
     uint other_ofr = mkr.newOfferByVolume(1 ether, 1 ether, 30_000);
     posthook_cb = abi.encodeCall(this.snipesOK, ($(base), $(quote), other_ofr));
 
-    uint ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 190_000, 0);
-    assertTrue(tkr.take(ofr, 1 ether), "take must succeed or test is void");
+    mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 190_000, 0);
+    assertTrue(tkr.marketOrderWithSuccess(1 ether), "take must succeed or test is void");
     assertTrue(mgv.best($(base), $(quote)) == 0, "snipe in posthook must work");
   }
 
@@ -706,11 +706,11 @@ contract GatekeepingTest is IMaker, MangroveTest {
   }
 
   function test_take_on_closed_fails() public {
-    uint ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 0, 0);
+    mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, 0, 0);
 
     mgv.kill();
     vm.expectRevert("mgv/dead");
-    tkr.take(ofr, 1 ether);
+    tkr.marketOrderWithSuccess(1 ether);
   }
 
   function test_newOffer_on_inactive_fails() public {
@@ -750,7 +750,7 @@ contract GatekeepingTest is IMaker, MangroveTest {
   function test_snipe_on_closed_fails() public {
     mgv.kill();
     vm.expectRevert("mgv/dead");
-    tkr.take(0, 1 ether);
+    tkr.marketOrderWithSuccess(1 ether);
   }
 
   function test_withdraw_on_closed_ok() public {

--- a/test/core/InvertedTakerOperations.t.sol
+++ b/test/core/InvertedTakerOperations.t.sol
@@ -102,6 +102,7 @@ contract InvertedTakerOperationsTest is ITaker, MangroveTest {
 
     Tick tick = mgv.offers($(base), $(quote), ofr).tick();
     mgv.marketOrderByTick($(base), $(quote), Tick.unwrap(tick), 1 ether, true);
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertEq(quote.balanceOf(address(mgv)) - mgvQuoteBal, 1 ether, "Mgv balance should have increased");
   }
 
@@ -113,19 +114,22 @@ contract InvertedTakerOperationsTest is ITaker, MangroveTest {
     uint ofr = 2;
     Tick tick = mgv.offers(_base, _quote, ofr).tick();
     (uint totalGot, uint totalGave,,) = mgv.marketOrderByTick(_base, _quote, Tick.unwrap(tick), 0.1 ether, true);
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertEq(totalGot, 0.1 ether, "Incorrect totalGot");
     assertEq(totalGave, 0.1 ether, "Incorrect totalGave");
   }
 
   function test_taker_mo_mgv_during_trade() public {
-    mkr.newOfferByVolume(0.1 ether, 0.1 ether, 100_000, 0);
-    mkr.newOfferByVolume(0.1 ether, 0.1 ether, 100_000, 0);
+    uint ofr1 = mkr.newOfferByVolume(0.1 ether, 0.1 ether, 100_000, 0);
+    uint ofr2 = mkr.newOfferByVolume(0.1 ether, 0.1 ether, 100_000, 0);
     _takerTrade = reenter;
     expectFrom($(mgv));
-    emit OfferSuccess($(base), $(quote), 1, $(this), 0.1 ether, 0.1 ether);
+    emit OfferSuccess($(base), $(quote), ofr1, $(this), 0.1 ether, 0.1 ether);
     expectFrom($(mgv));
-    emit OfferSuccess($(base), $(quote), 2, $(this), 0.1 ether, 0.1 ether);
+    emit OfferSuccess($(base), $(quote), ofr2, $(this), 0.1 ether, 0.1 ether);
     (uint got, uint gave,,) = mgv.marketOrderByVolume($(base), $(quote), 0.1 ether, 0.1 ether, true);
+    assertTrue(mkr.makerExecuteWasCalled(ofr1), "ofr1 must be executed or test is void");
+    assertTrue(mkr.makerExecuteWasCalled(ofr2), "ofr2 must be executed or test is void");
     assertEq(quoteBalance - gave - 0.1 ether, quote.balanceOf($(this)), "Incorrect transfer (gave) during reentrancy");
     assertEq(baseBalance + got + 0.1 ether, base.balanceOf($(this)), "Incorrect transfer (got) during reentrancy");
   }
@@ -136,6 +140,7 @@ contract InvertedTakerOperationsTest is ITaker, MangroveTest {
     uint bal = quote.balanceOf($(this));
     _takerTrade = noop;
     mgv.marketOrderByTick($(base), $(quote), Tick.unwrap(tick), 0.05 ether, true);
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertEq(quote.balanceOf($(this)), bal - 0.05 ether, "wrong taker balance");
   }
 
@@ -145,6 +150,7 @@ contract InvertedTakerOperationsTest is ITaker, MangroveTest {
     uint bal = quote.balanceOf($(this));
     _takerTrade = noop;
     mgv.marketOrderByTick($(base), $(quote), Tick.unwrap(tick), 0.02 ether, true);
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertEq(quote.balanceOf($(this)), bal - 0.02 ether, "wrong taker balance");
   }
 }

--- a/test/core/InvertedTakerOperations.t.sol
+++ b/test/core/InvertedTakerOperations.t.sol
@@ -101,10 +101,7 @@ contract InvertedTakerOperationsTest is ITaker, MangroveTest {
     uint mgvQuoteBal = quote.balanceOf(address(mgv));
 
     Tick tick = mgv.offers($(base), $(quote), ofr).tick();
-    (uint successes,,,,) = testInvertedMgv.snipesInTest(
-      $(base), $(quote), wrap_dynamic([ofr, uint(Tick.unwrap(tick)), 1 ether, 50_000]), true
-    );
-    assertTrue(successes == 1, "Trade should succeed");
+    mgv.marketOrderByTick($(base), $(quote), Tick.unwrap(tick), 1 ether, true);
     assertEq(quote.balanceOf(address(mgv)) - mgvQuoteBal, 1 ether, "Mgv balance should have increased");
   }
 
@@ -115,15 +112,12 @@ contract InvertedTakerOperationsTest is ITaker, MangroveTest {
     skipCheck = true;
     uint ofr = 2;
     Tick tick = mgv.offers(_base, _quote, ofr).tick();
-    (uint successes, uint totalGot, uint totalGave,,) = testInvertedMgv.snipesInTest(
-      _base, _quote, wrap_dynamic([ofr, uint(Tick.unwrap(tick)), 0.1 ether, 100_000]), true
-    );
-    assertTrue(successes == 1, "Snipe on reentrancy should succeed");
+    (uint totalGot, uint totalGave,,) = mgv.marketOrderByTick(_base, _quote, Tick.unwrap(tick), 0.1 ether, true);
     assertEq(totalGot, 0.1 ether, "Incorrect totalGot");
     assertEq(totalGave, 0.1 ether, "Incorrect totalGave");
   }
 
-  function test_taker_snipe_mgv_during_trade() public {
+  function test_taker_mo_mgv_during_trade() public {
     mkr.newOfferByVolume(0.1 ether, 0.1 ether, 100_000, 0);
     mkr.newOfferByVolume(0.1 ether, 0.1 ether, 100_000, 0);
     _takerTrade = reenter;
@@ -141,9 +135,7 @@ contract InvertedTakerOperationsTest is ITaker, MangroveTest {
     Tick tick = mgv.offers($(base), $(quote), ofr).tick();
     uint bal = quote.balanceOf($(this));
     _takerTrade = noop;
-    testInvertedMgv.snipesInTest(
-      $(base), $(quote), wrap_dynamic([ofr, uint(Tick.unwrap(tick)), 0.05 ether, 100_000]), true
-    );
+    mgv.marketOrderByTick($(base), $(quote), Tick.unwrap(tick), 0.05 ether, true);
     assertEq(quote.balanceOf($(this)), bal - 0.05 ether, "wrong taker balance");
   }
 
@@ -152,9 +144,7 @@ contract InvertedTakerOperationsTest is ITaker, MangroveTest {
     Tick tick = mgv.offers($(base), $(quote), ofr).tick();
     uint bal = quote.balanceOf($(this));
     _takerTrade = noop;
-    testInvertedMgv.snipesInTest(
-      $(base), $(quote), wrap_dynamic([ofr, uint(Tick.unwrap(tick)), 0.02 ether, 100_000]), true
-    );
+    mgv.marketOrderByTick($(base), $(quote), Tick.unwrap(tick), 0.02 ether, true);
     assertEq(quote.balanceOf($(this)), bal - 0.02 ether, "wrong taker balance");
   }
 }

--- a/test/core/MakerOperations.t.sol
+++ b/test/core/MakerOperations.t.sol
@@ -83,8 +83,8 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     bool funded;
     (funded,) = $(mgv).call{value: 1 ether}("");
     deal($(base), $(this), 1 ether);
-    uint ofr = mgv.newOfferByVolume($(base), $(quote), 0.05 ether, 0.05 ether, 200_000, 0);
-    require(tkr.take(ofr, 0.05 ether), "take must work or test is void");
+    mgv.newOfferByVolume($(base), $(quote), 0.05 ether, 0.05 ether, 200_000, 0);
+    require(tkr.marketOrderWithSuccess(0.05 ether), "take must work or test is void");
   }
 
   function test_withdraw_removes_mgv_balance_and_ethers() public {
@@ -134,15 +134,15 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     mkr.setShouldFailHook(true);
     expectFrom($(mgv));
     emit PosthookFail($(base), $(quote), ofr, "posthookFail");
-    tkr.take(ofr, 0.1 ether); // fails but we don't care
+    tkr.marketOrderWithSuccess(0.1 ether); // fails but we don't care
   }
 
   function test_returnData_succeeds() public {
     mkr.provisionMgv(1 ether);
     deal($(base), address(mkr), 1 ether);
-    uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 50000, OfferData({shouldRevert: false, executeData: "someData"}));
+    mkr.newOfferByVolume(1 ether, 1 ether, 50000, OfferData({shouldRevert: false, executeData: "someData"}));
 
-    bool success = tkr.take(ofr, 0.1 ether);
+    bool success = tkr.marketOrderWithSuccess(0.1 ether);
     assertTrue(success, "take should work");
   }
 
@@ -187,7 +187,7 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     deal($(base), address(mkr), 1 ether);
     uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
 
-    bool success = tkr.take(ofr, 0.1 ether);
+    bool success = tkr.marketOrderWithSuccess(0.1 ether);
     assertEq(success, true, "Snipe should succeed");
 
     uint bal1 = mgv.balanceOf(address(mkr));
@@ -327,9 +327,9 @@ contract MakerOperationsTest is MangroveTest, IMaker {
   function test_maker_gets_no_mgv_balance_on_partial_fill() public {
     mkr.provisionMgv(1 ether);
     deal($(base), address(mkr), 1 ether);
-    uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
+    mkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
     uint oldBalance = mgv.balanceOf(address(mkr));
-    bool success = tkr.take(ofr, 0.1 ether);
+    bool success = tkr.marketOrderWithSuccess(0.1 ether);
     assertTrue(success, "take must succeed");
     assertEq(mgv.balanceOf(address(mkr)), oldBalance, "mkr balance must not change");
   }
@@ -337,9 +337,9 @@ contract MakerOperationsTest is MangroveTest, IMaker {
   function test_maker_gets_no_mgv_balance_on_full_fill() public {
     mkr.provisionMgv(1 ether);
     deal($(base), address(mkr), 1 ether);
-    uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
+    mkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
     uint oldBalance = mgv.balanceOf(address(mkr));
-    bool success = tkr.take(ofr, 1 ether);
+    bool success = tkr.marketOrderWithSuccess(1 ether);
     assertTrue(success, "take must succeed");
     assertEq(mgv.balanceOf(address(mkr)), oldBalance, "mkr balance must not change");
   }
@@ -725,8 +725,8 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     mgv.setGasbase($(base), $(quote), offer_gasbase);
     mgv.setGasprice(1);
     mgv.setDensityFixed($(base), $(quote), 0);
-    uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 0, 0);
-    tkr.take(ofr, 0.1 ether);
+    mkr.newOfferByVolume(1 ether, 1 ether, 0, 0);
+    tkr.marketOrderWithSuccess(0.1 ether);
     assertEq(mgv.balanceOf(address(mkr)), 1 ether - offer_gasbase * 10 ** 9, "Wrong gasbase deducted");
   }
 
@@ -736,8 +736,8 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     mgv.setGasbase($(base), $(quote), offer_gasbase);
     mgv.setGasprice(1);
     mgv.setDensityFixed($(base), $(quote), 0);
-    uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 0, 0);
-    tkr.take(ofr, 0.1 ether);
+    mkr.newOfferByVolume(1 ether, 1 ether, 0, 0);
+    tkr.marketOrderWithSuccess(0.1 ether);
     assertEq(mgv.balanceOf(address(mkr)), 1 ether - offer_gasbase * 10 ** 9, "Wrong gasbase deducted");
   }
 

--- a/test/core/MakerOperations.t.sol
+++ b/test/core/MakerOperations.t.sol
@@ -80,11 +80,11 @@ contract MakerOperationsTest is MangroveTest, IMaker {
   function makerPosthook(MgvLib.SingleOrder calldata order, MgvLib.OrderResult calldata result) external {}
 
   function test_calldata_and_balance_in_makerExecute_are_correct() public {
-    bool funded;
-    (funded,) = $(mgv).call{value: 1 ether}("");
-    deal($(base), $(this), 1 ether);
-    mgv.newOfferByVolume($(base), $(quote), 0.05 ether, 0.05 ether, 200_000, 0);
+    mkr.provisionMgv(1 ether);
+    deal($(base), $(mkr), 1 ether);
+    uint ofr = mkr.newOfferByVolume($(base), $(quote), 0.05 ether, 0.05 ether, 200_000);
     require(tkr.marketOrderWithSuccess(0.05 ether), "take must work or test is void");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
   }
 
   function test_withdraw_removes_mgv_balance_and_ethers() public {
@@ -115,35 +115,39 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     uint oldBal = mgv.balanceOf(address(mkr));
     expectFrom($(mgv));
     emit Credit(address(mkr), 1 ether);
-    mkr.newOfferByVolumeWithFunding(1 ether, 1 ether, 50000, 0, 1 ether);
+    mkr.newOfferByVolumeWithFunding(1 ether, 1 ether, 100_000, 0, 1 ether);
     assertGt(mgv.balanceOf(address(mkr)), oldBal, "balance should have increased");
   }
 
   function test_fund_updateOffer() public {
     mkr.provisionMgv(1 ether);
-    uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 50000, 0);
+    uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
     expectFrom($(mgv));
     emit Credit(address(mkr), 0.9 ether);
-    mkr.updateOfferByVolumeWithFunding(1 ether, 1 ether, 50000, ofr, 0.9 ether);
+    mkr.updateOfferByVolumeWithFunding(1 ether, 1 ether, 100_000, ofr, 0.9 ether);
   }
 
   function test_posthook_fail_message() public {
     mkr.provisionMgv(1 ether);
-    uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 50000, 0);
+    deal($(base), address(mkr), 1 ether);
+    uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
 
     mkr.setShouldFailHook(true);
     expectFrom($(mgv));
     emit PosthookFail($(base), $(quote), ofr, "posthookFail");
     tkr.marketOrderWithSuccess(0.1 ether); // fails but we don't care
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
   }
 
   function test_returnData_succeeds() public {
     mkr.provisionMgv(1 ether);
     deal($(base), address(mkr), 1 ether);
-    mkr.newOfferByVolume(1 ether, 1 ether, 50000, OfferData({shouldRevert: false, executeData: "someData"}));
+    uint ofr =
+      mkr.newOfferByVolume(1 ether, 1 ether, 100_000, OfferData({shouldRevert: false, executeData: "someData"}));
 
     bool success = tkr.marketOrderWithSuccess(0.1 ether);
-    assertTrue(success, "take should work");
+    assertTrue(success, "market order should work");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
   }
 
   function test_delete_restores_balance() public {
@@ -188,7 +192,8 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
 
     bool success = tkr.marketOrderWithSuccess(0.1 ether);
-    assertEq(success, true, "Snipe should succeed");
+    assertEq(success, true, "market order should succeed");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
 
     uint bal1 = mgv.balanceOf(address(mkr));
     mkr.retractOfferWithDeprovision(ofr);
@@ -327,20 +332,22 @@ contract MakerOperationsTest is MangroveTest, IMaker {
   function test_maker_gets_no_mgv_balance_on_partial_fill() public {
     mkr.provisionMgv(1 ether);
     deal($(base), address(mkr), 1 ether);
-    mkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
+    uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
     uint oldBalance = mgv.balanceOf(address(mkr));
     bool success = tkr.marketOrderWithSuccess(0.1 ether);
-    assertTrue(success, "take must succeed");
+    assertTrue(success, "market order must succeed");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertEq(mgv.balanceOf(address(mkr)), oldBalance, "mkr balance must not change");
   }
 
   function test_maker_gets_no_mgv_balance_on_full_fill() public {
     mkr.provisionMgv(1 ether);
     deal($(base), address(mkr), 1 ether);
-    mkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
+    uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
     uint oldBalance = mgv.balanceOf(address(mkr));
     bool success = tkr.marketOrderWithSuccess(1 ether);
     assertTrue(success, "take must succeed");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertEq(mgv.balanceOf(address(mkr)), oldBalance, "mkr balance must not change");
   }
 
@@ -725,8 +732,8 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     mgv.setGasbase($(base), $(quote), offer_gasbase);
     mgv.setGasprice(1);
     mgv.setDensityFixed($(base), $(quote), 0);
-    mkr.newOfferByVolume(1 ether, 1 ether, 0, 0);
-    tkr.marketOrderWithSuccess(0.1 ether);
+    uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 0, 0);
+    tkr.clean(ofr, 0.1 ether);
     assertEq(mgv.balanceOf(address(mkr)), 1 ether - offer_gasbase * 10 ** 9, "Wrong gasbase deducted");
   }
 
@@ -736,8 +743,8 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     mgv.setGasbase($(base), $(quote), offer_gasbase);
     mgv.setGasprice(1);
     mgv.setDensityFixed($(base), $(quote), 0);
-    mkr.newOfferByVolume(1 ether, 1 ether, 0, 0);
-    tkr.marketOrderWithSuccess(0.1 ether);
+    uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 0, 0);
+    tkr.clean(ofr, 0.1 ether);
     assertEq(mgv.balanceOf(address(mkr)), 1 ether - offer_gasbase * 10 ** 9, "Wrong gasbase deducted");
   }
 

--- a/test/core/MakerPosthook.t.sol
+++ b/test/core/MakerPosthook.t.sol
@@ -255,8 +255,8 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     _posthook = failer_posthook;
     ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, gasreq, _gasprice);
     Tick offerTick = mgv.offers($(base), $(quote), ofr).tick();
-    Tick snipeTick = Tick.wrap(Tick.unwrap(offerTick) - 1); // Snipe at a lower price tick
-    assertFalse(tkr.cleanByTick(ofr, snipeTick, 1 ether, gasreq), "clean should fail");
+    Tick cleanTick = Tick.wrap(Tick.unwrap(offerTick) - 1); // Snipe at a lower price tick
+    assertFalse(tkr.cleanByTick(ofr, cleanTick, 1 ether, gasreq), "clean should fail");
     assertTrue(!called, "PostHook was called");
   }
 
@@ -422,7 +422,7 @@ contract MakerPosthookTest is MangroveTest, IMaker {
 
     ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, gasreq, _gasprice);
     bool success = tkr.marketOrderWithSuccess(1 ether);
-    assertTrue(success, "snipe should succeed");
+    assertTrue(success, "order should succeed");
     assertEq(balMaker - 1 ether, base.balanceOf($(this)), "Incorrect maker balance");
     assertEq(balTaker - 1 ether, quote.balanceOf(address(tkr)), "Incorrect taker balance");
   }

--- a/test/core/MakerPosthook.t.sol
+++ b/test/core/MakerPosthook.t.sol
@@ -414,7 +414,7 @@ contract MakerPosthookTest is MangroveTest, IMaker {
   }
 
   function reverting_posthook(MgvLib.SingleOrder calldata, MgvLib.OrderResult calldata) internal pure {
-    assert(false);
+    revert("reverting_posthook");
   }
 
   function test_reverting_posthook_does_not_revert_offer() public {
@@ -424,6 +424,10 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     _posthook = reverting_posthook;
 
     ofr = mgv.newOfferByVolume($(base), $(quote), 1 ether, 1 ether, gasreq, _gasprice);
+
+    expectFrom($(mgv));
+    emit PosthookFail($(base), $(quote), ofr, "reverting_posthook");
+
     bool success = tkr.marketOrderWithSuccess(1 ether);
     assertTrue(success, "order should succeed");
     assertEq(balMaker - 1 ether, base.balanceOf($(this)), "Incorrect maker balance");

--- a/test/core/Monitor.t.sol
+++ b/test/core/Monitor.t.sol
@@ -96,7 +96,6 @@ contract MonitorTest is MangroveTest {
     MgvStructs.OfferPacked offer = mgv.offers($(base), $(quote), ofrId);
 
     Tick tick = offer.tick();
-    uint[4][] memory targets = wrap_dynamic([ofrId, uint(Tick.unwrap(tick)), 0.04 ether, 100_000]);
 
     (MgvStructs.GlobalPacked _global, MgvStructs.LocalPacked _local) = mgv.config($(base), $(quote));
     _local = _local.lock(true);
@@ -115,8 +114,8 @@ contract MonitorTest is MangroveTest {
 
     expectToMockCall(monitor, abi.encodeCall(IMgvMonitor.notifySuccess, (order, $(this))), bytes(""));
 
-    (uint successes,,,,) = testMgv.snipesInTest($(base), $(quote), targets, true);
-    assertTrue(successes == 1, "snipe should succeed");
+    (uint got,,,) = mgv.marketOrderByTick($(base), $(quote), Tick.unwrap(tick), 0.04 ether, true);
+    assertTrue(got > 0, "order should succeed");
   }
 
   function test_notify_works_on_fail_when_set() public {
@@ -128,7 +127,6 @@ contract MonitorTest is MangroveTest {
     MgvStructs.OfferDetailPacked offerDetail = mgv.offerDetails($(base), $(quote), ofrId);
 
     Tick tick = offer.tick();
-    uint[4][] memory targets = wrap_dynamic([ofrId, uint(Tick.unwrap(tick)), 0.04 ether, 100_000]);
 
     (MgvStructs.GlobalPacked _global, MgvStructs.LocalPacked _local) = mgv.config($(base), $(quote));
     // config sent during maker callback has stale best and, is locked
@@ -148,7 +146,7 @@ contract MonitorTest is MangroveTest {
 
     expectToMockCall(monitor, abi.encodeCall(IMgvMonitor.notifyFail, (order, $(this))), bytes(""));
 
-    (uint successes,,,,) = testMgv.snipesInTest($(base), $(quote), targets, true);
-    assertTrue(successes == 0, "snipe should fail");
+    (uint got,,,) = mgv.marketOrderByTick($(base), $(quote), Tick.unwrap(tick), 0.04 ether, true);
+    assertTrue(got == 0, "order should fail");
   }
 }

--- a/test/core/Permit.t.sol
+++ b/test/core/Permit.t.sol
@@ -83,11 +83,9 @@ contract PermitTest is MangroveTest, TrivialTestMaker {
     });
   }
 
-  function snipeFor(uint value, address who) internal returns (uint, uint, uint, uint, uint) {
+  function marketOrderFor(uint value, address who) internal returns (uint, uint, uint, uint) {
     Tick tick = TickLib.tickFromPrice_e18(1 ether);
-    return testMgv.snipesForInTest(
-      $(base), $(quote), wrap_dynamic([uint(1), uint(Tick.unwrap(tick)), value, 300_000]), true, who
-    );
+    return mgv.marketOrderForByTick($(base), $(quote), Tick.unwrap(tick), value, true, who);
   }
 
   function newOfferByVolume(uint amount) internal {
@@ -101,7 +99,7 @@ contract PermitTest is MangroveTest, TrivialTestMaker {
     deal($(quote), good_owner, value);
     newOfferByVolume(value);
     vm.expectRevert("mgv/lowAllowance");
-    snipeFor(value, good_owner);
+    marketOrderFor(value, good_owner);
   }
 
   function test_wrong_owner() public {
@@ -163,8 +161,7 @@ contract PermitTest is MangroveTest, TrivialTestMaker {
     deal($(base), $(this), value);
     deal($(quote), good_owner, value);
     newOfferByVolume(value);
-    (uint successes, uint takerGot, uint takerGave,,) = snipeFor(value / 2, good_owner);
-    assertEq(successes, 1, "Snipe should succeed");
+    (uint takerGot, uint takerGave,,) = marketOrderFor(value / 2, good_owner);
     assertEq(takerGot, value / 2, "takerGot should be 1 ether");
     assertEq(takerGave, value / 2, "takerGot should be 1 ether");
 

--- a/test/core/Scenarii.t.sol
+++ b/test/core/Scenarii.t.sol
@@ -80,6 +80,7 @@ contract ScenariiTest is MangroveTest {
     saveBalances();
   }
 
+  // FIXME: Can this test be made meaningful without snipe?
   function test_snipe_insert_and_fail() public {
     offerOf = insert();
 
@@ -122,12 +123,7 @@ contract ScenariiTest is MangroveTest {
 
   function collectFailingOffer(uint failingOfferId) internal {
     // executing failing offer
-    try taker.takeWithInfo(failingOfferId, 0.5 ether) returns (bool success, uint takerGot, uint takerGave, uint, uint)
-    {
-      // take should return false not throw
-      assertTrue(!success, "Failer should fail");
-      assertEq(takerGot, 0, "Failed offer should declare 0 takerGot");
-      assertEq(takerGave, 0, "Failed offer should declare 0 takerGave");
+    try taker.clean(failingOfferId, 0.5 ether) {
       // failingOffer should have been removed from Mgv
       {
         assertTrue(

--- a/test/core/Scenarii.t.sol
+++ b/test/core/Scenarii.t.sol
@@ -81,43 +81,43 @@ contract ScenariiTest is MangroveTest {
   }
 
   // FIXME: Can this test be made meaningful without snipe?
-  function test_snipe_insert_and_fail() public {
-    offerOf = insert();
+  // function test_snipe_insert_and_fail() public {
+  //   offerOf = insert();
 
-    saveBalances();
-    saveOffers();
-    expectFrom($(mgv));
-    emit OrderStart();
-    expectFrom($(mgv));
-    emit OrderComplete(
-      $(base),
-      $(quote),
-      address(taker),
-      0.3 ether * (10_000 - testFee) / 10_000,
-      374979485972146063, // should not be hardcoded
-      0,
-      0.3 ether * testFee / 10_000
-    );
-    snipe();
-    logOrderBook($(base), $(quote), 4);
+  //   saveBalances();
+  //   saveOffers();
+  //   expectFrom($(mgv));
+  //   emit OrderStart();
+  //   expectFrom($(mgv));
+  //   emit OrderComplete(
+  //     $(base),
+  //     $(quote),
+  //     address(taker),
+  //     0.3 ether * (10_000 - testFee) / 10_000,
+  //     374979485972146063, // should not be hardcoded
+  //     0,
+  //     0.3 ether * testFee / 10_000
+  //   );
+  //   snipe();
+  //   logOrderBook($(base), $(quote), 4);
 
-    // restore offer that was deleted after partial fill, minus taken amount
-    makers.getMaker(2).updateOfferByVolume(1 ether - 0.375 ether, 0.8 ether - 0.3 ether, 80_000, 2);
+  //   // restore offer that was deleted after partial fill, minus taken amount
+  //   makers.getMaker(2).updateOfferByVolume(1 ether - 0.375 ether, 0.8 ether - 0.3 ether, 80_000, 2);
 
-    logOrderBook($(base), $(quote), 4);
+  //   logOrderBook($(base), $(quote), 4);
 
-    saveBalances();
-    saveOffers();
-    mo();
-    logOrderBook($(base), $(quote), 4);
+  //   saveBalances();
+  //   saveOffers();
+  //   mo();
+  //   logOrderBook($(base), $(quote), 4);
 
-    saveBalances();
-    saveOffers();
-    collectFailingOffer(offerOf[0]);
-    logOrderBook($(base), $(quote), 4);
-    saveBalances();
-    saveOffers();
-  }
+  //   saveBalances();
+  //   saveOffers();
+  //   collectFailingOffer(offerOf[0]);
+  //   logOrderBook($(base), $(quote), 4);
+  //   saveBalances();
+  //   saveOffers();
+  // }
 
   /* **************** TEST ROUTINES ************* */
 
@@ -269,62 +269,63 @@ contract ScenariiTest is MangroveTest {
     uint expectedFee;
   }
 
-  function snipe() internal returns (uint takerGot, uint takerGave, uint expectedFee) {
-    Bag memory bag;
-    bag.orderAmount = 0.3 ether;
-    bag.snipedId = 2;
-    // uint orderAmount = 0.3 ether;
-    // uint snipedId = 2;
-    expectedFee = reader.getFee($(base), $(quote), bag.orderAmount);
-    TestMaker maker = makers.getMaker(bag.snipedId); // maker whose offer will be sniped
+  // FIXME: Can this meaningfully be converted to clean and/or marketOrder?
+  // function snipe() internal returns (uint takerGot, uint takerGave, uint expectedFee) {
+  //   Bag memory bag;
+  //   bag.orderAmount = 0.3 ether;
+  //   bag.snipedId = 2;
+  //   // uint orderAmount = 0.3 ether;
+  //   // uint snipedId = 2;
+  //   expectedFee = reader.getFee($(base), $(quote), bag.orderAmount);
+  //   TestMaker maker = makers.getMaker(bag.snipedId); // maker whose offer will be sniped
 
-    //(uint init_mkr_wants, uint init_mkr_gives,,,,,)=mgv.getOfferInfo(2);
-    //---------------SNIPE------------------//
-    {
-      bool takeSuccess;
-      (takeSuccess, takerGot, takerGave,,) = taker.takeWithInfo(bag.snipedId, bag.orderAmount);
+  //   //(uint init_mkr_wants, uint init_mkr_gives,,,,,)=mgv.getOfferInfo(2);
+  //   //---------------SNIPE------------------//
+  //   {
+  //     bool takeSuccess;
+  //     (takeSuccess, takerGot, takerGave,,) = taker.takeWithInfo(bag.snipedId, bag.orderAmount);
 
-      assertTrue(takeSuccess, "snipe should be a success");
-    }
-    assertEq(
-      base.balanceOf(address(mgv)), //actual
-      balances.mgvBalanceBase + expectedFee, // expected
-      "incorrect Mangrove A balance"
-    );
-    assertEq(
-      base.balanceOf(address(taker)), // actual
-      balances.takerBalanceA + bag.orderAmount - expectedFee, // expected
-      "incorrect taker A balance"
-    );
-    assertEq(
-      takerGot,
-      bag.orderAmount - expectedFee, // expected
-      "Incorrect takerGot"
-    );
-    {
-      uint shouldGive =
-        (bag.orderAmount * offers[bag.snipedId][Info.makerWants]) / offers[bag.snipedId][Info.makerGives];
-      assertApproxEqRel(
-        quote.balanceOf(address(taker)), balances.takerBalanceB - shouldGive, relError(10), "incorrect taker B balance"
-      );
-      assertApproxEqRel(takerGave, shouldGive, relError(10), "Incorrect takerGave");
-    }
-    assertEq(
-      base.balanceOf(address(maker)),
-      balances.makersBalanceA[bag.snipedId] - bag.orderAmount,
-      "incorrect maker A balance"
-    );
-    assertApproxEqRel(
-      quote.balanceOf(address(maker)),
-      balances.makersBalanceB[bag.snipedId]
-        + (bag.orderAmount * offers[bag.snipedId][Info.makerWants]) / offers[bag.snipedId][Info.makerGives],
-      relError(10),
-      "incorrect maker B balance"
-    );
-    // Testing residual offer
-    (MgvStructs.OfferUnpacked memory ofr,) = mgv.offerInfo($(base), $(quote), bag.snipedId);
-    assertTrue(ofr.gives == 0, "Offer should not have a residual");
-  }
+  //     assertTrue(takeSuccess, "snipe should be a success");
+  //   }
+  //   assertEq(
+  //     base.balanceOf(address(mgv)), //actual
+  //     balances.mgvBalanceBase + expectedFee, // expected
+  //     "incorrect Mangrove A balance"
+  //   );
+  //   assertEq(
+  //     base.balanceOf(address(taker)), // actual
+  //     balances.takerBalanceA + bag.orderAmount - expectedFee, // expected
+  //     "incorrect taker A balance"
+  //   );
+  //   assertEq(
+  //     takerGot,
+  //     bag.orderAmount - expectedFee, // expected
+  //     "Incorrect takerGot"
+  //   );
+  //   {
+  //     uint shouldGive =
+  //       (bag.orderAmount * offers[bag.snipedId][Info.makerWants]) / offers[bag.snipedId][Info.makerGives];
+  //     assertApproxEqRel(
+  //       quote.balanceOf(address(taker)), balances.takerBalanceB - shouldGive, relError(10), "incorrect taker B balance"
+  //     );
+  //     assertApproxEqRel(takerGave, shouldGive, relError(10), "Incorrect takerGave");
+  //   }
+  //   assertEq(
+  //     base.balanceOf(address(maker)),
+  //     balances.makersBalanceA[bag.snipedId] - bag.orderAmount,
+  //     "incorrect maker A balance"
+  //   );
+  //   assertApproxEqRel(
+  //     quote.balanceOf(address(maker)),
+  //     balances.makersBalanceB[bag.snipedId]
+  //       + (bag.orderAmount * offers[bag.snipedId][Info.makerWants]) / offers[bag.snipedId][Info.makerGives],
+  //     relError(10),
+  //     "incorrect maker B balance"
+  //   );
+  //   // Testing residual offer
+  //   (MgvStructs.OfferUnpacked memory ofr,) = mgv.offerInfo($(base), $(quote), bag.snipedId);
+  //   assertTrue(ofr.gives == 0, "Offer should not have a residual");
+  // }
 }
 
 contract DeepCollectTest is MangroveTest {

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -294,8 +294,9 @@ contract TakerOperationsTest is MangroveTest {
 
     expectFrom($(mgv));
     emit OfferFail($(base), $(quote), ofr, $(this), 1 ether, 1 ether, "mgv/makerTransferFail");
-    vm.expectEmit(true, false, false, false, $(mgv));
-    emit Credit($(refusemkr), 0); // credited amount should be "mkr_provision - penalty"; Not including this in the emit assertion, as penalty is difficult to maintain.
+    //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit Credit($(refusemkr), 0 /*mkr_provision - penalty*/ );
     (uint successes,) = mgv.cleanByImpersonation(
       $(base), $(quote), wrap_dynamic(MgvLib.CleanTarget(ofr, Tick.unwrap(offerTick), 100_000, 1 ether)), $(this)
     );
@@ -329,8 +330,9 @@ contract TakerOperationsTest is MangroveTest {
 
     expectFrom($(mgv));
     emit OfferFail($(base), $(quote), ofr, $(this), 1 ether, 1 ether, "mgv/makerTransferFail");
-    vm.expectEmit(true, false, false, false, $(mgv));
-    emit Credit($(mkr), 0); // credited amount should be "mkr_provision - penalty"; Not including this in the emit assertion, as penalty is difficult to maintain.
+    //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit Credit($(mkr), 0 /*mkr_provision - penalty*/ );
     (uint takerGot, uint takerGave,,) = mgv.marketOrderByTick($(base), $(quote), Tick.unwrap(offerTick), 1 ether, true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
@@ -352,8 +354,9 @@ contract TakerOperationsTest is MangroveTest {
 
     expectFrom($(mgv));
     emit OfferFail($(base), $(quote), ofr, $(this), 1 ether, 1 ether, "mgv/makerReceiveFail");
-    vm.expectEmit(true, false, false, false, $(mgv));
-    emit Credit($(mkr), 0); // credited amount should be "mkr_provision - penalty"; Not including this in the emit assertion, as penalty is difficult to maintain.
+    //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit Credit($(mkr), 0 /*mkr_provision - penalty*/ );
     (uint takerGot, uint takerGave,,) = mgv.marketOrderByTick($(base), $(quote), Tick.unwrap(offerTick), 1 ether, true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
@@ -384,8 +387,9 @@ contract TakerOperationsTest is MangroveTest {
 
     expectFrom($(mgv));
     emit OfferFail($(base), $(quote), ofr, $(this), 1 ether, 1 ether, "mgv/makerRevert");
-    vm.expectEmit(true, false, false, false, $(mgv));
-    emit Credit($(failmkr), 0); // credited amount should be "mkr_provision - penalty"; Not including this in the emit assertion, as penalty is difficult to maintain.
+    //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
     (uint takerGot, uint takerGave,,) = mgv.marketOrderByTick($(base), $(quote), Tick.unwrap(offerTick), 1 ether, true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
@@ -952,11 +956,12 @@ contract TakerOperationsTest is MangroveTest {
     emit Transfer($(mgv), $(failmkr), 0 ether);
     expectFrom($(mgv));
     emit OfferFail($(base), $(quote), ofr, $(this), 0 ether, 0 ether, "mgv/makerRevert");
-    vm.expectEmit(true, false, false, false, $(mgv));
-    emit Credit($(failmkr), 0); // credited amount should be "mkr_provision - penalty"; Not including this in the emit assertion, as penalty is difficult to maintain.
+    //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
 
-    vm.expectEmit(true, true, true, false, $(mgv)); // Not checking data here as penalty is difficult to maintain
-    emit OrderComplete($(base), $(quote), $(this), 0 ether, 0 ether, 0, 0);
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit OrderComplete($(base), $(quote), $(this), 0 ether, 0 ether, 0, /*penalty*/ 0);
 
     (, uint bounty) =
       mgv.cleanByImpersonation($(base), $(quote), wrap_dynamic(MgvLib.CleanTarget(ofr, 0, 100_000, 0)), $(this));
@@ -984,8 +989,9 @@ contract TakerOperationsTest is MangroveTest {
     emit Transfer($(mgv), $(failmkr), 0 ether);
     expectFrom($(mgv));
     emit OfferFail($(base), $(quote), ofr, $(this), 0 ether, 0 ether, "mgv/makerRevert");
-    vm.expectEmit(true, false, false, false, $(mgv));
-    emit Credit($(failmkr), 0); // credited amount should be "mkr_provision - penalty"; Not including this in the emit assertion, as penalty is difficult to maintain.
+    //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
 
     expectFrom($(quote));
     emit Transfer($(this), $(mgv), 0 ether);
@@ -993,11 +999,12 @@ contract TakerOperationsTest is MangroveTest {
     emit Transfer($(mgv), $(failmkr), 0 ether);
     expectFrom($(mgv));
     emit OfferFail($(base), $(quote), ofr2, $(this), 0 ether, 0 ether, "mgv/makerRevert");
-    vm.expectEmit(true, false, false, false, $(mgv));
-    emit Credit($(failmkr), 0); // credited amount should be "mkr_provision - penalty"; Not including this in the emit assertion, as penalty is difficult to maintain.
+    //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
 
-    vm.expectEmit(true, true, true, false, $(mgv)); // Not checking data here as penalty is difficult to maintain
-    emit OrderComplete($(base), $(quote), $(this), 0 ether, 0 ether, 0, 0);
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit OrderComplete($(base), $(quote), $(this), 0 ether, 0 ether, 0, /*penalty1 + penalty2*/ 0);
 
     (uint successes, uint bounty) = mgv.cleanByImpersonation($(base), $(quote), targets, $(this));
 
@@ -1031,8 +1038,9 @@ contract TakerOperationsTest is MangroveTest {
     emit Transfer($(mgv), $(failmkr), 0 ether);
     expectFrom($(mgv));
     emit OfferFail($(base), $(quote), ofr, $(this), 0 ether, 0 ether, "mgv/makerRevert");
-    vm.expectEmit(true, false, false, false, $(mgv));
-    emit Credit($(failmkr), 0); // credited amount should be "mkr_provision - penalty"; Not including this in the emit assertion, as penalty is difficult to maintain.
+    //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
 
     expectFrom($(quote));
     emit Transfer($(this), $(mgv), 0 ether);
@@ -1047,11 +1055,12 @@ contract TakerOperationsTest is MangroveTest {
     emit Transfer($(mgv), $(failmkr), 0 ether);
     expectFrom($(mgv));
     emit OfferFail($(base), $(quote), ofr3, $(this), 0 ether, 0 ether, "mgv/makerRevert");
-    vm.expectEmit(true, false, false, false, $(mgv));
-    emit Credit($(failmkr), 0); // credited amount should be "mkr_provision - penalty"; Not including this in the emit assertion, as penalty is difficult to maintain.
+    //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
 
-    vm.expectEmit(true, true, true, false, $(mgv)); // Not checking data here as penalty is difficult to maintain
-    emit OrderComplete($(base), $(quote), $(this), 0 ether, 0 ether, 0, 0);
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit OrderComplete($(base), $(quote), $(this), 0 ether, 0 ether, 0, /*penalty1 + penalty3*/ 0);
 
     (uint successes, uint bounty) = mgv.cleanByImpersonation($(base), $(quote), targets, $(this));
 
@@ -1091,11 +1100,12 @@ contract TakerOperationsTest is MangroveTest {
     emit Transfer($(mgv), $(failNonZeroMkr), 1);
     expectFrom($(mgv));
     emit OfferFail($(base), $(quote), ofr, $(otherTkr), 1, 1, "mgv/makerRevert");
-    vm.expectEmit(true, false, false, false, $(mgv));
-    emit Credit($(failNonZeroMkr), 0); // credited amount should be "mkr_provision - penalty"; Not including this in the emit assertion, as penalty is difficult to maintain.
+    //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit Credit($(failNonZeroMkr), 0 /*mkr_provision - penalty*/ );
 
-    vm.expectEmit(true, true, true, false, $(mgv)); // Not checking data here as penalty is difficult to maintain
-    emit OrderComplete($(base), $(quote), $(this), 0 ether, 0 ether, 0, 0);
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit OrderComplete($(base), $(quote), $(this), 0 ether, 0 ether, 0, /*penalty*/ 0);
 
     (, bounty) =
       mgv.cleanByImpersonation($(base), $(quote), wrap_dynamic(MgvLib.CleanTarget(ofr, 0, 100_000, 1)), $(otherTkr));

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -84,7 +84,9 @@ contract TakerOperationsTest is MangroveTest {
     assertEq(weiBalanceBefore, mgv.balanceOf($(this)), "Taker should not take bounty");
   }
 
-  // FIXME: Not sure what this tests?
+  // The purpose of this test is to make sure inbound volumes are rounded up when partially
+  // taking an offer i.e. you can't have the taker pay 0 if the maker sends > 0 to the taker.
+  // The test sets this up with a wants=9, gives=10 offer, and the taker asks for a volume of 1.
   function test_taker_cannot_drain_maker() public {
     mgv.setDensityFixed($(base), $(quote), 0);
     quote.approve($(mgv), 1 ether);

--- a/test/lib/MangroveTest.sol
+++ b/test/lib/MangroveTest.sol
@@ -144,8 +144,6 @@ contract MangroveTest is Test2, HasMgvEvents {
   }
 
   AbstractMangrove internal mgv;
-  TestMangrove internal testMgv; // FIXME: Temporary way to allows snipes in tests until all test have migrated to `clean` and `marketOrder`. See also TestMangrove further down.
-  TestInvertedMangrove internal testInvertedMgv; // FIXME: Temporary way to allows snipes in tests until all test have migrated to `clean` and `marketOrder`. See also TestMangrove further down.
   MgvReader internal reader;
   TestToken internal base;
   TestToken internal quote;
@@ -295,29 +293,17 @@ contract MangroveTest is Test2, HasMgvEvents {
   // Deploy mangrove, inverted or not
   function setupMangrove(bool inverted) public returns (AbstractMangrove _mgv) {
     if (inverted) {
-      // FIXME: Remove once migration away from `snipes` has been completed
-      _mgv = testInvertedMgv = new TestInvertedMangrove({
+      _mgv = new InvertedMangrove({
         governance: $(this),
         gasprice: options.gasprice,
         gasmax: options.gasmax
       });
-      // _mgv = new InvertedMangrove({
-      //   governance: $(this),
-      //   gasprice: options.gasprice,
-      //   gasmax: options.gasmax
-      // });
     } else {
-      // FIXME: Remove once migration away from `snipes` has been completed
-      _mgv = testMgv = new TestMangrove({
+      _mgv = new Mangrove({
         governance: $(this),
         gasprice: options.gasprice,
         gasmax: options.gasmax
       });
-      // _mgv = new Mangrove({
-      //   governance: $(this),
-      //   gasprice: options.gasprice,
-      //   gasmax: options.gasmax
-      // });
     }
     vm.label($(_mgv), "Mangrove");
   }
@@ -364,9 +350,7 @@ contract MangroveTest is Test2, HasMgvEvents {
   }
 
   function setupTaker(address $out, address $in, string memory label) public returns (TestTaker) {
-    // FIXME: Temporary while migrating tests away from `snipes`
-    // TestTaker tt = new TestTaker(mgv, IERC20($out), IERC20($in));
-    TestTaker tt = new TestTaker(testMgv, IERC20($out), IERC20($in));
+    TestTaker tt = new TestTaker(mgv, IERC20($out), IERC20($in));
     vm.deal(address(tt), 100 ether);
     vm.label(address(tt), label);
     return tt;
@@ -585,173 +569,4 @@ contract MangroveTest is Test2, HasMgvEvents {
   function logTickTreeBranch(address outbound_tkn, address inbound_tkn) public view {
     Pair({mgv: mgv, reader: reader, outbound_tkn: outbound_tkn, inbound_tkn: inbound_tkn}).logTickTreeBranch();
   }
-}
-
-// FIXME: This is a temporary contract that will be removed once all tests are migrated away from the old `snipes`.
-abstract contract TestSnipingMangrove is MgvOfferTakingWithPermit {
-  // FIXME: The snipe code has been moved from MgvOfferTaking and MgvOfferTakingWithPermit w/o changes except renames of `snipes*` to `snipes*InTest`.
-  /* The delegate version of `snipes` is `snipesFor`, which takes a `taker` address as additional argument. */
-  function snipesForInTest(
-    address outbound_tkn,
-    address inbound_tkn,
-    uint[4][] calldata targets,
-    bool fillWants,
-    address taker
-  ) external returns (uint successes, uint takerGot, uint takerGave, uint bounty, uint feePaid) {
-    unchecked {
-      (successes, takerGot, takerGave, bounty, feePaid) =
-        generalSnipes(outbound_tkn, inbound_tkn, targets, fillWants, taker);
-      /* The sender's allowance is verified after the order complete so that the actual amounts are checked against the allowance, instead of the declared `takerGives`. The former may be lower.
-    
-    An immediate consequence is that any funds available to Mangrove through `approve` can be used to clean offers. After a `snipesFor` where all offers have failed, all token transfers have been reverted, so `takerGave=0` and the check will succeed -- but the sender will still have received the bounty of the failing offers. */
-      deductSenderAllowance(outbound_tkn, inbound_tkn, taker, takerGave);
-    }
-  }
-
-  /* `snipes` executes multiple offers. It takes a `uint[4][]` as penultimate argument, with each array element of the form `[offerId,tick,fillVolume,offerGasreq]`. The return parameters are of the form `(successes,snipesGot,snipesGave,bounty,feePaid)`. 
-  Note that we do not distinguish further between mismatched arguments/offer fields on the one hand, and an execution failure on the other. Still, a failed offer has to pay a penalty, and ultimately transaction logs explicitly mention execution failures (see `MgvLib.sol`). */
-
-  function snipesInTest(address outbound_tkn, address inbound_tkn, uint[4][] calldata targets, bool fillWants)
-    external
-    returns (uint, uint, uint, uint, uint)
-  {
-    unchecked {
-      return generalSnipes(outbound_tkn, inbound_tkn, targets, fillWants, msg.sender);
-    }
-  }
-
-  /*
-     From an array of _n_ `[offerId, tick,fillVolume,gasreq]` elements, execute each snipe in sequence. Returns `(successes, takerGot, takerGave, bounty, feePaid)`. 
-
-     Note that if this function is not internal, anyone can make anyone use Mangrove.
-     Note that unlike general market order, the returned total values are _not_ `mor.totalGot` and `mor.totalGave`, since those are reset at every iteration of the `targets` array. Instead, accumulators `snipesGot` and `snipesGave` are used. */
-  function generalSnipes(
-    address outbound_tkn,
-    address inbound_tkn,
-    uint[4][] calldata targets,
-    bool fillWants,
-    address taker
-  ) internal returns (uint successCount, uint snipesGot, uint snipesGave, uint totalPenalty, uint feePaid) {
-    unchecked {
-      MultiOrder memory mor;
-      mor.taker = taker;
-      mor.fillWants = fillWants;
-
-      MgvLib.SingleOrder memory sor;
-      sor.outbound_tkn = outbound_tkn;
-      sor.inbound_tkn = inbound_tkn;
-      Pair storage pair;
-      (sor.global, sor.local, pair) = _config(outbound_tkn, inbound_tkn);
-
-      /* For the snipes to even start, the market needs to be both active and not currently protected from reentrancy. */
-      activeMarketOnly(sor.global, sor.local);
-      unlockedMarketOnly(sor.local);
-
-      emit OrderStart();
-
-      /* ### Main loop */
-      //+clear+
-
-      /* Call `internalSnipes` function. */
-      (successCount, snipesGot, snipesGave) = internalSnipes(pair, mor, sor, targets);
-
-      /* Over the course of the snipes order, a penalty reserved for `msg.sender` has accumulated in `mor.totalPenalty`. No actual transfers have occured yet -- all the ethers given by the makers as provision are owned by Mangrove. `sendPenalty` finally gives the accumulated penalty to `msg.sender`. */
-      sendPenalty(mor.totalPenalty);
-      //+clear+
-
-      emit OrderComplete(sor.outbound_tkn, sor.inbound_tkn, taker, snipesGot, snipesGave, mor.totalPenalty, mor.feePaid);
-      totalPenalty = mor.totalPenalty;
-      feePaid = mor.feePaid;
-    }
-  }
-
-  /* ## Internal snipes */
-  //+clear+
-  /* `internalSnipes` works by looping over targets. Each successive offer is executed under a [reentrancy lock](#internalSnipes/liftReentrancy), then its posthook is called. Going upward, each offer's `maker` contract is called again with its remaining gas and given the chance to update its offers on the book. */
-  function internalSnipes(
-    Pair storage pair,
-    MultiOrder memory mor,
-    MgvLib.SingleOrder memory sor,
-    uint[4][] calldata targets
-  ) internal returns (uint successCount, uint snipesGot, uint snipesGave) {
-    unchecked {
-      for (uint i = 0; i < targets.length; ++i) {
-        /* Reset these amounts since every snipe is treated individually. Only the total penalty is sent at the end of all snipes. */
-        mor.totalGot = 0;
-        mor.totalGave = 0;
-
-        /* Initialize single order struct. */
-        sor.offerId = targets[i][0];
-        OfferData storage offerData = pair.offerData[sor.offerId];
-        sor.offer = offerData.offer;
-        sor.offerDetail = offerData.detail;
-
-        /* If we removed the `isLive` conditional, a single expired or nonexistent offer in `targets` would revert the entire transaction (by the division by `offer.gives` below since `offer.gives` would be 0). We also check that `gasreq` is not worse than specified. A taker who does not care about `gasreq` can specify any amount larger than $2^{24}-1$. A mismatched price will be detected by `execute`. */
-        if (!sor.offer.isLive() || sor.offerDetail.gasreq() > targets[i][3]) {
-          /* We move on to the next offer in the array. */
-          continue;
-        } else {
-          {
-            Tick tick = Tick.wrap(int(targets[i][1]));
-            require(TickLib.inRange(tick), "mgv/snipes/tick/outOfRange");
-            mor.maxTick = tick;
-          }
-          {
-            uint fillVolume = targets[i][2];
-            require(uint96(fillVolume) == fillVolume, "mgv/snipes/volume/96bits");
-            mor.fillVolume = fillVolume;
-          }
-
-          /* We start be enabling the reentrancy lock for this (`outbound_tkn`,`inbound_tkn`) pair. */
-          sor.local = sor.local.lock(true);
-          pair.local = sor.local;
-
-          /* `execute` will adjust `sor.wants`,`sor.gives`, and may attempt to execute the offer if its price is low enough. It is crucial that an error due to `taker` triggers a revert. That way [`mgvData`](#MgvOfferTaking/statusCodes) not in `["mgv/tradeSuccess","mgv/notExecuted"]` means the failure is the maker's fault. */
-          /* Post-execution, `sor.wants`/`sor.gives` reflect how much was sent/taken by the offer. */
-          (uint gasused, bytes32 makerData, bytes32 mgvData) = execute(pair, mor, sor);
-
-          if (mgvData == "mgv/tradeSuccess") {
-            successCount += 1;
-          }
-
-          /* In the market order, we were able to avoid stitching back offers after every `execute` since we knew a continuous segment starting at best would be consumed. Here, we cannot do this optimisation since offers in the `targets` array may be anywhere in the book. So we stitch together offers immediately after each `execute`. */
-          if (mgvData != "mgv/notExecuted") {
-            // updates best&tick
-            sor.local = dislodgeOffer(pair, sor.offer, sor.local, true);
-          }
-
-          /* <a id="internalSnipes/liftReentrancy"></a> Now that the current snipe is over, we can lift the lock on the book. In the same operation we
-        * lift the reentrancy lock, and
-        * update the storage
-
-        so we are free from out of order storage writes.
-        */
-          sor.local = sor.local.lock(false);
-          pair.local = sor.local;
-
-          /* `payTakerMinusFees` keeps the fee in Mangrove, proportional to the amount purchased, and gives the rest to the taker */
-          payTakerMinusFees(mor, sor);
-
-          /* In an inverted Mangrove, amounts have been lent by each offer's maker to the taker. We now call the taker. This is a noop in a normal Mangrove. */
-          executeEnd(mor, sor);
-
-          /* After an offer execution, we may run callbacks and increase the total penalty. As that part is common to market orders and snipes, it lives in its own `postExecute` function. */
-          if (mgvData != "mgv/notExecuted") {
-            postExecute(mor, sor, gasused, makerData, mgvData);
-          }
-
-          snipesGot += mor.totalGot;
-          snipesGave += mor.totalGave;
-        }
-      }
-    }
-  }
-}
-
-contract TestMangrove is Mangrove, TestSnipingMangrove {
-  constructor(address governance, uint gasprice, uint gasmax) Mangrove(governance, gasprice, gasmax) {}
-}
-
-contract TestInvertedMangrove is InvertedMangrove, TestSnipingMangrove {
-  constructor(address governance, uint gasprice, uint gasmax) InvertedMangrove(governance, gasprice, gasmax) {}
 }

--- a/test/lib/agents/TestTaker.sol
+++ b/test/lib/agents/TestTaker.sol
@@ -3,8 +3,6 @@
 pragma solidity ^0.8.10;
 
 import {AbstractMangrove} from "mgv_src/AbstractMangrove.sol";
-// FIXME: Temporarily use TestMangrove until all tests are migrated away from snipes
-import {TestMangrove} from "mgv_test/lib/MangroveTest.sol";
 import {IERC20, ITaker, MgvLib} from "mgv_src/MgvLib.sol";
 import {Script2} from "mgv_lib/Script2.sol";
 import {TransferLib} from "mgv_lib/TransferLib.sol";
@@ -12,15 +10,12 @@ import {Tick} from "mgv_lib/TickLib.sol";
 
 contract TestTaker is ITaker, Script2 {
   AbstractMangrove _mgv;
-  TestMangrove _testMgv;
   address _base;
   address _quote;
   bool acceptNative = true;
 
-  // constructor(AbstractMangrove mgv, IERC20 base, IERC20 quote) {
-  constructor(TestMangrove mgv, IERC20 base, IERC20 quote) {
+  constructor(AbstractMangrove mgv, IERC20 base, IERC20 quote) {
     _mgv = mgv;
-    _testMgv = mgv;
     _base = address(base);
     _quote = address(quote);
   }
@@ -37,16 +32,6 @@ contract TestTaker is ITaker, Script2 {
 
   function approveSpender(address spender, uint amount) external {
     _mgv.approve(_base, _quote, spender, amount);
-  }
-
-  // FIXME: This is only by Scenarii.t.sol which is not easy to migrate nor determine if is still relevant
-  function takeWithInfo(uint offerId, uint takerWants) external returns (bool, uint, uint, uint, uint) {
-    Tick tick = _mgv.offers(_base, _quote, offerId).tick();
-    uint[4][] memory targets = wrap_dynamic([offerId, uint(Tick.unwrap(tick)), takerWants, type(uint48).max]);
-    (uint successes, uint got, uint gave, uint totalPenalty, uint feePaid) =
-      _testMgv.snipesInTest(_base, _quote, targets, true);
-    return (successes == 1, got, gave, totalPenalty, feePaid);
-    //return taken;
   }
 
   function clean(uint offerId, uint takerWants) public returns (bool success) {


### PR DESCRIPTION
This PR completes the replacement of `snipes` with `cleanByImpersonation` started in  #437 by migrating all tests away from `snipes` and `snipesFor`. 

TODO:
- [ ]  The main test in `Scenarii.t.sol` relied on snipe. It is not clear to me whether it's a test of sniping (and thus can be deleted) or if it also tests something else (and thus should be removed)? @jkrivine maybe knows?

