### PR TITLE
tick math

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "lib/solady"]
+	path = lib/solady
+	url = https://github.com/Vectorized/solady

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
-[submodule "lib/solady"]
-	path = lib/solady
-	url = https://github.com/Vectorized/solady

--- a/lib/Constants.sol
+++ b/lib/Constants.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.17;
+
+uint constant ONES = type(uint).max;
+uint constant TOPBIT = 1 << 255;
+
+// MIN_TICK and MAX_TICK should be inside the addressable range defined by the sizes of LEAF, LEVEL0, LEVEL1, LEVEL2
+int constant MIN_TICK = -524287;
+int constant MAX_TICK = -MIN_TICK;
+
+// sizes must match field sizes in structs.ts where relevant
+uint constant TICK_BITS = 24;
+uint constant OFFER_BITS = 32;
+
+// only power-of-two sizes are supported for LEAF_SIZE and LEVEL*_SIZE
+uint constant LEAF_SIZE_BITS = 2; 
+uint constant LEVEL0_SIZE_BITS = 6;
+uint constant LEVEL1_SIZE_BITS = 6;
+uint constant LEVEL2_SIZE_BITS = 6;
+
+int constant LEAF_SIZE = int(2 ** (LEAF_SIZE_BITS));
+int constant LEVEL0_SIZE = int(2 ** (LEVEL0_SIZE_BITS));
+int constant LEVEL1_SIZE = int(2 ** (LEVEL1_SIZE_BITS));
+int constant LEVEL2_SIZE = int(2 ** (LEVEL2_SIZE_BITS));
+
+uint constant LEAF_SIZE_MASK = ~(ONES << LEAF_SIZE_BITS);
+uint constant LEVEL0_SIZE_MASK = ~(ONES << LEVEL0_SIZE_BITS);
+uint constant LEVEL1_SIZE_MASK = ~(ONES << LEVEL1_SIZE_BITS);
+uint constant LEVEL2_SIZE_MASK = ~(ONES << LEVEL2_SIZE_BITS);
+
+int constant NUM_LEVEL1 = int(LEVEL2_SIZE);
+int constant NUM_LEVEL0 = NUM_LEVEL1 * LEVEL1_SIZE;
+int constant NUM_LEAFS = NUM_LEVEL0 * LEVEL0_SIZE;
+int constant NUM_TICKS = NUM_LEAFS * LEAF_SIZE;
+
+uint constant OFFER_MASK = ONES >> (256 - OFFER_BITS);
+
+
+
+// +/- 2**20-1 because only 20 bits are examined by the logPrice->price function
+int constant MIN_LOG_PRICE = -((1 << 20)-1);
+int constant MAX_LOG_PRICE = -MIN_LOG_PRICE;
+uint constant MIN_PRICE_MANTISSA = 4735129379934731672174804159539094721182826496;
+int constant MIN_PRICE_EXP = 303;
+uint constant MAX_PRICE_MANTISSA = 3441571814221581909035848501253497354125574144;
+int constant MAX_PRICE_EXP = 0;
+uint constant MANTISSA_BITS = 152;
+uint constant MANTISSA_BITS_MINUS_ONE = MANTISSA_BITS-1;
+// Maximum volume that can be multiplied by a price mantissa
+uint constant MAX_SAFE_VOLUME = (1<<(256-MANTISSA_BITS+1))-1;

--- a/lib/DensityLib.sol
+++ b/lib/DensityLib.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.17;
 
 import {Tick,Field} from "mgv_lib/TickLib.sol";
