### PR TITLE
feat: emit offerSucces and offerFail during posthook end

### DIFF
--- a/src/IMangrove.sol
+++ b/src/IMangrove.sol
@@ -24,9 +24,9 @@ interface IMangrove {
   event Debit(address indexed maker, uint amount);
   event Kill();
   event NewMgv();
-  event OfferFail(bytes32 indexed olKeyHash, uint id, address taker, uint takerWants, uint takerGives, bytes32 mgvData);
+  event OfferFail(bytes32 indexed olKeyHash, uint id, uint takerWants, uint takerGives, uint penalty, bytes32 mgvData);
   event OfferRetract(bytes32 indexed olKeyHash, uint id, bool deprovision);
-  event OfferSuccess(bytes32 indexed olKeyHash, uint id, address taker, uint takerWants, uint takerGives);
+  event OfferSuccess(bytes32 indexed olKeyHash, uint id, uint takerWants, uint takerGives);
   event OfferWrite(
     bytes32 indexed olKeyHash, address maker, int logPrice, uint gives, uint gasprice, uint gasreq, uint id
   );

--- a/src/MgvLib.sol
+++ b/src/MgvLib.sol
@@ -104,7 +104,6 @@ contract HasMgvEvents {
     bytes32 indexed olKeyHash,
     uint id,
     // `maker` is not logged because it can be retrieved from the state using `(outbound_tkn,inbound_tkn,id)`.
-    address indexed taker,
     uint takerWants,
     uint takerGives
   );
@@ -114,9 +113,9 @@ contract HasMgvEvents {
     bytes32 indexed olKeyHash,
     uint id,
     // `maker` is not logged because it can be retrieved from the state using `(olKeyHash)`.
-    address indexed taker,
     uint takerWants,
     uint takerGives,
+    uint penalty,
     // `mgvData` may only be `"mgv/makerRevert"`, `"mgv/makerTransferFail"` or `"mgv/makerReceiveFail"`
     bytes32 mgvData
   );

--- a/test/core/InvertedTakerOperations.t.sol
+++ b/test/core/InvertedTakerOperations.t.sol
@@ -120,9 +120,9 @@ contract InvertedTakerOperationsTest is ITaker, MangroveTest {
     uint ofr2 = mkr.newOfferByVolume(0.1 ether, 0.1 ether, 100_000, 0);
     _takerTrade = reenter;
     expectFrom($(mgv));
-    emit OfferSuccess(olKey.hash(), ofr1, $(this), 0.1 ether, 0.1 ether);
+    emit OfferSuccess(olKey.hash(), ofr2, 0.1 ether, 0.1 ether);
     expectFrom($(mgv));
-    emit OfferSuccess(olKey.hash(), ofr2, $(this), 0.1 ether, 0.1 ether);
+    emit OfferSuccess(olKey.hash(), ofr1, 0.1 ether, 0.1 ether);
     (uint got, uint gave,,) = mgv.marketOrderByVolume(olKey, 0.1 ether, 0.1 ether, true);
     assertTrue(mkr.makerExecuteWasCalled(ofr1), "ofr1 must be executed or test is void");
     assertTrue(mkr.makerExecuteWasCalled(ofr2), "ofr2 must be executed or test is void");

--- a/test/core/MakerPosthook.t.sol
+++ b/test/core/MakerPosthook.t.sol
@@ -179,9 +179,10 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     uint balMaker = base.balanceOf($(this));
     uint balTaker = quote.balanceOf(address(tkr));
     ofr = mgv.newOfferByVolume(olKey, 1 ether, 1 ether, gasreq, _gasprice);
+    ofr = mgv.newOfferByVolume(olKey, 1 ether, 1 ether, gasreq, _gasprice);
     makerRevert = true;
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, address(tkr), 1 ether, 1 ether, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 2375880000000000, "mgv/makerRevert");
     bool success = tkr.marketOrderWithSuccess(1 ether);
     assertTrue(!success, "market order should fail");
     assertTrue(called, "PostHook not called");
@@ -197,7 +198,7 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     makerRevert = true;
 
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, address(tkr), 1 ether, 1 ether, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 2517320000000000, "mgv/makerRevert");
     bool success = tkr.marketOrderWithSuccess(1 ether);
     assertTrue(!success, "market order should fail");
     assertTrue(called, "PostHook not called");
@@ -271,11 +272,11 @@ contract MakerPosthookTest is MangroveTest, IMaker {
       "Incorrect maker balance before take"
     );
     expectFrom($(mgv));
