### PR TITLE
feat: remove posthookFail event

### DIFF
--- a/src/IMangrove.sol
+++ b/src/IMangrove.sol
@@ -25,8 +25,20 @@ interface IMangrove {
   event Kill();
   event NewMgv();
   event OfferFail(bytes32 indexed olKeyHash, uint id, uint takerWants, uint takerGives, uint penalty, bytes32 mgvData);
+  event OfferFailWithPosthookData(
+    bytes32 indexed olKeyHash,
+    uint id,
+    uint takerWants,
+    uint takerGives,
+    uint penalty,
+    bytes32 mgvData,
+    bytes32 posthookData
+  );
   event OfferRetract(bytes32 indexed olKeyHash, uint id, bool deprovision);
   event OfferSuccess(bytes32 indexed olKeyHash, uint id, uint takerWants, uint takerGives);
+  event OfferSuccessWithPosthookData(
+    bytes32 indexed olKeyHash, uint id, uint takerWants, uint takerGives, bytes32 posthookData
+  );
   event OfferWrite(
     bytes32 indexed olKeyHash, address maker, int logPrice, uint gives, uint gasprice, uint gasreq, uint id
   );

--- a/src/IMangrove.sol
+++ b/src/IMangrove.sol
@@ -34,7 +34,6 @@ interface IMangrove {
     bytes32 indexed olKeyHash, address taker, uint takerGot, uint takerGave, uint penalty, uint feePaid
   );
   event OrderStart();
-  event PosthookFail(bytes32 indexed olKeyHash, uint offerId, bytes32 posthookData);
   event SetActive(bytes32 indexed olKeyHash, bool value);
   event SetDensityFixed(bytes32 indexed olKeyHash, uint value);
   event SetFee(bytes32 indexed olKeyHash, uint value);

--- a/src/MgvLib.sol
+++ b/src/MgvLib.sol
@@ -108,6 +108,15 @@ contract HasMgvEvents {
     uint takerGives
   );
 
+  event OfferSuccessWithPosthookData(
+    bytes32 indexed olKeyHash,
+    uint id,
+    // `maker` is not logged because it can be retrieved from the state using `(outbound_tkn,inbound_tkn,id)`.
+    uint takerWants,
+    uint takerGives,
+    bytes32 posthookData
+  );
+
   /* Log information when a trade execution reverts or returns a non empty bytes32 word */
   event OfferFail(
     bytes32 indexed olKeyHash,
@@ -120,8 +129,17 @@ contract HasMgvEvents {
     bytes32 mgvData
   );
 
-  /* Log information when a posthook reverts */
-  event PosthookFail(bytes32 indexed olKeyHash, uint offerId, bytes32 posthookData);
+  event OfferFailWithPosthookData(
+    bytes32 indexed olKeyHash,
+    uint id,
+    // `maker` is not logged because it can be retrieved from the state using `(olKeyHash)`.
+    uint takerWants,
+    uint takerGives,
+    uint penalty,
+    // `mgvData` may only be `"mgv/makerRevert"`, `"mgv/makerTransferFail"` or `"mgv/makerReceiveFail"`
+    bytes32 mgvData,
+    bytes32 posthookData
+  );
 
   /* * After `permit` and `approve` */
   event Approval(address indexed outbound_tkn, address indexed inbound_tkn, address owner, address spender, uint value);

--- a/test/core/MakerOperations.t.sol
+++ b/test/core/MakerOperations.t.sol
@@ -135,7 +135,7 @@ contract MakerOperationsTest is MangroveTest, IMaker {
 
     mkr.setShouldFailHook(true);
     expectFrom($(mgv));
-    emit PosthookFail(olKey.hash(), ofr, "posthookFail");
+    emit OfferSuccessWithPosthookData(olKey.hash(), ofr, 0.1 ether, 0.1 ether, "posthookFail");
     tkr.marketOrderWithSuccess(0.1 ether); // fails but we don't care
     assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
   }

--- a/test/core/MakerPosthook.t.sol
+++ b/test/core/MakerPosthook.t.sol
@@ -181,8 +181,8 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     ofr = mgv.newOfferByVolume(olKey, 1 ether, 1 ether, gasreq, _gasprice);
     ofr = mgv.newOfferByVolume(olKey, 1 ether, 1 ether, gasreq, _gasprice);
     makerRevert = true;
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 2376040000000000, "mgv/makerRevert");
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, /*penalty*/ 0, "mgv/makerRevert");
     bool success = tkr.marketOrderWithSuccess(1 ether);
     assertTrue(!success, "market order should fail");
     assertTrue(called, "PostHook not called");
@@ -197,8 +197,8 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     ofr = mgv.newOfferByVolume(olKey, 1 ether, 1 ether, gasreq, _gasprice);
     makerRevert = true;
 
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 2517480000000000, "mgv/makerRevert");
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, /*penalty*/ 0, "mgv/makerRevert");
     bool success = tkr.marketOrderWithSuccess(1 ether);
     assertTrue(!success, "market order should fail");
     assertTrue(called, "PostHook not called");
