### PR TITLE
fix: correct leaf and best.prev after partially consumed tick

### DIFF
--- a/src/MgvHasOffers.sol
+++ b/src/MgvHasOffers.sol
@@ -179,6 +179,13 @@ contract MgvHasOffers is MgvRoot {
             if (index == local.tick().level1Index()) {
               field = local.level1().flipBitAtLevel1(offerTick);
               local = local.level1(field);
+              // FIXME: this should be moved to the matching if(shouldUpdateBranch)
+              // that would avoid an unnecessary write when !shouldUpdateBranch
+              // but we need to still have acces to the index
+              // and also must check that the case local.level2().isEmpty()
+              // does not result in corrupted data (eg a wrong yet trusted pair.level1[index])
+              // (answer is probably that local.level2().isEmpty should not return
+              // but rather let control flow continue, and that log2/ctz should not throw on 0
               if (field.isEmpty()) {
                 pair.level1[index] = field;
               }

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -1046,7 +1046,6 @@ contract TakerOperationsTest is MangroveTest {
     assertEq(best.prev(), 0, "best.prev should be 0");
     Leaf emptyLeaf = leaf.setTickFirst(tick, 0).setTickLast(tick, 0);
     assertTrue(emptyLeaf.isEmpty(), "leaf should not have other tick used");
-    // console.log(toString(pair.leafs(leafIndex)));
   }
 }
 

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -1045,7 +1045,7 @@ contract TakerOperationsTest is MangroveTest {
     assertEq(pair.local().tickPosInLeaf(), tick.posInLeaf(), "wrong local.tickPosInleaf");
     assertEq(best.prev(), 0, "best.prev should be 0");
     Leaf emptyLeaf = leaf.setTickFirst(tick, 0).setTickLast(tick, 0);
-    assertTrue(emptyLeaf.isEmpty(), "leaf should have not other tick used");
+    assertTrue(emptyLeaf.isEmpty(), "leaf should not have other tick used");
     // console.log(toString(pair.leafs(leafIndex)));
   }
 }


### PR DESCRIPTION
fix bug found by @espendk 

test checks correctness under a range of conditions (marketORder starts at tick or before tick, leave 1 or >1 offers in tick)