-    emit OfferSuccess(olKey.hash(), ofr, address(tkr), 1 ether, 1 ether);
-    expectFrom($(mgv));
     emit Credit($(this), mkr_provision);
     expectFrom($(mgv));
     emit OfferRetract(olKey.hash(), ofr, true);
+    expectFrom($(mgv));
+    emit OfferSuccess(olKey.hash(), ofr, 1 ether, 1 ether);
     bool success = tkr.marketOrderWithSuccess(2 ether);
     assertTrue(success, "market order should succeed");
     assertTrue(called, "PostHook not called");
@@ -299,12 +300,12 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     );
     makerRevert = true;
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, address(tkr), 1 ether, 1 ether, "mgv/makerRevert");
-    expectFrom($(mgv));
     emit OfferRetract(olKey.hash(), ofr, true);
     //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(this), 0 /*penalty*/ );
+    expectFrom($(mgv));
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 3004400000000000, "mgv/makerRevert");
     bool success = tkr.marketOrderWithSuccess(2 ether);
     assertTrue(!success, "market order should fail");
     assertTrue(called, "PostHook not called");
@@ -316,9 +317,9 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     _posthook = retractOffer_posthook;
     ofr = mgv.newOfferByVolume(olKey, 1 ether, 1 ether, gasreq, _gasprice);
     expectFrom($(mgv));
-    emit OfferSuccess(olKey.hash(), ofr, address(tkr), 1 ether, 1 ether);
-    expectFrom($(mgv));
     emit OfferRetract(olKey.hash(), ofr, true);
+    expectFrom($(mgv));
+    emit OfferSuccess(olKey.hash(), ofr, 1 ether, 1 ether);
     bool success = tkr.marketOrderWithSuccess(2 ether);
     assertTrue(success, "market order should succeed");
     assertTrue(called, "PostHook not called");
@@ -389,12 +390,12 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     );
     makerRevert = true; // maker should fail
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, address(tkr), 1 ether, 1 ether, "mgv/makerRevert");
-    expectFrom($(mgv));
     emit OfferRetract(olKey.hash(), ofr, true);
     //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(this), 0 /*refund*/ );
+    expectFrom($(mgv));
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 3004400000000000, "mgv/makerRevert");
     bool success = tkr.marketOrderWithSuccess(2 ether);
     assertTrue(called, "PostHook not called");
 
@@ -407,7 +408,7 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     ofr = mgv.newOfferByVolume(olKey, 1 ether, 1 ether, gasreq, _gasprice);
     makerRevert = true; // maker should fail
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, address(tkr), 1 ether, 1 ether, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 2491160000000000, "mgv/makerRevert");
     tkr.marketOrderWithSuccess(2 ether);
   }
 

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -175,8 +175,6 @@ contract TakerOperationsTest is MangroveTest {
     emit Transfer($(mgv), $(mkr), 1 ether);
     expectFrom($(base));
     emit Transfer($(mkr), $(mgv), 1 ether);
-    expectFrom($(mgv));
-    emit OfferSuccess(olKey.hash(), ofr1, $(this), 1 ether, LogPriceLib.inboundFromOutbound(offerLogPrice1, 1 ether));
 
     expectFrom($(quote));
     emit Transfer($(this), $(mgv), 0.1 ether);
@@ -184,13 +182,13 @@ contract TakerOperationsTest is MangroveTest {
     emit Transfer($(mgv), $(mkr), 0.1 ether);
     expectFrom($(base));
     emit Transfer($(mkr), $(mgv), 0.1 ether);
-    expectFrom($(mgv));
-    emit OfferSuccess(
-      olKey.hash(), ofr2, $(this), 0.1 ether, LogPriceLib.inboundFromOutbound(offerLogPrice2, 0.1 ether)
-    );
 
     expectFrom($(base));
     emit Transfer($(mgv), $(this), 1.1 ether);
+    expectFrom($(mgv));
+    emit OfferSuccess(olKey.hash(), ofr2, 0.1 ether, LogPriceLib.inboundFromOutbound(offerLogPrice2, 0.1 ether));
+    expectFrom($(mgv));
+    emit OfferSuccess(olKey.hash(), ofr1, 1 ether, LogPriceLib.inboundFromOutbound(offerLogPrice1, 1 ether));
     expectFrom($(mgv));
     emit OrderComplete(olKey.hash(), $(this), 1.1 ether, 1.1 ether, 0, 0);
 
@@ -296,11 +294,11 @@ contract TakerOperationsTest is MangroveTest {
     uint beforeQuote = quote.balanceOf($(this));
     uint beforeWei = $(this).balance;
 
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, $(this), 1 ether, 1 ether, "mgv/makerTransferFail");
     //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(refusemkr), 0 /*mkr_provision - penalty*/ );
+    expectFrom($(mgv));
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 5741640000000000, "mgv/makerTransferFail");
     (uint successes,) =
       mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, logPrice, 100_000, 1 ether)), $(this));
     assertEq(successes, 1, "clean should succeed");