@@ -304,8 +304,8 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(this), 0 /*penalty*/ );
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 3004560000000000, "mgv/makerRevert");
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, /*penalty*/ 0, "mgv/makerRevert");
     bool success = tkr.marketOrderWithSuccess(2 ether);
     assertTrue(!success, "market order should fail");
     assertTrue(called, "PostHook not called");
@@ -394,8 +394,8 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(this), 0 /*refund*/ );
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 3004560000000000, "mgv/makerRevert");
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, /*penalty*/ 0, "mgv/makerRevert");
     bool success = tkr.marketOrderWithSuccess(2 ether);
     assertTrue(called, "PostHook not called");
 
@@ -407,8 +407,8 @@ contract MakerPosthookTest is MangroveTest, IMaker {
   function test_makerRevert_is_logged() public {
     ofr = mgv.newOfferByVolume(olKey, 1 ether, 1 ether, gasreq, _gasprice);
     makerRevert = true; // maker should fail
-    expectFrom($(mgv));
-    emit OfferFailWithPosthookData(olKey.hash(), ofr, 1 ether, 1 ether, 2491320000000000, "mgv/makerRevert", "");
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit OfferFailWithPosthookData(olKey.hash(), ofr, 1 ether, 1 ether, /*penalty*/ 0, "mgv/makerRevert", "");
     tkr.marketOrderWithSuccess(2 ether);
   }
 

--- a/test/core/MakerPosthook.t.sol
+++ b/test/core/MakerPosthook.t.sol
@@ -182,7 +182,7 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     ofr = mgv.newOfferByVolume(olKey, 1 ether, 1 ether, gasreq, _gasprice);
     makerRevert = true;
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 2375880000000000, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 2376040000000000, "mgv/makerRevert");
     bool success = tkr.marketOrderWithSuccess(1 ether);
     assertTrue(!success, "market order should fail");
     assertTrue(called, "PostHook not called");
@@ -198,7 +198,7 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     makerRevert = true;
 
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 2517320000000000, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 2517480000000000, "mgv/makerRevert");
     bool success = tkr.marketOrderWithSuccess(1 ether);
     assertTrue(!success, "market order should fail");
     assertTrue(called, "PostHook not called");
@@ -305,7 +305,7 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(this), 0 /*penalty*/ );
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 3004400000000000, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 3004560000000000, "mgv/makerRevert");
     bool success = tkr.marketOrderWithSuccess(2 ether);
     assertTrue(!success, "market order should fail");
     assertTrue(called, "PostHook not called");
@@ -395,7 +395,7 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(this), 0 /*refund*/ );
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 3004400000000000, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 3004560000000000, "mgv/makerRevert");
     bool success = tkr.marketOrderWithSuccess(2 ether);
     assertTrue(called, "PostHook not called");
 
@@ -408,7 +408,7 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     ofr = mgv.newOfferByVolume(olKey, 1 ether, 1 ether, gasreq, _gasprice);
     makerRevert = true; // maker should fail
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 2491160000000000, "mgv/makerRevert");
+    emit OfferFailWithPosthookData(olKey.hash(), ofr, 1 ether, 1 ether, 2491320000000000, "mgv/makerRevert", "");
     tkr.marketOrderWithSuccess(2 ether);
   }
 
@@ -424,7 +424,7 @@ contract MakerPosthookTest is MangroveTest, IMaker {
 
     ofr = mgv.newOfferByVolume(olKey, 1 ether, 1 ether, gasreq, _gasprice);
     expectFrom($(mgv));
-    emit PosthookFail(olKey.hash(), ofr, "reverting_posthook");
+    emit OfferSuccessWithPosthookData(olKey.hash(), ofr, 1 ether, 1 ether, "reverting_posthook");
 
     bool success = tkr.marketOrderWithSuccess(1 ether);
     assertTrue(success, "order should succeed");

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -298,7 +298,7 @@ contract TakerOperationsTest is MangroveTest {
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(refusemkr), 0 /*mkr_provision - penalty*/ );
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 5741640000000000, "mgv/makerTransferFail");
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 5741800000000000, "mgv/makerTransferFail");
     (uint successes,) =
       mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, logPrice, 100_000, 1 ether)), $(this));
     assertEq(successes, 1, "clean should succeed");