-
+import {MIN_LOG_PRICE,ONES} from "mgv_lib/Constants.sol";
 import {BitLib} from "mgv_lib/BitLib.sol";
 
 /* Density
@@ -43,8 +43,6 @@ so the small values have some holes:
 
 type Density is uint;
 using DensityLib for Density global;
-
-uint constant ONES = type(uint).max;
 
 library DensityLib {
   // Numbers in this file assume that density is 9 bits in structs.ts

--- a/lib/LogPriceConversionLib.sol
+++ b/lib/LogPriceConversionLib.sol
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.17;
+
+import "mgv_lib/Constants.sol";
+import "mgv_lib/BitLib.sol";
+
+library LogPriceConversionLib {
+  // returns a normalized price
+  // outbound constraint is for consistency, could be higher
+  function priceFromVolumes(uint inboundAmt, uint outboundAmt) internal pure returns (uint mantissa, uint exp) {
+    require(inboundAmt <= MAX_SAFE_VOLUME, "priceFromVolumes/inbound/tooBig");
+    require(outboundAmt <= MAX_SAFE_VOLUME, "priceFromVolumes/outbound/tooBig");
+    require(outboundAmt != 0, "priceFromVolumes/outbound/0");
+    require(inboundAmt != 0, "priceFromVolumes/inbound/0");
+    uint ratio = (inboundAmt << MANTISSA_BITS) / outboundAmt; 
+    // ratio cannot be 0 as long as (1<<MANTISSA_BITS)/MAX_SAFE_VOLUME > 0
+    uint log2 = BitLib.fls(ratio);
+    if (log2 > MANTISSA_BITS_MINUS_ONE) {
+      uint diff = log2 - MANTISSA_BITS_MINUS_ONE;
+      return (ratio >> diff, MANTISSA_BITS - diff);
+    } else {
+      uint diff = MANTISSA_BITS_MINUS_ONE - log2;
+      return (ratio << diff, MANTISSA_BITS + diff);
+    }
+  }
+
+  function logPriceFromVolumes(uint inboundAmt, uint outboundAmt) internal pure returns (int24 logPrice) {
+    (uint man, uint exp) = priceFromVolumes(inboundAmt, outboundAmt);
+    return logPriceFromNormalizedPrice(man,exp);
+  }
+
+  // expects a normalized price float
+  function logPriceFromPrice(uint mantissa, int exp) internal pure returns (int24) {
+    uint normalized_exp;
+    (mantissa, normalized_exp) = normalizePrice(mantissa, exp);
+    return logPriceFromNormalizedPrice(mantissa,normalized_exp);
+  }
+
+  // return greatest logPrice t such that price(logPrice) <= input price
+  // does not expect a normalized price float
+  function logPriceFromNormalizedPrice(uint mantissa, uint exp) internal pure returns (int24 logPrice) {
+    if (floatLt(mantissa, int(exp), MIN_PRICE_MANTISSA, MIN_PRICE_EXP)) {
+      revert("mgv/price/tooLow");
+    }
+    if (floatLt(MAX_PRICE_MANTISSA, MAX_PRICE_EXP, mantissa, int(exp))) {
+      revert("mgv/price/tooHigh");
+    }
+    int log2price = int(MANTISSA_BITS_MINUS_ONE) - int(exp) << 64;
+    uint mpow = mantissa >> MANTISSA_BITS_MINUS_ONE - 127; // give 129 bits of room left
+
+    assembly ("memory-safe") {
+      // 13 bits of precision
+      mpow := shr(127, mul(mpow, mpow))
+      let highbit := shr(128, mpow)
+      log2price := or(log2price, shl(63, highbit))
+      mpow := shr(highbit, mpow)
+
+      mpow := shr(127, mul(mpow, mpow))
+      highbit := shr(128, mpow)
+      log2price := or(log2price, shl(62, highbit))
+      mpow := shr(highbit, mpow)
+
+      mpow := shr(127, mul(mpow, mpow))
+      highbit := shr(128, mpow)
+      log2price := or(log2price, shl(61, highbit))
+      mpow := shr(highbit, mpow)
+
+      mpow := shr(127, mul(mpow, mpow))
+      highbit := shr(128, mpow)
+      log2price := or(log2price, shl(60, highbit))
+      mpow := shr(highbit, mpow)
+
+      mpow := shr(127, mul(mpow, mpow))
+      highbit := shr(128, mpow)
+      log2price := or(log2price, shl(59, highbit))
+      mpow := shr(highbit, mpow)
+
+      mpow := shr(127, mul(mpow, mpow))
+      highbit := shr(128, mpow)
+      log2price := or(log2price, shl(58, highbit))
+      mpow := shr(highbit, mpow)
+
+      mpow := shr(127, mul(mpow, mpow))
+      highbit := shr(128, mpow)
+      log2price := or(log2price, shl(57, highbit))
+      mpow := shr(highbit, mpow)
+
+      mpow := shr(127, mul(mpow, mpow))
+      highbit := shr(128, mpow)
+      log2price := or(log2price, shl(56, highbit))
+      mpow := shr(highbit, mpow)
+
+      mpow := shr(127, mul(mpow, mpow))
+      highbit := shr(128, mpow)
+      log2price := or(log2price, shl(55, highbit))
+      mpow := shr(highbit, mpow)
+
+      mpow := shr(127, mul(mpow, mpow))
+      highbit := shr(128, mpow)
+      log2price := or(log2price, shl(54, highbit))
+      mpow := shr(highbit, mpow)
+
+      mpow := shr(127, mul(mpow, mpow))
+      highbit := shr(128, mpow)
+      log2price := or(log2price, shl(53, highbit))
+      mpow := shr(highbit, mpow)
+
+      mpow := shr(127, mul(mpow, mpow))
+      highbit := shr(128, mpow)
+      log2price := or(log2price, shl(52, highbit))
+      mpow := shr(highbit, mpow)
+
+      mpow := shr(127, mul(mpow, mpow))
+      highbit := shr(128, mpow)
+      log2price := or(log2price, shl(51, highbit))
+      mpow := shr(highbit, mpow)
+
+      mpow := shr(127, mul(mpow, mpow))
+      highbit := shr(128, mpow)
+      log2price := or(log2price, shl(50, highbit))
+    }
+
+    int log_bp_price = log2price * 127869479499801913173570;
+
+    int24 logPriceLow = int24((log_bp_price - 1701479891078076505009565712080972645) >> 128);
+    int24 logPriceHigh = int24((log_bp_price + 290040965921304576580754310682015830659) >> 128);
+
+    (uint mantissaHigh, uint expHigh) = priceFromLogPrice(logPriceHigh);
+
+    bool priceHighGt = floatLt(mantissa, int(exp), mantissaHigh, int(expHigh));
+    if (logPriceLow == logPriceHigh || priceHighGt) {
+      logPrice = logPriceLow;
+    } else { 
+      logPrice = logPriceHigh;
+    }
+  }
+
+  // normalized float comparison
+  function floatLt(uint mantissa_a, int exp_a, uint mantissa_b, int exp_b) internal pure returns (bool) {
+    return (exp_a > exp_b || (exp_a == exp_b && mantissa_a < mantissa_b));
+  }
+
+  // return price from logPrice, as a non-normalized float (meaning the leftmost set bit is not always in the  same position)
+  // first return value is the mantissa, second value is the opposite of the exponent
+  function nonNormalizedPriceFromLogPrice(int logPrice) internal pure returns (uint man, uint exp) {
+    uint absLogPrice = logPrice < 0 ? uint(-int(logPrice)) : uint(logPrice);
+    require(absLogPrice <= uint(MAX_LOG_PRICE), "absLogPrice/outOfBounds");
+
+    // each 1.0001^(2^i) below is shifted 128+(an additional shift value)
+    int extra_shift;
+    if (absLogPrice & 0x1 != 0) {
+      man = 0xfff97272373d413259a46990580e2139;
+    } else {
+      man = 0x100000000000000000000000000000000;
+    }
+    if (absLogPrice & 0x2 != 0) {
+      man = (man * 0xfff2e50f5f656932ef12357cf3c7fdcb) >> 128;
+    }
+    if (absLogPrice & 0x4 != 0) {
+      man = (man * 0xffe5caca7e10e4e61c3624eaa0941ccf) >> 128;
+    }
+    if (absLogPrice & 0x8 != 0) {
+      man = (man * 0xffcb9843d60f6159c9db58835c926643) >> 128;
+    }
+    if (absLogPrice & 0x10 != 0) {
+      man = (man * 0xff973b41fa98c081472e6896dfb254bf) >> 128;
+    }
+    if (absLogPrice & 0x20 != 0) {
+      man = (man * 0xff2ea16466c96a3843ec78b326b52860) >> 128;
+    }
+    if (absLogPrice & 0x40 != 0) {
+      man = (man * 0xfe5dee046a99a2a811c461f1969c3052) >> 128;
+    }
+    if (absLogPrice & 0x80 != 0) {
+      man = (man * 0xfcbe86c7900a88aedcffc83b479aa3a3) >> 128;
+    }
+    if (absLogPrice & 0x100 != 0) {
+      man = (man * 0xf987a7253ac413176f2b074cf7815e53) >> 128;
+    }
+    if (absLogPrice & 0x200 != 0) {
+      man = (man * 0xf3392b0822b70005940c7a398e4b70f2) >> 128;
+    }
+    if (absLogPrice & 0x400 != 0) {
+      man = (man * 0xe7159475a2c29b7443b29c7fa6e889d8) >> 128;
+    }
+    if (absLogPrice & 0x800 != 0) {
+      man = (man * 0xd097f3bdfd2022b8845ad8f792aa5825) >> 128;
+    }
+    if (absLogPrice & 0x1000 != 0) {
+      man = (man * 0xa9f746462d870fdf8a65dc1f90e061e4) >> 128;
+    }
+    if (absLogPrice & 0x2000 != 0) {
+      man = (man * 0xe1b0d342ada5437121767bec575e65ed) >> 128;
+      extra_shift += 1;
+    }
+    if (absLogPrice & 0x4000 != 0) {
+      man = (man * 0xc6f84d7e5f423f66048c541550bf3e96) >> 128;
+      extra_shift += 2;
+    }
+    if (absLogPrice & 0x8000 != 0) {
+      man = (man * 0x9aa508b5b7a84e1c677de54f3e99bc8f) >> 128;
+      extra_shift += 4;
+    }
+    if (absLogPrice & 0x10000 != 0) {
+      man = (man * 0xbad5f1bdb70232cd33865244bdcc089c) >> 128;
+      extra_shift += 9;
+    }
+    if (absLogPrice & 0x20000 != 0) {
+      man = (man * 0x885b9613d7e87aa498106fb7fa5edd37) >> 128;
+      extra_shift += 18;
+    }
+    if (absLogPrice & 0x40000 != 0) {
+      man = (man * 0x9142e0723efb884889d1f447715afacd) >> 128;
+      extra_shift += 37;
+    }
+    if (absLogPrice & 0x80000 != 0) {
+      man = (man * 0xa4d9a773d61316918f140bd96e8e6814) >> 128;
+      extra_shift += 75;
+    }
+    if (logPrice > 0) {
+      man = type(uint).max / man;
+      extra_shift = -extra_shift;
+    }
+    // 18 ensures exp>= 0
+    man = man << 18;
+    exp = uint(128 + 18 + extra_shift);
+  }
+
+  // return price from logPrice, as a normalized float
+  // first return value is the mantissa, second value is -exp
+  function priceFromLogPrice(int logPrice) internal pure returns (uint man, uint exp) {
+    (man, exp) = nonNormalizedPriceFromLogPrice(logPrice);
+
+    uint log_bp_2X232 = 47841652135324370225811382070797757678017615758549045118126590952295589692;
+    // log_1.0001(price) * log_2(1.0001)
+    int log2price = (int(logPrice) << 232) / int(log_bp_2X232);
+    // floor(log) towards negative infinity
+    if (logPrice < 0 && int(logPrice) << 232 % log_bp_2X232 != 0) {
+      log2price = log2price - 1;
+    }
+    // MANTISSA_BITS was chosen so that diff cannot be <0 
+    uint diff = uint(int(MANTISSA_BITS_MINUS_ONE) - int(exp) - log2price);
+    man = man << diff;
+    exp = exp + diff;
+  }
+
+  // normalize a price float
+  // normalizes a representation of mantissa * 2^-exp
+  // examples:
+  // 1 ether:1 -> normalizePrice(1 ether, 0)
+  // 1: 1 ether -> normalizePrice(1,?)
+  // 1:1 -> normalizePrice(1,0)
+  // 1:2 -> normalizePrice(1,1)
+  function normalizePrice(uint mantissa, int exp) internal pure returns (uint, uint) {
+    require(mantissa != 0,"normalizePrice/mantissaIs0");
+    uint log2price = BitLib.fls(mantissa);
+    int shift = int(MANTISSA_BITS_MINUS_ONE) - int(log2price);
+    if (shift < 0) {
+      mantissa = mantissa >> uint(-shift);
+    } else {
+      mantissa = mantissa << uint(shift);
+    }
+    log2price = BitLib.fls(mantissa);
+    exp = exp + shift;
+    if (exp < 0) {
+      revert("mgv/normalizePrice/lowExp");
+    }
+    return (mantissa,uint(exp));
+  }
+}

--- a/lib/LogPriceConversionLib.sol
+++ b/lib/LogPriceConversionLib.sol
@@ -260,7 +260,6 @@ library LogPriceConversionLib {
     } else {
       mantissa = mantissa << uint(shift);
     }
-    log2price = BitLib.fls(mantissa);
     exp = exp + shift;
     if (exp < 0) {
       revert("mgv/normalizePrice/lowExp");

--- a/lib/LogPriceLib.sol
+++ b/lib/LogPriceLib.sol
@@ -16,15 +16,6 @@ library LogPriceLib {
     return Tick.unwrap(tick) * int(tickScale);
   }
 
-  function logPriceFromTakerVolumes(uint takerGives, uint takerWants) internal pure returns (int) {
-    if (takerGives == 0 || takerWants == 0) {
-
-      // If inboundAmt is 0 then the price is irrelevant for taker
-      return MAX_LOG_PRICE;
-    }
-    return LogPriceConversionLib.logPriceFromVolumes(takerGives, takerWants);
-  }
-
   // tick underestimates the price, so we underestimate  inbound here, i.e. the inbound/outbound price will again be underestimated
   // no overflow if outboundAmt is on 104 bits
   // rounds down

--- a/lib/LogPriceLib.sol
+++ b/lib/LogPriceLib.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.17;
+
+import {Tick} from "mgv_lib/TickLib.sol";
+import "mgv_lib/Constants.sol";
+import "mgv_lib/LogPriceConversionLib.sol";
+
+library LogPriceLib {
+
+  function inRange(int logPrice) internal pure returns (bool) {
+    return logPrice >= MIN_LOG_PRICE && logPrice <= MAX_LOG_PRICE;
+  }
+  // 
+  // FIXME ensure that you only called tick*tickScale if you previously stored the tick as a result of logPrice/tickScale. Otherwise you may go beyond the MAX/MIN.
+  function fromTick(Tick tick, uint tickScale) internal pure returns (int) {
+    return Tick.unwrap(tick) * int(tickScale);
+  }
+
+  function logPriceFromTakerVolumes(uint takerGives, uint takerWants) internal pure returns (int) {
+    if (takerGives == 0 || takerWants == 0) {
+
+      // If inboundAmt is 0 then the price is irrelevant for taker
+      return MAX_LOG_PRICE;
+    }
+    return LogPriceConversionLib.logPriceFromVolumes(takerGives, takerWants);
+  }
+
+  // tick underestimates the price, so we underestimate  inbound here, i.e. the inbound/outbound price will again be underestimated
+  // no overflow if outboundAmt is on 104 bits
+  // rounds down
+  function inboundFromOutbound(int logPrice, uint outboundAmt) internal pure returns (uint) {
+    (uint sig, uint exp) = LogPriceConversionLib.nonNormalizedPriceFromLogPrice(logPrice);
+    return (sig * outboundAmt) >> exp;
+  }
+
+  // no overflow if outboundAmt is on 104 bits
+  // rounds up
+  function inboundFromOutboundUp(int logPrice, uint outboundAmt) internal pure returns (uint) {
+    (uint sig, uint exp) = LogPriceConversionLib.nonNormalizedPriceFromLogPrice(logPrice);
+    uint prod = sig*outboundAmt;
+    return (prod>>exp) + (prod%(1<<exp)==0 ? 0 : 1);
+  }
+
+  // temporarily commenting this out because it's used in commented out tests
+  // function inboundFromOutboundUpTick(Tick tick, uint outboundAmt) internal pure returns (uint) {
+  //   uint nextPrice_e18 = Tick.wrap(Tick.unwrap(tick)+1).priceFromTick_e18();
+  //   uint prod = nextPrice_e18 * outboundAmt;
+  //   prod = prod/1e18;
+  //   if (prod == 0) {
+  //     return 0;
+  //   }
+  //   return prod-1;
+  // }  
+
+  // tick underestimates the price, and we underestimate outbound here, so price will be overestimated here
+  // no overflow if inboundAmt is on 104 bits
+  // rounds down
+  function outboundFromInbound(int logPrice, uint inboundAmt) internal pure returns (uint) {
+    (uint sig, uint exp) = LogPriceConversionLib.nonNormalizedPriceFromLogPrice(-logPrice);
+    return (sig * inboundAmt) >> exp;
+  }
+
+  function outboundFromInboundUp(int logPrice, uint inboundAmt) internal pure returns (uint) {
+    (uint sig, uint exp) = LogPriceConversionLib.nonNormalizedPriceFromLogPrice(-logPrice);
+    uint prod = sig*inboundAmt;
+    return (prod>>exp) + (prod%(1<<exp)==0 ? 0 : 1);
+  }
+
+
+
+}

--- a/lib/TickLib.sol
+++ b/lib/TickLib.sol
@@ -1,42 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.17;
 
+import "mgv_lib/Constants.sol";
 import {BitLib} from "mgv_lib/BitLib.sol";
-
-import {FixedPointMathLib as FP} from "solady/utils/FixedPointMathLib.sol";
-uint constant ONES = type(uint).max;
-uint constant TOPBIT = 1 << 255;
-
-// MIN_TICK and MAX_TICK should be inside the addressable range defined by the sizes of LEAF, LEVEL0, LEVEL1, LEVEL2
-int constant MIN_TICK = -524287;
-int constant MAX_TICK = -MIN_TICK;
-
-// sizes must match field sizes in structs.ts where relevant
-uint constant TICK_BITS = 24;
-uint constant OFFER_BITS = 32;
-
-// only power-of-two sizes are supported for LEAF_SIZE and LEVEL*_SIZE
-uint constant LEAF_SIZE_BITS = 2; 
-uint constant LEVEL0_SIZE_BITS = 6;
-uint constant LEVEL1_SIZE_BITS = 6;
-uint constant LEVEL2_SIZE_BITS = 6;
-
-int constant LEAF_SIZE = int(2 ** (LEAF_SIZE_BITS));
-int constant LEVEL0_SIZE = int(2 ** (LEVEL0_SIZE_BITS));
-int constant LEVEL1_SIZE = int(2 ** (LEVEL1_SIZE_BITS));
-int constant LEVEL2_SIZE = int(2 ** (LEVEL2_SIZE_BITS));
-
-uint constant LEAF_SIZE_MASK = ~(ONES << LEAF_SIZE_BITS);
-uint constant LEVEL0_SIZE_MASK = ~(ONES << LEVEL0_SIZE_BITS);
-uint constant LEVEL1_SIZE_MASK = ~(ONES << LEVEL1_SIZE_BITS);
-uint constant LEVEL2_SIZE_MASK = ~(ONES << LEVEL2_SIZE_BITS);
-
-int constant NUM_LEVEL1 = int(LEVEL2_SIZE);
-int constant NUM_LEVEL0 = NUM_LEVEL1 * LEVEL1_SIZE;
-int constant NUM_LEAFS = NUM_LEVEL0 * LEVEL0_SIZE;
-int constant NUM_TICKS = NUM_LEAFS * LEAF_SIZE;
-
-uint constant OFFER_MASK = ONES >> (256 - OFFER_BITS);
 
 type Leaf is uint;
 
@@ -157,124 +123,8 @@ library LeafLib {
       }
     }
   }
-
 }
 
-library LogPriceLib {
-  // Could have an INVALID tick that is > 24 bits? But in `local` how do I write "empty"?
-  int constant BP = 1.0001 * 1e18;
-  // FP.lnWad(BP)
-  uint constant lnBP = 99995000333308;
-  // FIXME should depend on the min and max prices 
-  int constant MIN_LOG_PRICE = -524287;
-  int constant MAX_LOG_PRICE = -MIN_LOG_PRICE;
-
-  function inRange(int logPrice) internal pure returns (bool) {
-    return logPrice >= MIN_LOG_PRICE && logPrice <= MAX_LOG_PRICE;
-  }
-  function logPriceFromPrice_e18(uint price_e18) internal pure returns (int) {
-    return logPriceFromVolumes(price_e18, 1 ether);
-  }
-
-  // tick to price, price must not exceed max
-  // if tickscale is 1 maxtick is maxprice
-  // the only way there is a general max tickscale is if I cant have as many ticks as I want?
-  // 
-  // FIXME ensure that you only called tick*tickScale if you previously stored the tick as a result of logPrice/tickScale. Otherwise you may go beyond the MAX/MIN.
-  function fromTick(Tick tick, uint tickScale) internal pure returns (int) {
-    return Tick.unwrap(tick) * int(tickScale);
-  }
-
-
-  function logPriceFromTakerVolumes(uint takerGives, uint takerWants) internal pure returns (int) {
-    if (takerGives == 0 || takerWants == 0) {
-      // If inboundAmt is 0 then the price is irrelevant for taker
-      return MAX_LOG_PRICE;
-    }
-    return logPriceFromVolumes(takerGives, takerWants);
-  }
-
-  function logPriceFromVolumes(uint inboundAmt, uint outboundAmt) internal pure returns (int logPrice) {
-    (uint num, uint den) = (inboundAmt,outboundAmt);
-    if (inboundAmt < outboundAmt) {
-      (num,den) = (den,num);
-    } else {
-    }
-    int lnPrice = FP.lnWad(int(num * 1e18/den));
-    // why is univ3 not doing that? Because they start from a ratio < 1 ?
-    int lbpPrice = int(FP.divWad(uint(lnPrice),lnBP)/1e18);
-    // note this implies the lowest tick will never be used! (could use for something else?)
-    if (inboundAmt < outboundAmt) {
-      lbpPrice = - lbpPrice;
-    }
-
-    uint pr = priceFromLogPrice_e18(lbpPrice);
-    if (pr > inboundAmt * 1e18 / outboundAmt) {
-      lbpPrice = lbpPrice - 1;
-    } else {
-    }
-
-    return lbpPrice;
-  }
-
-  // priceFromTick_e18(Tick.wrap(MAX_TICK));
-  uint constant MAX_PRICE_E18 = 58661978243588296630604521258702056828566;
-  // priceFromTick_e18(Tick.wrap(MIN_TICK));
-  // FIXME: added 1 since it's currently 0, which is not a valid price
-  uint constant MIN_PRICE_E18 = 1;
-
-  // returns 1.0001^tick*1e18
-  // TODO: returned an even more scaled up price, as much as possible
-  //max pow before overflow when computing with fixedpointlib, and when overflow when multiplying 
-  /*
-    To avoid having to do a full-width mulDiv (or reducing the tick precision) when computing amounts from prices, we choose the following values:
-    - max tick is 694605 (a litte more than 1.3 * 2^19)
-    - min tick is -694605 (a litte more than 1.3 * 2^19)
-    - priceFromTick_e18 returns 1.0001^tick * 1e18
-    - with volumes on 96 bits, and a tick in range, there is no overflow doing bp^tick * 1e18 * volume / 1e18
-    */
-  function priceFromLogPrice_e18(int logPrice) internal pure returns (uint) {
-    require(inRange(logPrice),"mgv/priceFromLogPrice/outOfRange");
-    // FIXME this must round up so tick(price(tick)) = tick
-    // FIXME add a test for this
-    // Right now e.g. priceFromTick(1) is too low, and tickFromVolumes(1 ether,Tick(1).outboundFromInbound(1 ether)) is 0 (should be 1)
-    return uint(FP.powWad(BP, logPrice * 1e18));
-  }
-
-  // tick underestimates the price, so we underestimate  inbound here, i.e. the inbound/outbound price will again be underestimated
-  function inboundFromOutbound(int logPrice, uint outboundAmt) internal pure returns (uint) {
-    return priceFromLogPrice_e18(logPrice) * outboundAmt/1e18;
-  }
-
-  function inboundFromOutboundUp(int logPrice, uint outboundAmt) internal pure returns (uint) {
-    uint prod = priceFromLogPrice_e18(logPrice) * outboundAmt;
-    return prod/1e18 + (prod%1e18==0 ? 0 : 1);
-  }
-
-  function inboundFromOutboundUpTick(int logPrice, uint outboundAmt) internal pure returns (uint) {
-    uint nextPrice_e18 = priceFromLogPrice_e18(logPrice+1);
-    uint prod = nextPrice_e18 * outboundAmt;
-    prod = prod/1e18;
-    if (prod == 0) {
-      return 0;
-    }
-    return prod-1;
-  }  
-
-  // tick underestimates the price, and we udnerestimate outbound here, so price will be overestimated here
-  function outboundFromInbound(int logPrice, uint inboundAmt) internal pure returns (uint) {
-    return inboundAmt * 1e18/priceFromLogPrice_e18(logPrice);
-  }
-
-  function outboundFromInboundUp(int logPrice, uint inboundAmt) internal pure returns (uint) {
-    uint prod = inboundAmt * 1e18;
-    uint price = priceFromLogPrice_e18(logPrice);
-    return prod/price + (prod%price==0?0:1);
-  }
-
-
-
-}
 
 library TickLib {
 

--- a/lib/preprocessed/ToString.post.sol
+++ b/lib/preprocessed/ToString.post.sol
@@ -12,7 +12,9 @@ import {Vm} from "forge-std/Vm.sol";
 Vm constant vm = Vm(VM_ADDRESS);
 
 // Manual user-defined types
-import {Tick,Field,Leaf,MIN_TICK,MAX_TICK,LogPriceLib} from "mgv_lib/TickLib.sol";
+import "mgv_lib/TickLib.sol";
+import "mgv_lib/LogPriceLib.sol";
+import "mgv_lib/LogPriceConversionLib.sol";
 import {Density,DensityLib} from "mgv_lib/DensityLib.sol";
 import {OLKey} from "mgv_src/MgvLib.sol";
 
@@ -66,7 +68,8 @@ function toString(Tick tick) pure returns (string memory ret) {
 }
 
 function logPriceToString(int logPrice) pure returns (string memory ret) {
-  string memory str = toFixed(LogPriceLib.priceFromLogPrice_e18(logPrice),18);
+  (uint man, uint exp)  = LogPriceConversionLib.priceFromLogPrice(logPrice);
+  string memory str = toFixed(man,exp);
 
   ret = string.concat(unicode"⦗ ",vm.toString(logPrice),"|", str,unicode":1 ⦘");
 }

--- a/preprocessing/ToString.pre.sol.ts
+++ b/preprocessing/ToString.pre.sol.ts
@@ -14,7 +14,9 @@ import {Vm} from "forge-std/Vm.sol";
 Vm constant vm = Vm(VM_ADDRESS);
 
 // Manual user-defined types
-import {Tick,Field,Leaf,MIN_TICK,MAX_TICK,LogPriceLib} from "mgv_lib/TickLib.sol";
+import "mgv_lib/TickLib.sol";
+import "mgv_lib/LogPriceLib.sol";
+import "mgv_lib/LogPriceConversionLib.sol";
 import {Density,DensityLib} from "mgv_lib/DensityLib.sol";
 import {OLKey} from "mgv_src/MgvLib.sol";
 
@@ -53,7 +55,8 @@ function toString(Tick tick) pure returns (string memory ret) {
 }
 
 function logPriceToString(int logPrice) pure returns (string memory ret) {
-  string memory str = toFixed(LogPriceLib.priceFromLogPrice_e18(logPrice),18);
+  (uint man, uint exp)  = LogPriceConversionLib.priceFromLogPrice(logPrice);
+  string memory str = toFixed(man,exp);
 
   ret = string.concat(unicode"⦗ ",vm.toString(logPrice),"|", str,unicode":1 ⦘");
 }

--- a/preprocessing/lib/preproc.ts
+++ b/preprocessing/lib/preproc.ts
@@ -16,8 +16,7 @@ export const struct_utilities = `/* since you can't convert bool to uint in an e
 function uint_of_bool(bool b) pure returns (uint u) {
   assembly { u := b }
 }
-
-uint constant ONES = type(uint).max;`;
+import "mgv_lib/Constants.sol";`;
 
 const field_var = (_name: string, prop: string) => {
   return `${_name}_${prop}`;

--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -111,7 +111,9 @@ const struct_defs = {
       10 billions. */
       fields.gives,
     ],
-    additionalDefinitions: `import {Tick,TickLib, LogPriceLib} from "mgv_lib/TickLib.sol";
+    additionalDefinitions: `import "mgv_lib/TickLib.sol";
+import "mgv_lib/LogPriceLib.sol";
+import "mgv_lib/LogPriceConversionLib.sol";
 
 using OfferPackedExtra for OfferPacked global;
 using OfferUnpackedExtra for OfferUnpacked global;
@@ -157,7 +159,7 @@ function pack(uint __prev, uint __next, uint __wants, uint __gives) pure returns
   return pack({
     __prev: __prev,
     __next: __next,
-    __logPrice: LogPriceLib.logPriceFromVolumes(__wants,__gives),
+    __logPrice: LogPriceConversionLib.logPriceFromVolumes(__wants,__gives),
     __gives: __gives
   });
 }}

--- a/src/IMangrove.sol
+++ b/src/IMangrove.sol
@@ -67,9 +67,13 @@ interface IMangrove is HasMgvEvents {
     external
     returns (uint takerGot, uint takerGave, uint bounty, uint fee);
 
-  function marketOrderByPrice(OLKey memory olKey, uint maxPrice_e18, uint fillVolume, bool fillWants)
-    external
-    returns (uint takerGot, uint takerGave, uint bounty, uint fee);
+  function marketOrderByPrice(
+    OLKey memory olKey,
+    uint maxPrice_mantissa,
+    int maxPrice_exp,
+    uint fillVolume,
+    bool fillWants
+  ) external returns (uint takerGot, uint takerGave, uint bounty, uint fee);
 
   function marketOrderByLogPrice(OLKey memory olKey, int maxLogPrice, uint fillVolume, bool fillWants)
     external
@@ -79,9 +83,14 @@ interface IMangrove is HasMgvEvents {
     external
     returns (uint takerGot, uint takerGave, uint bounty, uint feePaid);
 
-  function marketOrderForByPrice(OLKey memory olKey, uint maxPrice_e18, uint fillVolume, bool fillWants, address taker)
-    external
-    returns (uint takerGot, uint takerGave, uint bounty, uint feePaid);
+  function marketOrderForByPrice(
+    OLKey memory olKey,
+    uint maxPrice_mantissa,
+    int maxPrice_exp,
+    uint fillVolume,
+    bool fillWants,
+    address taker
+  ) external returns (uint takerGot, uint takerGave, uint bounty, uint feePaid);
 
   function marketOrderForByLogPrice(OLKey memory olKey, int logPrice, uint fillVolume, bool fillWants, address taker)
     external

--- a/src/MgvLib.sol
+++ b/src/MgvLib.sol
@@ -8,6 +8,8 @@ import "./preprocessed/MgvStructs.post.sol" as MgvStructs;
 import {IERC20} from "./IERC20.sol";
 import {Density, DensityLib} from "mgv_lib/DensityLib.sol";
 import "mgv_lib/TickLib.sol";
+import "mgv_lib/LogPriceLib.sol";
+import "mgv_lib/LogPriceConversionLib.sol";
 
 using OLLib for OLKey global;
 // OLKey is OfferList

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -53,7 +53,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
     returns (uint takerGot, uint takerGave, uint bounty, uint fee)
   {
     uint fillVolume = fillWants ? takerWants : takerGives;
-    int maxLogPrice = LogPriceLib.logPriceFromTakerVolumes(takerGives, takerWants);
+    int maxLogPrice = LogPriceConversionLib.logPriceFromVolumes(takerGives, takerWants);
     return marketOrderByLogPrice(olKey, maxLogPrice, fillVolume, fillWants);
   }
 

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -17,6 +17,7 @@ import {
 } from "./MgvLib.sol";
 import {MgvHasOffers} from "./MgvHasOffers.sol";
 import {TickLib} from "./../lib/TickLib.sol";
+import "mgv_lib/LogPriceConversionLib.sol";
 import "mgv_lib/Debug.sol";
 
 abstract contract MgvOfferTaking is MgvHasOffers {
@@ -45,27 +46,25 @@ abstract contract MgvOfferTaking is MgvHasOffers {
      The `takerGives/takerWants` ratio induces a maximum average price that the taker is ready to pay across all offers that will be executed during the market order. It is thus possible to execute an offer with a price worse than the initial (`takerGives`/`takerWants`) ratio given as argument to `marketOrder` if some cheaper offers were executed earlier in the market order.
 
   The market order stops when the price has become too high, or when the end of the book has been reached, or:
-  * If `fillWants` is true, the market order stops when `takerWants` units of `outbound_tkn` have been obtained. With `fillWants` set to true, to buy a specific volume of `outbound_tkn` at any price, set `takerWants` to the amount desired and `takerGives` to $2^{160}-1$.
+  * If `fillWants` is true, the market order stops when `takerWants` units of `outbound_tkn` have been obtained. With `fillWants` set to true, to buy a specific volume of `outbound_tkn` at any price, set `takerWants` to the amount desired and `takerGives` to $2^{104}-1$.
   * If `fillWants` is false, the taker is filling `gives` instead: the market order stops when `takerGives` units of `inbound_tkn` have been sold. With `fillWants` set to false, to sell a specific volume of `inbound_tkn` at any price, set `takerGives` to the amount desired and `takerWants` to $0$. */
   function marketOrderByVolume(OLKey memory olKey, uint takerWants, uint takerGives, bool fillWants)
     public
     returns (uint takerGot, uint takerGave, uint bounty, uint fee)
   {
-    require(uint160(takerWants) == takerWants, "mgv/mOrder/takerWants/160bits");
-    require(uint160(takerGives) == takerGives, "mgv/mOrder/takerGives/160bits");
     uint fillVolume = fillWants ? takerWants : takerGives;
     int maxLogPrice = LogPriceLib.logPriceFromTakerVolumes(takerGives, takerWants);
     return marketOrderByLogPrice(olKey, maxLogPrice, fillVolume, fillWants);
   }
 
-  function marketOrderByPrice(OLKey memory olKey, uint maxPrice_e18, uint fillVolume, bool fillWants)
-    external
-    returns (uint takerGot, uint takerGave, uint bounty, uint fee)
-  {
-    require(maxPrice_e18 <= LogPriceLib.MAX_PRICE_E18, "mgv/mOrder/maxPrice/tooHigh");
-    require(maxPrice_e18 >= LogPriceLib.MIN_PRICE_E18, "mgv/mOrder/maxPrice/tooLow");
-
-    int maxLogPrice = LogPriceLib.logPriceFromPrice_e18(maxPrice_e18);
+  function marketOrderByPrice(
+    OLKey memory olKey,
+    uint maxPrice_mantissa,
+    int maxPrice_exp,
+    uint fillVolume,
+    bool fillWants
+  ) external returns (uint takerGot, uint takerGave, uint bounty, uint fee) {
+    int maxLogPrice = LogPriceConversionLib.logPriceFromPrice(maxPrice_mantissa, maxPrice_exp);
     return marketOrderByLogPrice(olKey, maxLogPrice, fillVolume, fillWants);
   }
 
@@ -135,9 +134,8 @@ abstract contract MgvOfferTaking is MgvHasOffers {
     returns (uint takerGot, uint takerGave, uint bounty, uint fee)
   {
     unchecked {
-      //TODO is uint160 correct with new price limits?
-      /* Since amounts stored in offers are 96 bits wide, checking that `takerWants` and `takerGives` fit in 160 bits prevents overflow during the main market order loop. */
-      require(uint160(fillVolume) == fillVolume, "mgv/mOrder/fillVolume/160bits");
+      /* Checking that `takerWants` and `takerGives` fit in 104 bits prevents overflow during the main market order loop. */
+      require(fillVolume <= MAX_SAFE_VOLUME, "mgv/mOrder/fillVolume/tooBig");
       require(LogPriceLib.inRange(maxLogPrice), "mgv/mOrder/logPrice/outOfRange");
 
       /* `MultiOrder` (defined above) maintains information related to the entire market order. During the order, initial `wants`/`gives` values minus the accumulated amounts traded so far give the amounts that remain to be traded. */

--- a/src/MgvOfferTakingWithPermit.sol
+++ b/src/MgvOfferTakingWithPermit.sol
@@ -87,7 +87,7 @@ abstract contract MgvOfferTakingWithPermit is MgvOfferTaking {
       require(uint160(takerWants) == takerWants, "mgv/mOrder/takerWants/160bits");
       require(uint160(takerGives) == takerGives, "mgv/mOrder/takerGives/160bits");
       uint fillVolume = fillWants ? takerWants : takerGives;
-      int logPrice = LogPriceLib.logPriceFromTakerVolumes(takerGives, takerWants);
+      int logPrice = LogPriceConversionLib.logPriceFromVolumes(takerGives, takerWants);
       return marketOrderForByLogPrice(olKey, logPrice, fillVolume, fillWants, taker);
     }
   }

--- a/src/MgvOfferTakingWithPermit.sol
+++ b/src/MgvOfferTakingWithPermit.sol
@@ -5,6 +5,7 @@ import {HasMgvEvents, Tick, LogPriceLib, OLKey} from "./MgvLib.sol";
 
 import {MgvOfferTaking} from "./MgvOfferTaking.sol";
 import {TickLib} from "./../lib/TickLib.sol";
+import "mgv_lib/LogPriceConversionLib.sol";
 
 abstract contract MgvOfferTakingWithPermit is MgvOfferTaking {
   /* Takers may provide allowances on specific offerLists, so other addresses can execute orders in their name. Allowance may be set using the usual `approve` function, or through an [EIP712](https://eips.ethereum.org/EIPS/eip-712) `permit`.
@@ -91,15 +92,17 @@ abstract contract MgvOfferTakingWithPermit is MgvOfferTaking {
     }
   }
 
-  function marketOrderForByPrice(OLKey memory olKey, uint maxPrice_e18, uint fillVolume, bool fillWants, address taker)
-    external
-    returns (uint takerGot, uint takerGave, uint bounty, uint feePaid)
-  {
+  function marketOrderForByPrice(
+    OLKey memory olKey,
+    uint maxPrice_mantissa,
+    int maxPrice_exp,
+    uint fillVolume,
+    bool fillWants,
+    address taker
+  ) external returns (uint takerGot, uint takerGave, uint bounty, uint feePaid) {
     unchecked {
-      require(maxPrice_e18 <= LogPriceLib.MAX_PRICE_E18, "mgv/mOrder/maxPrice/tooHigh");
-      require(maxPrice_e18 >= LogPriceLib.MIN_PRICE_E18, "mgv/mOrder/maxPrice/tooLow");
-      int logPrice = LogPriceLib.logPriceFromPrice_e18(maxPrice_e18);
-      return marketOrderForByLogPrice(olKey, logPrice, fillVolume, fillWants, taker);
+      int maxLogPrice = LogPriceConversionLib.logPriceFromPrice(maxPrice_mantissa, maxPrice_exp);
+      return marketOrderForByLogPrice(olKey, maxLogPrice, fillVolume, fillWants, taker);
     }
   }
 

--- a/src/preprocessed/MgvGlobal.post.sol
+++ b/src/preprocessed/MgvGlobal.post.sol
@@ -12,8 +12,7 @@ pragma solidity ^0.8.13;
 function uint_of_bool(bool b) pure returns (uint u) {
   assembly { u := b }
 }
-
-uint constant ONES = type(uint).max;
+import "mgv_lib/Constants.sol";
 
 struct GlobalUnpacked {
   address monitor;

--- a/src/preprocessed/MgvLocal.post.sol
+++ b/src/preprocessed/MgvLocal.post.sol
@@ -12,8 +12,7 @@ pragma solidity ^0.8.13;
 function uint_of_bool(bool b) pure returns (uint u) {
   assembly { u := b }
 }
-
-uint constant ONES = type(uint).max;
+import "mgv_lib/Constants.sol";
 
 struct LocalUnpacked {
   bool active;

--- a/src/preprocessed/MgvOffer.post.sol
+++ b/src/preprocessed/MgvOffer.post.sol
@@ -12,8 +12,7 @@ pragma solidity ^0.8.13;
 function uint_of_bool(bool b) pure returns (uint u) {
   assembly { u := b }
 }
-
-uint constant ONES = type(uint).max;
+import "mgv_lib/Constants.sol";
 
 struct OfferUnpacked {
   uint prev;
@@ -27,7 +26,9 @@ type OfferPacked is uint;
 using Library for OfferPacked global;
 
 ////////////// ADDITIONAL DEFINITIONS, IF ANY ////////////////
-import {Tick,TickLib, LogPriceLib} from "mgv_lib/TickLib.sol";
+import "mgv_lib/TickLib.sol";
+import "mgv_lib/LogPriceLib.sol";
+import "mgv_lib/LogPriceConversionLib.sol";
 
 using OfferPackedExtra for OfferPacked global;
 using OfferUnpackedExtra for OfferUnpacked global;
@@ -73,7 +74,7 @@ function pack(uint __prev, uint __next, uint __wants, uint __gives) pure returns
   return pack({
     __prev: __prev,
     __next: __next,
-    __logPrice: LogPriceLib.logPriceFromVolumes(__wants,__gives),
+    __logPrice: LogPriceConversionLib.logPriceFromVolumes(__wants,__gives),
     __gives: __gives
   });
 }}

--- a/src/preprocessed/MgvOfferDetail.post.sol
+++ b/src/preprocessed/MgvOfferDetail.post.sol
@@ -12,8 +12,7 @@ pragma solidity ^0.8.13;
 function uint_of_bool(bool b) pure returns (uint u) {
   assembly { u := b }
 }
-
-uint constant ONES = type(uint).max;
+import "mgv_lib/Constants.sol";
 
 struct OfferDetailUnpacked {
   address maker;

--- a/test/core/Density.t.sol
+++ b/test/core/Density.t.sol
@@ -7,7 +7,6 @@ pragma solidity ^0.8.10;
 // import "mgv_test/lib/MangroveTest.sol";
 import "mgv_lib/Test2.sol";
 import "mgv_src/MgvLib.sol";
-import {FixedPointMathLib as FP} from "solady/utils/FixedPointMathLib.sol";
 import {DensityLib} from "mgv_lib/DensityLib.sol";
 
 // In these tests, the testing contract is the market maker.

--- a/test/core/DynamicTicks.t.sol
+++ b/test/core/DynamicTicks.t.sol
@@ -6,6 +6,7 @@ import "mgv_test/lib/MangroveTest.sol";
 import {MgvStructs, MAX_TICK, MIN_TICK, LogPriceLib} from "mgv_src/MgvLib.sol";
 import {DensityLib} from "mgv_lib/DensityLib.sol";
 import {stdError} from "forge-std/StdError.sol";
+import "mgv_lib/Constants.sol";
 
 // In these tests, the testing contract is the market maker.
 contract DynamicTicksTest is MangroveTest {
@@ -37,7 +38,7 @@ contract DynamicTicksTest is MangroveTest {
   }
 
   function boundLogPrice(int24 logPrice) internal view returns (int24) {
-    return int24(bound(logPrice, LogPriceLib.MIN_LOG_PRICE, LogPriceLib.MAX_LOG_PRICE));
+    return int24(bound(logPrice, MIN_LOG_PRICE, MAX_LOG_PRICE));
   }
 
   function test_newOffer_store_and_retrieve(uint24 tickScale, uint24 tickScale2, int24 logPrice) public {

--- a/test/core/Leaf.t.sol
+++ b/test/core/Leaf.t.sol
@@ -8,7 +8,7 @@ pragma solidity ^0.8.10;
 import "mgv_lib/Test2.sol";
 // import "abdk-libraries-solidity/ABDKMathQuad.sol";
 import "mgv_src/MgvLib.sol";
-import {FixedPointMathLib as FP} from "solady/utils/FixedPointMathLib.sol";
+import "mgv_lib/LogPriceConversionLib.sol";
 
 // In these tests, the testing contract is the market maker.
 contract LeafTest is Test2 {
@@ -125,74 +125,46 @@ contract TickTest is Test {
     );
   }
 
-  // "price" is the price paid by takers
-  // for now tick is rounded towards 0, ie:
-  // * gives is stored
-  // * if price (wants/gives) < 1, then wants will be higher (ie price will be higher) than real
-  // * if price (wants/gives) > 1, then wants will be lower (ie price will be lower) than real
-  // * probably should always round price towards -infty
+  // note that tick(p) is max {t | price(t) <= p}
   function test_logPriceFromVolumes() public {
-    assertEq(LogPriceLib.logPriceFromVolumes(1, 1), 0);
-    assertEq(LogPriceLib.logPriceFromVolumes(2, 1), 6931);
-    assertEq(LogPriceLib.logPriceFromVolumes(1, 2), -6932);
-    assertEq(LogPriceLib.logPriceFromVolumes(1e18, 1), 414486);
-    //FIXME when tick range is restored use uint96 again
-    // assertEq(LogPriceLib.logPriceFromVolumes(type(uint96).max, 1), 665454);
-    // assertEq(LogPriceLib.logPriceFromVolumes(1, type(uint96).max), -665454);
-    assertEq(LogPriceLib.logPriceFromVolumes(type(uint72).max, 1), 499090);
-    assertEq(LogPriceLib.logPriceFromVolumes(1, type(uint72).max), -499090);
-    assertEq(LogPriceLib.logPriceFromVolumes(999999, 1000000), -1);
-    assertEq(LogPriceLib.logPriceFromVolumes(1000000, 999999), 0);
-    assertEq(LogPriceLib.logPriceFromVolumes(1000000 * 1e18, 999999 * 1e18), 0);
+    assertEq(LogPriceConversionLib.logPriceFromVolumes(1, 1), 0);
+    assertEq(LogPriceConversionLib.logPriceFromVolumes(2, 1), 6931);
+    assertEq(LogPriceConversionLib.logPriceFromVolumes(1, 2), -6932);
+    assertEq(LogPriceConversionLib.logPriceFromVolumes(1e18, 1), 414486);
+    assertEq(LogPriceConversionLib.logPriceFromVolumes(type(uint96).max, 1), 665454);
+    assertEq(LogPriceConversionLib.logPriceFromVolumes(1, type(uint96).max), -665455);
+    assertEq(LogPriceConversionLib.logPriceFromVolumes(type(uint72).max, 1), 499090);
+    assertEq(LogPriceConversionLib.logPriceFromVolumes(1, type(uint72).max), -499091);
+    assertEq(LogPriceConversionLib.logPriceFromVolumes(999999, 1000000), -1);
+    assertEq(LogPriceConversionLib.logPriceFromVolumes(1000000, 999999), 0);
+    assertEq(LogPriceConversionLib.logPriceFromVolumes(1000000 * 1e18, 999999 * 1e18), 0);
   }
 
   function test_priceFromLogPrice() public {
-    // 1bp of 1bp as 18 decimals fixed point number
-    uint err = 1e18 / 100 / 100 / 100 / 100;
-    // tick is ln_bp(1e6)
-    // compares to 1.0001**tick*1e18
-    assertApproxEqRel(LogPriceLib.priceFromLogPrice_e18(138162), 999998678087145849760004, err);
-    // tick is ln_bp(1)
-    // compares to 1.0001**tick*1e18
-    assertApproxEqRel(LogPriceLib.priceFromLogPrice_e18(0), 1.0001 ** 0 * 1e18, err);
-    // FIXME Tick example used to be 665454 but it's out of range for now
-    /* 
-      // tick is ln_bp(type(uint96).max)
-      // compares to 1.0001**tick*1e18
-      assertApproxEqRel(Tick.wrap(665454).priceFromTick_e18(), 79223695601626514454341026560883173411222330007, err);
-      // console.log(Tick.wrap(-421417).priceFromTick_e18());
-    */
-    assertApproxEqRel(LogPriceLib.priceFromLogPrice_e18(524287), 58661978243259926126959077156658796822528, err);
+    inner_test_priceFromLogPrice({
+      tick: 2 ** 20 - 1,
+      expected_sig: 3441571814221581909035848501253497354125574144,
+      expected_exp: 0
+    });
+
+    inner_test_priceFromLogPrice({
+      tick: 138162,
+      expected_sig: 5444510673556857440102348422228887810808479744,
+      expected_exp: 132
+    });
+
+    //FIXME
+    // Do -1,0,1,max
   }
 
-  function test_volume_inverse() public {
-    uint gives = 1 ether;
-    int logPrice = LogPriceLib.logPriceFromPrice_e18(2000e18);
-    uint wantsA = LogPriceLib.inboundFromOutbound(logPrice, gives);
-    uint wantsB = LogPriceLib.outboundFromInbound(-logPrice, gives);
-    uint givesAA = LogPriceLib.outboundFromInbound(logPrice, wantsA);
-    uint givesBA = LogPriceLib.inboundFromOutbound(-logPrice, wantsA);
-    uint givesAB = LogPriceLib.outboundFromInbound(logPrice, wantsB);
-    uint givesBB = LogPriceLib.inboundFromOutbound(-logPrice, wantsB);
-
-    console.log("Gives %s Wants %s", gives, wantsA);
-    console.log("WantsA %s WantsB %s", wantsA, wantsB);
-    console.log("givesAA %s givesBA %s", givesAA, givesBA);
-    console.log("givesAB %s givesBB %s", givesAB, givesBB);
-
-    /*
-  Running 1 test for test/core/Leaf.t.sol:TickTest
-  [PASS] test_volume_inverse() (gas: 30617)
-  Logs:
-  Gives 1000000000000000000 Wants 1999835018391757675359
-  WantsA 1999835018391757675359 WantsB 1999835018391760277054
-  givesAA 1000000000000000000 givesBA 999999999999998699
-  givesAB 1000000000000001300 givesBB 999999999999999999    
-    */
+  function inner_test_priceFromLogPrice(int tick, uint expected_sig, uint expected_exp) internal {
+    (uint sig, uint exp) = LogPriceConversionLib.priceFromLogPrice(tick);
+    assertEq(expected_sig, sig, "wrong sig");
+    assertEq(expected_exp, exp, "wrong exp");
   }
 
   function showLogPriceApprox(uint wants, uint gives) internal pure {
-    int logPrice = LogPriceLib.logPriceFromVolumes(wants, gives);
+    int logPrice = LogPriceConversionLib.logPriceFromVolumes(wants, gives);
     uint wants2 = LogPriceLib.inboundFromOutbound(logPrice, gives);
     uint gives2 = LogPriceLib.outboundFromInbound(logPrice, wants);
     console.log("logPrice  ", logPriceToString(logPrice));
@@ -301,5 +273,15 @@ contract FieldTest is Test {
 
   function assertFirstOnePosition(uint field, uint pos) internal {
     assertEq(Field.wrap(field).firstOnePosition(), pos);
+  }
+
+  //FIXME move constants-related tests to a separate contract and test them all
+  function test_constants_min_max_price() public {
+    (uint man, uint exp) = LogPriceConversionLib.priceFromLogPrice(MIN_LOG_PRICE);
+    assertEq(man, MIN_PRICE_MANTISSA);
+    assertEq(int(exp), MIN_PRICE_EXP);
+    (man, exp) = LogPriceConversionLib.priceFromLogPrice(MAX_LOG_PRICE);
+    assertEq(man, MAX_PRICE_MANTISSA);
+    assertEq(int(exp), MAX_PRICE_EXP);
   }
 }

--- a/test/core/Leaf.t.sol
+++ b/test/core/Leaf.t.sol
@@ -284,4 +284,18 @@ contract FieldTest is Test {
     assertEq(man, MAX_PRICE_MANTISSA);
     assertEq(int(exp), MAX_PRICE_EXP);
   }
+
+  function price_priceFromVolumes_not_zero_div() public {
+    // should not revert
+    (uint man, uint exp) = LogPriceConversionLib.priceFromVolumes(1, type(uint).max);
+    assertTrue(man != 0, "mantissa cannot be 0");
+  }
+
+  function price_priceFromVolumes_not_zero_div_fuzz(uint inbound, uint outbound) public {
+    vm.assume(inbound != 0);
+    vm.assume(outbound != 0);
+    // should not revert
+    (uint man, uint exp) = LogPriceConversionLib.priceFromVolumes(inbound, outbound);
+    assertTrue(man != 0, "mantissa cannot be 0");
+  }
 }

--- a/test/core/Permit.t.sol
+++ b/test/core/Permit.t.sol
@@ -46,7 +46,10 @@ import {TrivialTestMaker, TestMaker} from "mgv_test/lib/agents/TestMaker.sol";
 import {Vm} from "forge-std/Vm.sol";
 import {console2, StdStorage, stdStorage} from "forge-std/Test.sol";
 import {IMangrove} from "mgv_src/IMangrove.sol";
-import {TickLib, Tick, LogPriceLib} from "mgv_lib/TickLib.sol";
+import {AbstractMangrove} from "mgv_src/AbstractMangrove.sol";
+import "mgv_lib/TickLib.sol";
+import "mgv_lib/LogPriceLib.sol";
+import "mgv_lib/LogPriceConversionLib.sol";
 import {OLKey} from "mgv_src/MgvLib.sol";
 
 contract PermitTest is MangroveTest, TrivialTestMaker {
@@ -85,7 +88,7 @@ contract PermitTest is MangroveTest, TrivialTestMaker {
   }
 
   function marketOrderFor(uint value, address who) internal returns (uint, uint, uint, uint) {
-    int logPrice = LogPriceLib.logPriceFromPrice_e18(1 ether);
+    int logPrice = LogPriceConversionLib.logPriceFromPrice(1, 0);
     return mgv.marketOrderForByLogPrice(olKey, logPrice, value, true, who);
   }
 

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -3,7 +3,10 @@
 pragma solidity ^0.8.10;
 
 import "mgv_test/lib/MangroveTest.sol";
-import {MAX_TICK, MIN_TICK, LogPriceLib} from "mgv_lib/TickLib.sol";
+import "mgv_lib/Constants.sol";
+import "mgv_lib/TickLib.sol";
+import "mgv_lib/LogPriceLib.sol";
+import "mgv_lib/LogPriceConversionLib.sol";
 
 /* The following constructs an ERC20 with a transferFrom callback method,
    and a TestTaker which throws away any funds received upon getting
@@ -86,13 +89,14 @@ contract TakerOperationsTest is MangroveTest {
 
   // The purpose of this test is to make sure inbound volumes are rounded up when partially
   // taking an offer i.e. you can't have the taker pay 0 if the maker sends > 0 to the taker.
-  // The test sets this up with a wants=9, gives=10 offer, and the taker asks for a volume of 1.
+  // The test sets this up with a price slightly below 1/2, gives=10, and then taker asks for 1. So it should give < 1/2. If maker balance does not increase, it was drained.
   function test_taker_cannot_drain_maker() public {
     mgv.setDensityFixed(olKey, 0);
     quote.approve($(mgv), 1 ether);
-    mkr.newOfferByVolume(9, 10, 100_000, 0);
+    int tick = -7000; // price slightly < 1/2
+    mkr.newOfferByLogPrice(tick, 10, 100_000, 0);
     uint oldBal = quote.balanceOf($(this));
-    mgv.marketOrderByLogPrice(olKey, LogPriceLib.MAX_LOG_PRICE, 1, true);
+    mgv.marketOrderByLogPrice(olKey, MAX_LOG_PRICE, 1, true);
     uint newBal = quote.balanceOf($(this));
     assertGt(oldBal, newBal, "oldBal should be strictly higher");
   }
@@ -117,7 +121,7 @@ contract TakerOperationsTest is MangroveTest {
     /* Setting fillWants = true means we should not receive more than `wants`.
        Here we are asking for 0.1 eth to an offer that gives 1eth for ~nothing.
        We should still only receive 0.1 eth */
-    int logPrice = LogPriceLib.logPriceFromPrice_e18(1 ether);
+    int logPrice = LogPriceConversionLib.logPriceFromPrice(1, 0);
     (uint got, uint gave,,) = mgv.marketOrderByLogPrice(olKey, logPrice, 0.1 ether, true);
     assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertApproxEqRel(got, 0.1 ether, relError(10), "Wrong got value");
@@ -134,7 +138,7 @@ contract TakerOperationsTest is MangroveTest {
     /* Setting fillWants = false means we should spend as little as possible to receive
        as much as possible.
        Here despite asking for .1eth the offer gives 1eth for ~0 so we should receive 1eth. */
-    int logPrice = LogPriceLib.logPriceFromPrice_e18(1 ether);
+    int logPrice = LogPriceConversionLib.logPriceFromPrice(1, 0);
     (uint got, uint gave,,) = mgv.marketOrderByLogPrice(olKey, logPrice, 0.1 ether, false);
     assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertApproxEqRel(got, 1 ether, relError(10), "Wrong got value");
@@ -147,7 +151,7 @@ contract TakerOperationsTest is MangroveTest {
     mkr.expect("mgv/tradeSuccess"); // trade should be OK on the maker side
     quote.approve($(mgv), 1 ether);
 
-    int logPrice = LogPriceLib.logPriceFromPrice_e18(1 ether);
+    int logPrice = LogPriceConversionLib.logPriceFromPrice(1, 0);
     (uint got, uint gave,,) = mgv.marketOrderByLogPrice(olKey, logPrice, 1 ether, false);
     assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertEq(got, 1 ether, "Taker did not get correct amount");
@@ -474,19 +478,19 @@ contract TakerOperationsTest is MangroveTest {
     assertEq(takerGot, 2 ether, "Incorrect declared delivered amount (taker)");
   }
 
-  // before ticks: testing whether a wants of 0 works
-  // after ticks: wants of 0 not possible since we store log(wants/gives) as tick. Testing with an extremely small amount.
+  // before ticks: testing that a wants of 0 works
+  // after ticks: wants of 0 as input not acceptd for now but *resulting* wants is doable thanks to approximatoin
+  // FIXME: maybe wants=0 should be allowed
   function test_fillGives_at_0_wants_works() public {
-    uint ofr = mkr.newOfferByVolume(10, 2 ether, 100_000, 0);
+    uint wants = 1;
+    uint ofr = mkr.newOfferByVolume(wants, 2 ether, 100_000, 0);
     int logPrice = mgv.offers(olKey, ofr).logPrice();
     mkr.expect("mgv/tradeSuccess");
     quote.approve($(mgv), 10 ether);
 
     (uint takerGot, uint takerGave,,) = mgv.marketOrderByLogPrice(olKey, logPrice, 10, false);
-    // console.log("offer wants",mgv.offers(olKey,ofr).wants());
-    // console.log("offer tick",mgv.offers(olKey,ofr).tick().toString());
     assertTrue(mkr.makerPosthookWasCalled(ofr), "ofr posthook must be called or test is void");
-    assertEq(takerGave, 10, "Incorrect declared delivered amount (maker)");
+    assertEq(takerGave, 0, "Incorrect declared delivered amount (maker)");
     assertEq(takerGot, 2 ether, "Incorrect declared delivered amount (taker)");
   }
 
@@ -539,7 +543,7 @@ contract TakerOperationsTest is MangroveTest {
       olKey.hash(),
       ofr,
       takerWants,
-      LogPriceLib.inboundFromOutbound(offer.logPrice(), takerWants),
+      LogPriceLib.inboundFromOutboundUp(offer.logPrice(), takerWants),
       /*penalty*/
       0,
       "mgv/makerTransferFail"
@@ -739,9 +743,16 @@ contract TakerOperationsTest is MangroveTest {
     }
   }
 
-  function test_takerWants_wider_than_160_bits_fails_marketOrder() public {
-    vm.expectRevert("mgv/mOrder/takerWants/160bits");
-    mgv.marketOrderByVolume(olKey, 2 ** 160, 1, true);
+  // FIXME error should not depend on the other volume argument being > 0
+  function test_marketOrderByVolume_takerGives_extrema() public {
+    vm.expectRevert("priceFromVolumes/inbound/tooBig");
+    mgv.marketOrderByVolume(olKey, 1, MAX_SAFE_VOLUME + 1, true);
+    vm.expectRevert("priceFromVolumes/outbound/tooBig");
+    mgv.marketOrderByVolume(olKey, MAX_SAFE_VOLUME + 1, 1, true);
+    vm.expectRevert("priceFromVolumes/inbound/tooBig");
+    mgv.marketOrderByVolume(olKey, 1, MAX_SAFE_VOLUME + 1, false);
+    vm.expectRevert("priceFromVolumes/outbound/tooBig");
+    mgv.marketOrderByVolume(olKey, MAX_SAFE_VOLUME + 1, 1, false);
   }
 
   function test_clean_with_0_wants_ejects_offer() public {

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -825,7 +825,7 @@ contract TakerOperationsTest is MangroveTest {
     quote.approve($(mgv), 1 ether);
     uint failing_ofr = failmkr.newOfferByVolume(1 ether, 1 ether, 100_000);
     uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 100_000);
-    (uint got,,,) = mgv.marketOrderByVolume(olKey, 1 ether, 0, true);
+    (uint got,,,) = mgv.marketOrderByVolume(olKey, 1 ether, 1 ether, true);
     assertTrue(failmkr.makerPosthookWasCalled(failing_ofr), "failing_ofr posthook must be called or test is void");
     assertTrue(mkr.makerPosthookWasCalled(ofr), "ofr posthook must be called or test is void");
     assertEq(got, 1 ether, "should have gotten 1 ether");

--- a/test/core/gas/MarketOrderOtherOfferList.t.sol
+++ b/test/core/gas/MarketOrderOtherOfferList.t.sol
@@ -85,10 +85,10 @@ contract ExternalMarketOrderOtherOfferList_WithNoOtherOffersGasTest is GasTestBa
 
   function test_market_order_by_price_full() public {
     (IMangrove mgv, TestTaker taker, OLKey memory _olKey,) = getStored();
-    uint price = LogPriceLib.priceFromLogPrice_e18(MIDDLE_LOG_PRICE);
+    (uint mantissa, uint exp) = LogPriceConversionLib.priceFromLogPrice(MIDDLE_LOG_PRICE);
     vm.prank($(taker));
     _gas();
-    mgv.marketOrderByPrice(_olKey, price, 1 ether, false);
+    mgv.marketOrderByPrice(_olKey, mantissa, int(exp), 1 ether, false);
     gas_();
     assertEq(0, mgv.best(_olKey));
     description = string.concat(description, " - Case: market order by price full fill");

--- a/test/lib/agents/TestMaker.sol
+++ b/test/lib/agents/TestMaker.sol
@@ -317,6 +317,24 @@ contract SimpleTestMaker is TrivialTestMaker, Script2 {
     return offerId;
   }
 
+  function updateOfferByLogPrice(int logPrice, uint gives, uint gasreq, uint offerId) public {
+    OfferData memory offerData;
+    updateOfferByLogPrice(olKey, logPrice, gives, gasreq, offerId, 0, offerData);
+  }
+
+  function updateOfferByLogPrice(
+    OLKey memory _olKey,
+    int logPrice,
+    uint gives,
+    uint gasreq,
+    uint offerId,
+    uint amount,
+    OfferData memory offerData
+  ) public {
+    mgv.updateOfferByLogPrice{value: amount}(_olKey, logPrice, gives, gasreq, 0, offerId);
+    offerDatas[_olKey.hash()][offerId] = offerData;
+  }
+
   function updateOfferByVolume(uint wants, uint gives, uint gasreq, uint offerId, OfferData memory offerData) public {
     updateOfferByVolumeWithFunding(wants, gives, gasreq, offerId, 0, offerData);
   }


### PR DESCRIPTION
Inspired by uniswap's approach, using price instead of sqrtPrice, and floating point instead of fixed point.

Precise conversion functions:
- `logPriceFromPrice: mantissa,exp -> logPrice`
- `priceFromLogPrice: logPrice -> mantissa,exp`

Also:
- `logPriceFromVolumes: inbound,outbound -> logPrice`
- `priceFromVolumes: inbound,outbound -> mantissa,exp`

Some properties:
* `logPrice` must be in the range`+/- 1_048_575` to be valid (that's `+/- 2^20-1`). With a 1bp tick spacing, that means prices between `2.9e-46` and `3.4e45` (more than enough).
* `logPriceFromPrice(price)` should return `max { logPrice | priceFromLogPrice(logPrice) <= price }`
* For a valid `logPrice`, `logPriceFromPrice(priceFromLogPrice(logPrice)) == logPrice`.
* `priceFromLogPrice(logPrice)` is sometimes a little below, sometimes a little above `1.0001^logPrice`. Precision should be within 0.0001%. There should be some off-by-1 results, that is, if `1.0001^logPrice < price < priceFromLogPrice(logPrice)` then  `logPriceFromPrice(price) = ⌊log_1.0001(price)⌋ - 1`, and if `priceFromLogPrice(logPrice) < price < 1.0001^logPrice` then `logPriceFromPrice(price) = ⌊log_1.0001(price)⌋ + 1`.
* Currently the tree data structure does not accomodate this range with a 1bp tick spacing (current bounds are `+/- 524287`).