### PR TITLE
fix: cache local.tick() before flipping branch bits

### DIFF
--- a/lib/TickLib.sol
+++ b/lib/TickLib.sol
@@ -128,6 +128,10 @@ library LeafLib {
 
 library TickLib {
 
+  function eq(Tick tick1, Tick tick2) internal pure returns (bool) {
+    return Tick.unwrap(tick1) == Tick.unwrap(tick2);
+  }
+
   function inRange(Tick tick) internal pure returns (bool) {
     return Tick.unwrap(tick) >= MIN_TICK && Tick.unwrap(tick) <= MAX_TICK;
   }

--- a/test/core/MakerOperations.t.sol
+++ b/test/core/MakerOperations.t.sol
@@ -883,12 +883,79 @@ contract MakerOperationsTest is MangroveTest, IMaker {
       reader.local(olKey).tickPosInLeaf(), offer.tick(olKey.tickScale).posInLeaf(), "posInLeaf should have changed"
     );
   }
+  /* 
+  When an offer ofr is updated, ofr is removed then re-added. In that case, if
+  ofr is about to be inserted as the best offer, we don't go fetch the "next
+  best offer" just after removing ofr. Instead we leave the updated tick branch
+  in local as-is, to be flushed to storage when ofr gets inserted again. Since
+  `local.tick()` is deduced from branch stored in local, `local.tick()` becomes
+  wrong (it becomes higher than it really is). So we must check that it gets
+  cached, otherwise we will 
+    a) fail to flush the local level0/level1 to the right index
+    b) flush the local level0/level1 to the wrong current index
+  To really test a), we need to have some data already where level0/level1
+  should be flushed (to check if the flushing has an effect), so we write an
+  offer there (at lowTick) before it's best, and then we make it best so it gets
+  cached to local (but the original data is still in storage)
+  */
+
+  function test_currentTick_is_cached_no_level01_erasure() public {
+    // Create a very low tick so that later the branch of lowTick will be both in storage and in cache
+    Tick veryLowTick = Tick.wrap(-100000);
+    uint ofr_veryLow = mgv.newOfferByLogPrice(olKey, Tick.unwrap(veryLowTick), 1 ether, 10_000, 0);
+
+    // Create an offer at lowTick
+    Tick lowTick = Tick.wrap(10);
+    uint ofr = mgv.newOfferByLogPrice(olKey, Tick.unwrap(lowTick), 1 ether, 10_000, 0);
+
+    // Make sure very low tick uses a different branch
+    assertTrue(
+      veryLowTick.level0Index() != lowTick.level0Index(), "test setup: [very]lowTick level0Index should be different"
+    );
+    assertTrue(
+      veryLowTick.level1Index() != lowTick.level1Index(), "test setup: [very]lowTick level1Index should be different"
+    );
+
+    // Remove veryLowTick. Now lowTick is the best, and its branch is in cache, but also in storage!
+    mgv.retractOffer(olKey, ofr_veryLow, true);
+
+    // Derive a "bad" local from it
+    MgvStructs.LocalPacked badLocal = reader.local(olKey).level0(FieldLib.EMPTY).level1(FieldLib.EMPTY);
+    // Make sure we changed the implied tick of badLocal
+    assertTrue(!badLocal.tick().eq(lowTick), "test setup: bad tick should not be original lowTick");
+    // Make sure we have changed level indices
+    assertTrue(
+      badLocal.tick().level0Index() != lowTick.level0Index(), "test setup: bad tick level0Index should be different"
+    );
+    assertTrue(
+      badLocal.tick().level1Index() != lowTick.level1Index(), "test setup: bad tick level1Index should be different"
+    );
+    // Create a tick there
+    mgv.newOfferByLogPrice(olKey, Tick.unwrap(badLocal.tick()), 1 ether, 10_000, 0);
+    // Save level0, level1
+    Field highLevel0 = mgv.level0(olKey, badLocal.tick().level0Index());
+    Field highLevel1 = mgv.level1(olKey, badLocal.tick().level1Index());
+    // Update the new tick to an even better tick
+    mgv.updateOfferByLogPrice(olKey, Tick.unwrap(veryLowTick), 1 ether, 10_000, 0, ofr);
+
+    // Make sure we the high offer's branch is still fine
+    assertEq(
+      mgv.level0(olKey, badLocal.tick().level0Index()), highLevel0, "badLocal's tick's level0 should not have changed"
+    );
+    assertEq(
+      mgv.level1(olKey, badLocal.tick().level1Index()), highLevel1, "badLocal's tick's level1 should not have changed"
+    );
+    // Make sure the previously local offer's branch is now empty
+    assertEq(mgv.level0(olKey, lowTick.level0Index()), FieldLib.EMPTY, "lowTick's level0 should have been flushed");
+    assertEq(mgv.level1(olKey, lowTick.level1Index()), FieldLib.EMPTY, "lowTick's level1 should have been flushed");
+  }
+
+  // FIXME
+  // fix test_higher_tick so I'm sure the posInLeaf I'm testing is right
 
   function test_higher_tick() public {
     mgv.newOfferByLogPrice(olKey, 2, 1 ether, 100_000, 0);
     (, MgvStructs.LocalPacked local) = mgv.config(olKey);
-    // console.log("pos in leaf", toString(local));
-    // console.log(LogPriceLib.priceFromLogPrice_e18(LogPriceLib.fromTick(local.tick(),olKey.tickScale)));
 
     mgv.newOfferByLogPrice(olKey, 3, 1 ether, 100_000, 0);
     (, local) = mgv.config(olKey);


### PR DESCRIPTION
Fixes bug found by @espendk in #486
