### PR TITLE
fix: port permit_typehash to new arg names + test

### DIFF
--- a/src/MgvOfferTakingWithPermit.sol
+++ b/src/MgvOfferTakingWithPermit.sol
@@ -13,7 +13,7 @@ abstract contract MgvOfferTakingWithPermit is MgvOfferTaking {
   /* Storing nonces avoids replay attacks. */
   mapping(address => uint) public nonces;
   /* Following [EIP712](https://eips.ethereum.org/EIPS/eip-712), structured data signing has `keccak256("Permit(address outbound_tkn,address inbound_tkn,address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)")` in its prefix. */
-  bytes32 public constant PERMIT_TYPEHASH = 0xb7bf278e51ab1478b10530c0300f911d9ed3562fc93ab5e6593368fe23c077a2;
+  bytes32 public constant PERMIT_TYPEHASH = 0xf0ea0a7146fb6eedb561d97b593d57d9b7df3c94d689372dc01302e5780248f4;
   /* Initialized in the constructor, `DOMAIN_SEPARATOR` avoids cross-application permit reuse. */
   bytes32 public immutable DOMAIN_SEPARATOR;
 

--- a/test/core/Permit.t.sol
+++ b/test/core/Permit.t.sol
@@ -168,6 +168,13 @@ contract PermitTest is MangroveTest, TrivialTestMaker {
       mgv.allowances($(base), $(quote), good_owner, $(this)), value / 2 + (value % 2), "Allowance incorrectly decreased"
     );
   }
+
+  function test_permit_typehash() public {
+    bytes32 expected = keccak256(
+      "Permit(address outbound_tkn,address inbound_tkn,address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
+    );
+    assertEq(mgv.PERMIT_TYPEHASH(), expected, "wrong PERMIT_TYPEHASH");
+  }
 }
 
 /* Permit utilities */


### PR DESCRIPTION
permit_typehash was the hash with base,quote names for token args (instead of outbound_tkn,inbound_tkn)