### PR TITLE
test: Make tests more robust by removing concrete penalties from events

### DIFF
--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -297,8 +297,8 @@ contract TakerOperationsTest is MangroveTest {
     //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(refusemkr), 0 /*mkr_provision - penalty*/ );
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 5741640000000000, "mgv/makerTransferFail");
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, /*penalty*/ 0, "mgv/makerTransferFail");
     (uint successes,) =
       mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, logPrice, 100_000, 1 ether)), $(this));
     assertEq(successes, 1, "clean should succeed");
@@ -332,8 +332,8 @@ contract TakerOperationsTest is MangroveTest {
     //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(mkr), 0 /*mkr_provision - penalty*/ );
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 4696520000000000, "mgv/makerTransferFail");
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, /*penalty*/ 0, "mgv/makerTransferFail");
     (uint takerGot, uint takerGave,,) = mgv.marketOrderByLogPrice(olKey, logPrice, 1 ether, true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
@@ -356,8 +356,8 @@ contract TakerOperationsTest is MangroveTest {
     //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(mkr), 0 /*mkr_provision - penalty*/ );
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 3256560000000000, "mgv/makerReceiveFail");
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, /*penalty*/ 0, "mgv/makerReceiveFail");
     (uint takerGot, uint takerGave,,) = mgv.marketOrderByLogPrice(olKey, logPrice, 1 ether, true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
@@ -389,8 +389,8 @@ contract TakerOperationsTest is MangroveTest {
     //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 4401040000000000, "mgv/makerRevert");
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, /*penalty*/ 0, "mgv/makerRevert");
     (uint takerGot, uint takerGave,,) = mgv.marketOrderByLogPrice(olKey, logPrice, 1 ether, true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
@@ -534,13 +534,14 @@ contract TakerOperationsTest is MangroveTest {
     MgvStructs.OfferPacked offer = mgv.offers(olKey, ofr);
 
     uint takerWants = 50 ether;
-    expectFrom($(mgv));
+    vm.expectEmit(true, true, true, false, $(mgv));
     emit OfferFail(
       olKey.hash(),
       ofr,
       takerWants,
       LogPriceLib.inboundFromOutbound(offer.logPrice(), takerWants),
-      4696520000000000,
+      /*penalty*/
+      0,
       "mgv/makerTransferFail"
     );
     (,, uint bounty,) = mgv.marketOrderByLogPrice(olKey, logPrice, 50 ether, true);
@@ -629,8 +630,8 @@ contract TakerOperationsTest is MangroveTest {
     mkr.expect("mgv/makerRevert");
     mkr.shouldRevert(true);
     quote.approve($(mgv), 1 ether);
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, 4000000000000000, "mgv/makerRevert");
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit OfferFail(olKey.hash(), ofr, 1 ether, 1 ether, /*penalty*/ 0, "mgv/makerRevert");
     mgv.marketOrderByLogPrice(olKey, logPrice, 1 ether, true);
     assertFalse(mkr.makerPosthookWasCalled(ofr), "ofr posthook must not be called or test is void");
   }
@@ -951,8 +952,8 @@ contract TakerOperationsTest is MangroveTest {
     //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 0 ether, 0 ether, 4401040000000000, "mgv/makerRevert");
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit OfferFail(olKey.hash(), ofr, 0 ether, 0 ether, /*penalty*/ 0, "mgv/makerRevert");
 
     vm.expectEmit(true, true, true, false, $(mgv));
     emit OrderComplete(olKey.hash(), $(this), 0 ether, 0 ether, 0, /*penalty*/ 0);
@@ -983,8 +984,8 @@ contract TakerOperationsTest is MangroveTest {
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
     //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 0 ether, 0 ether, 4401040000000000, "mgv/makerRevert");
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit OfferFail(olKey.hash(), ofr, 0 ether, 0 ether, /*penalty*/ 0, "mgv/makerRevert");
 
     expectFrom($(quote));
     emit Transfer($(this), $(mgv), 0 ether);
@@ -994,8 +995,8 @@ contract TakerOperationsTest is MangroveTest {
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
     // TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr2, 0 ether, 0 ether, 4001040000000000, "mgv/makerRevert");
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit OfferFail(olKey.hash(), ofr2, 0 ether, 0 ether, /*penalty*/ 0, "mgv/makerRevert");
 
     vm.expectEmit(true, true, true, false, $(mgv));
     emit OrderComplete(olKey.hash(), $(this), 0 ether, 0 ether, 0, /*penalty1 + penalty2*/ 0);
@@ -1032,8 +1033,8 @@ contract TakerOperationsTest is MangroveTest {
     emit Transfer($(mgv), $(failmkr), 0 ether);
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 0 ether, 0 ether, 4401040000000000, "mgv/makerRevert");
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit OfferFail(olKey.hash(), ofr, 0 ether, 0 ether, /*penalty*/ 0, "mgv/makerRevert");
 
     expectFrom($(quote));
     emit Transfer($(this), $(mgv), 0 ether);
@@ -1046,8 +1047,8 @@ contract TakerOperationsTest is MangroveTest {
     emit Transfer($(mgv), $(failmkr), 0 ether);
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(failmkr), 0 /*mkr_provision - penalty*/ );
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr3, 0 ether, 0 ether, 4001040000000000, "mgv/makerRevert");
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit OfferFail(olKey.hash(), ofr3, 0 ether, 0 ether, /*penalty*/ 0, "mgv/makerRevert");
 
     vm.expectEmit(true, true, true, false, $(mgv));
     emit OrderComplete(olKey.hash(), $(this), 0 ether, 0 ether, 0, /*penalty1 + penalty3*/ 0);
@@ -1090,8 +1091,8 @@ contract TakerOperationsTest is MangroveTest {
     //TODO: when events can be checked instead of expected, take given penalty instead of ignoring it
     vm.expectEmit(true, true, true, false, $(mgv));
     emit Credit($(failNonZeroMkr), 0 /*mkr_provision - penalty*/ );
-    expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), ofr, 1, 1, 4411600000000000, "mgv/makerRevert");
+    vm.expectEmit(true, true, true, false, $(mgv));
+    emit OfferFail(olKey.hash(), ofr, 1, 1, /*penalty*/ 0, "mgv/makerRevert");
 
     vm.expectEmit(true, true, true, false, $(mgv));
     emit OrderComplete(olKey.hash(), $(this), 0 ether, 0 ether, 0, /*penalty*/ 0);


### PR DESCRIPTION
Penalty is volatile during development, so putting constants into the expected events means having to regularly fix tests by running them with -vvv and copying the penalty into the test; This is tedious and adds little value. Ideally, Foundry would allow us to check events in a more granular way. But until this happens, having more robust tests seems preferable.