@@ -333,7 +333,7 @@ contract TakerOperationsTest is MangroveTest {
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(mkr), 0 /*mkr_provision - penalty*/ );
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 4696520000000000, "mgv/makerTransferFail");
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 4696680000000000, "mgv/makerTransferFail");
     (uint takerGot, uint takerGave,,) = mgv.marketOrderByLogPrice(olKey, logPrice, 1 ether, true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
@@ -357,7 +357,7 @@ contract TakerOperationsTest is MangroveTest {
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(mkr), 0 /*mkr_provision - penalty*/ );
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 3256560000000000, "mgv/makerReceiveFail");
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 3256720000000000, "mgv/makerReceiveFail");
     (uint takerGot, uint takerGave,,) = mgv.marketOrderByLogPrice(olKey, logPrice, 1 ether, true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
@@ -390,7 +390,7 @@ contract TakerOperationsTest is MangroveTest {
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 4401040000000000, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 4401200000000000, "mgv/makerRevert");
     (uint takerGot, uint takerGave,,) = mgv.marketOrderByLogPrice(olKey, logPrice, 1 ether, true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
@@ -540,7 +540,7 @@ contract TakerOperationsTest is MangroveTest {
       ofr,
       takerWants,
       LogPriceLib.inboundFromOutbound(offer.logPrice(), takerWants),
-      4696520000000000,
+      4696680000000000,
       "mgv/makerTransferFail"
     );
     (,, uint bounty,) = mgv.marketOrderByLogPrice(olKey, logPrice, 50 ether, true);
@@ -630,7 +630,7 @@ contract TakerOperationsTest is MangroveTest {
     mkr.shouldRevert(true);
     quote.approve($(mgv), 1 ether);
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 4000000000000000, "mgv/makerRevert");
+    emit OfferFailWithPosthookData(olKey.hash(), ofr, 1 ether, 1 ether, 4000000000000000, "mgv/makerRevert", "");
     mgv.marketOrderByLogPrice(olKey, logPrice, 1 ether, true);
     assertFalse(mkr.makerPosthookWasCalled(ofr), "ofr posthook must not be called or test is void");
   }
@@ -952,7 +952,7 @@ contract TakerOperationsTest is MangroveTest {
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 0 ether, 0 ether, 4401040000000000, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), ofr, 0 ether, 0 ether, 4401200000000000, "mgv/makerRevert");
 
     vm.expectEmit(true, true, true, false, $(mgv));
     emit OrderComplete(olKey.hash(), $(this), 0 ether, 0 ether, 0, /*penalty*/ 0);
@@ -984,7 +984,7 @@ contract TakerOperationsTest is MangroveTest {
     emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
     //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 0 ether, 0 ether, 4401040000000000, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), ofr, 0 ether, 0 ether, 4401200000000000, "mgv/makerRevert");
 
     expectFrom($(quote));
     emit Transfer($(this), $(mgv), 0 ether);
@@ -995,7 +995,7 @@ contract TakerOperationsTest is MangroveTest {
     emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
     // TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr2, 0 ether, 0 ether, 4001040000000000, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), ofr2, 0 ether, 0 ether, 4001200000000000, "mgv/makerRevert");
 
     vm.expectEmit(true, true, true, false, $(mgv));
     emit OrderComplete(olKey.hash(), $(this), 0 ether, 0 ether, 0, /*penalty1 + penalty2*/ 0);
@@ -1033,7 +1033,7 @@ contract TakerOperationsTest is MangroveTest {
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 0 ether, 0 ether, 4401040000000000, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), ofr, 0 ether, 0 ether, 4401200000000000, "mgv/makerRevert");
 
     expectFrom($(quote));
     emit Transfer($(this), $(mgv), 0 ether);
@@ -1047,7 +1047,7 @@ contract TakerOperationsTest is MangroveTest {
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr3, 0 ether, 0 ether, 4001040000000000, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), ofr3, 0 ether, 0 ether, 4001200000000000, "mgv/makerRevert");
 
     vm.expectEmit(true, true, true, false, $(mgv));
     emit OrderComplete(olKey.hash(), $(this), 0 ether, 0 ether, 0, /*penalty1 + penalty3*/ 0);
@@ -1091,7 +1091,7 @@ contract TakerOperationsTest is MangroveTest {
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(failNonZeroMkr), 0 /*mkr_provision - penalty*/ );
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 1, 1, 4411600000000000, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), ofr, 1, 1, 4411760000000000, "mgv/makerRevert");
 
     vm.expectEmit(true, true, true, false, $(mgv));
     emit OrderComplete(olKey.hash(), $(this), 0 ether, 0 ether, 0, /*penalty*/ 0);

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -630,8 +630,8 @@ contract TakerOperationsTest is MangroveTest {
     mkr.expect("mgv/makerRevert");
     mkr.shouldRevert(true);
     quote.approve($(mgv), 1 ether);
-    expectFrom($(mgv));
-    emit OfferFailWithPosthookData(olKey.hash(), ofr, 1 ether, 1 ether, 4000000000000000, "mgv/makerRevert", "");
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit OfferFailWithPosthookData(olKey.hash(), ofr, 1 ether, 1 ether, /*penalty*/ 0, "mgv/makerRevert", "");
     mgv.marketOrderByLogPrice(olKey, logPrice, 1 ether, true);
     assertFalse(mkr.makerPosthookWasCalled(ofr), "ofr posthook must not be called or test is void");
   }


### PR DESCRIPTION
This PR removes the event PosthookFail. Instead OfferSuccess and OfferFail now has 2 versions, one with posthookData and one without, and we then emit the one with the posthook data, when the posthook fails.

The reason for this change, is to make the worst case more gas efficient. With this change we now emit only one event, either OfferSuccess or OfferFail, when a posthook fails. Where it used to emit both the PosthookFail event and the Offer{Success,Fail} event. We can therefore save a little gas and it intuitively makes more sense to have one, instead of two, when we can. 

Running a test where the posthook fails, with and without these changes, showed a small gas change of ~600, meaning we save ~600 gas in this case.