@@ -331,11 +329,11 @@ contract TakerOperationsTest is MangroveTest {
     uint beforeQuote = quote.balanceOf($(this));
     uint beforeWei = $(this).balance;
 
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, $(this), 1 ether, 1 ether, "mgv/makerTransferFail");
     //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(mkr), 0 /*mkr_provision - penalty*/ );
+    expectFrom($(mgv));
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 4696520000000000, "mgv/makerTransferFail");
     (uint takerGot, uint takerGave,,) = mgv.marketOrderByLogPrice(olKey, logPrice, 1 ether, true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
@@ -355,11 +353,11 @@ contract TakerOperationsTest is MangroveTest {
     uint beforeQuote = quote.balanceOf($(this));
     uint beforeWei = $(this).balance;
 
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, $(this), 1 ether, 1 ether, "mgv/makerReceiveFail");
     //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(mkr), 0 /*mkr_provision - penalty*/ );
+    expectFrom($(mgv));
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 3256560000000000, "mgv/makerReceiveFail");
     (uint takerGot, uint takerGave,,) = mgv.marketOrderByLogPrice(olKey, logPrice, 1 ether, true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
@@ -388,11 +386,11 @@ contract TakerOperationsTest is MangroveTest {
     uint beforeQuote = quote.balanceOf($(this));
     uint beforeWei = $(this).balance;
 
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, $(this), 1 ether, 1 ether, "mgv/makerRevert");
     //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
+    expectFrom($(mgv));
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 4401040000000000, "mgv/makerRevert");
     (uint takerGot, uint takerGave,,) = mgv.marketOrderByLogPrice(olKey, logPrice, 1 ether, true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
@@ -540,9 +538,9 @@ contract TakerOperationsTest is MangroveTest {
     emit OfferFail(
       olKey.hash(),
       ofr,
-      $(this),
       takerWants,
       LogPriceLib.inboundFromOutbound(offer.logPrice(), takerWants),
+      4696520000000000,
       "mgv/makerTransferFail"
     );
     (,, uint bounty,) = mgv.marketOrderByLogPrice(olKey, logPrice, 50 ether, true);
@@ -632,7 +630,7 @@ contract TakerOperationsTest is MangroveTest {
     mkr.shouldRevert(true);
     quote.approve($(mgv), 1 ether);
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, $(this), 1 ether, 1 ether, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 4000000000000000, "mgv/makerRevert");
     mgv.marketOrderByLogPrice(olKey, logPrice, 1 ether, true);
     assertFalse(mkr.makerPosthookWasCalled(ofr), "ofr posthook must not be called or test is void");
   }
@@ -932,8 +930,6 @@ contract TakerOperationsTest is MangroveTest {
     emit Transfer($(mgv), $(mkr), 0 ether);
     expectFrom($(base));
     emit Transfer($(mkr), $(mgv), 0 ether);
-    expectFrom($(mgv));
-    emit OfferSuccess(olKey.hash(), ofr, $(this), 0 ether, LogPriceLib.inboundFromOutbound(logPrice, 0 ether));
 
     (uint successes,) = mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, 0, 100_000, 0)), $(this));
     assertEq(successes, 0, "cleaning should have failed");
@@ -952,11 +948,11 @@ contract TakerOperationsTest is MangroveTest {
     emit Transfer($(this), $(mgv), 0 ether);
     expectFrom($(quote));
     emit Transfer($(mgv), $(failmkr), 0 ether);
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, $(this), 0 ether, 0 ether, "mgv/makerRevert");
     //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
+    expectFrom($(mgv));
+    emit OfferFail(olKey.hash(), ofr, 0 ether, 0 ether, 4401040000000000, "mgv/makerRevert");
 
     vm.expectEmit(true, true, true, false, $(mgv));
     emit OrderComplete(olKey.hash(), $(this), 0 ether, 0 ether, 0, /*penalty*/ 0);
@@ -984,21 +980,22 @@ contract TakerOperationsTest is MangroveTest {
     emit Transfer($(this), $(mgv), 0 ether);
     expectFrom($(quote));
     emit Transfer($(mgv), $(failmkr), 0 ether);
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, $(this), 0 ether, 0 ether, "mgv/makerRevert");
-    //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
+    //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
+    expectFrom($(mgv));
+    emit OfferFail(olKey.hash(), ofr, 0 ether, 0 ether, 4401040000000000, "mgv/makerRevert");
 
     expectFrom($(quote));
     emit Transfer($(this), $(mgv), 0 ether);
     expectFrom($(quote));
     emit Transfer($(mgv), $(failmkr), 0 ether);
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr2, $(this), 0 ether, 0 ether, "mgv/makerRevert");
-    //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
+
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
+    // TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
+    expectFrom($(mgv));
+    emit OfferFail(olKey.hash(), ofr2, 0 ether, 0 ether, 4001040000000000, "mgv/makerRevert");
 
     vm.expectEmit(true, true, true, false, $(mgv));
     emit OrderComplete(olKey.hash(), $(this), 0 ether, 0 ether, 0, /*penalty1 + penalty2*/ 0);
@@ -1033,28 +1030,24 @@ contract TakerOperationsTest is MangroveTest {
     emit Transfer($(this), $(mgv), 0 ether);
     expectFrom($(quote));
     emit Transfer($(mgv), $(failmkr), 0 ether);
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, $(this), 0 ether, 0 ether, "mgv/makerRevert");
-    //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
+    expectFrom($(mgv));
+    emit OfferFail(olKey.hash(), ofr, 0 ether, 0 ether, 4401040000000000, "mgv/makerRevert");
 
     expectFrom($(quote));
     emit Transfer($(this), $(mgv), 0 ether);
     expectFrom($(quote));
     emit Transfer($(mgv), $(mkr), 0 ether);
-    expectFrom($(mgv));
-    emit OfferSuccess(olKey.hash(), ofr2, $(this), 0 ether, 0 ether);
 
     expectFrom($(quote));
     emit Transfer($(this), $(mgv), 0 ether);
     expectFrom($(quote));
     emit Transfer($(mgv), $(failmkr), 0 ether);
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr3, $(this), 0 ether, 0 ether, "mgv/makerRevert");
-    //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
+    expectFrom($(mgv));
+    emit OfferFail(olKey.hash(), ofr3, 0 ether, 0 ether, 4001040000000000, "mgv/makerRevert");
 
     vm.expectEmit(true, true, true, false, $(mgv));
     emit OrderComplete(olKey.hash(), $(this), 0 ether, 0 ether, 0, /*penalty1 + penalty3*/ 0);
@@ -1094,11 +1087,11 @@ contract TakerOperationsTest is MangroveTest {
     emit Transfer($(otherTkr), $(mgv), 1);
     expectFrom($(quote));
     emit Transfer($(mgv), $(failNonZeroMkr), 1);
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, $(otherTkr), 1, 1, "mgv/makerRevert");
     //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(failNonZeroMkr), 0 /*mkr_provision - penalty*/ );
+    expectFrom($(mgv));
+    emit OfferFail(olKey.hash(), ofr, 1, 1, 4411600000000000, "mgv/makerRevert");
 
     vm.expectEmit(true, true, true, false, $(mgv));
     emit OrderComplete(olKey.hash(), $(this), 0 ether, 0 ether, 0, /*penalty*/ 0);


### PR DESCRIPTION
This PR moves the events OfferSucces and OfferFail, so that they are not longer called at offer execution but at posthook end. The reason for moving the events, is to be able to add the exact penalty amount.

By moving the OfferFail event, it enables us to add the penalty amount to the event, without having to add another event. 
The taker has also been removed from the OfferSuccess and OfferFail events, as that information can be gathered ny the OrderComplete event. ( Later, in another PR, that will be moved to OrderStart)
This now solves the issue that we were not able deduce what offer triggered what penalty. This was becayse the OfferFail event was emitted at offer execution and the corresponding credit event (handling the penalty) was done in the posthook. We can now easily tell what offer triggered what penalty. And without adding any new events.

The consequences of this is:
1. OfferSucces and OfferFail are now emitted in reverse, compared to before. This is because they are emitted in the posthook.
2. When Cleaning offers, then they are not emitted in reverse, as each offer is taken one by one and not by a market order.
