### PR TITLE
Prevent makers from reading offer list during `makerExecute`

### DIFF
--- a/lib/DensityLib.sol
+++ b/lib/DensityLib.sol
@@ -58,6 +58,10 @@ library DensityLib {
   uint constant FIXED_BITS = FIXED_INTEGER_BITS + FIXED_FRACTIONAL_BITS;
   uint constant FIXED_MASK = ~(ONES << FIXED_BITS);
 
+  function eq(Density a, Density b) internal pure returns (bool) { unchecked {
+    return Density.unwrap(a) == Density.unwrap(b);
+  }}
+
   // Check the size of a fixed-point formatted density
   function checkFixedDensity(uint densityFixed) internal pure returns (bool) { unchecked {
     return densityFixed & FIXED_MASK == densityFixed;

--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -118,6 +118,9 @@ import "mgv_lib/LogPriceConversionLib.sol";
 using OfferPackedExtra for OfferPacked global;
 using OfferUnpackedExtra for OfferUnpacked global;
 
+// cleanup-mask: 0s at location of fields to hide from maker, 1s elsewhere
+uint constant hide_fields_from_maker_mask = ~(prev_mask_inv | next_mask_inv);
+
 library OfferPackedExtra {
   // Compute wants from tick and gives
   function wants(OfferPacked offer) internal pure returns (uint) {
@@ -132,6 +135,13 @@ library OfferPackedExtra {
   }
   function tick(OfferPacked offer, uint tickScale) internal pure returns (Tick) {
     return TickLib.fromLogPrice(offer.logPrice(),tickScale);
+  }
+  function clearFieldsForMaker(OfferPacked offer) internal pure returns (OfferPacked) {
+    unchecked {
+      return OfferPacked.wrap(
+        OfferPacked.unwrap(offer)
+        & hide_fields_from_maker_mask);
+    }
   }
 }
 
@@ -304,6 +314,9 @@ import {Density, DensityLib} from "mgv_lib/DensityLib.sol";
 using LocalPackedExtra for LocalPacked global;
 using LocalUnpackedExtra for LocalUnpacked global;
 
+// cleanup-mask: 0s at location of fields to hide from maker, 1s elsewhere
+uint constant hide_fields_from_maker_mask = ~(tickPosInLeaf_mask_inv | level0_mask_inv | level1_mask_inv | level2_mask_inv | last_mask_inv);
+
 library LocalPackedExtra {
   function densityFromFixed(LocalPacked local, uint densityFixed) internal pure returns (LocalPacked) { unchecked {
     return local.density(DensityLib.fromFixed(densityFixed));
@@ -316,6 +329,13 @@ library LocalPackedExtra {
   }}
   function bestTick(LocalPacked local) internal pure returns (Tick) {
     return TickLib.tickFromBranch(local.tickPosInLeaf(),local.level0(),local.level1(),local.level2());
+  }
+  function clearFieldsForMaker(LocalPacked local) internal pure returns (LocalPacked) {
+    unchecked {
+      return LocalPacked.wrap(
+        LocalPacked.unwrap(local)
+        & hide_fields_from_maker_mask);
+    }
   }
 }
 

--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -119,7 +119,7 @@ using OfferPackedExtra for OfferPacked global;
 using OfferUnpackedExtra for OfferUnpacked global;
 
 // cleanup-mask: 0s at location of fields to hide from maker, 1s elsewhere
-uint constant hide_fields_from_maker_mask = ~(prev_mask_inv | next_mask_inv);
+uint constant HIDE_FIELDS_FROM_MAKER_MASK = ~(prev_mask_inv | next_mask_inv);
 
 library OfferPackedExtra {
   // Compute wants from tick and gives
@@ -140,7 +140,7 @@ library OfferPackedExtra {
     unchecked {
       return OfferPacked.wrap(
         OfferPacked.unwrap(offer)
-        & hide_fields_from_maker_mask);
+        & HIDE_FIELDS_FROM_MAKER_MASK);
     }
   }
 }
@@ -315,7 +315,7 @@ using LocalPackedExtra for LocalPacked global;
 using LocalUnpackedExtra for LocalUnpacked global;
 
 // cleanup-mask: 0s at location of fields to hide from maker, 1s elsewhere
-uint constant hide_fields_from_maker_mask = ~(tickPosInLeaf_mask_inv | level0_mask_inv | level1_mask_inv | level2_mask_inv | last_mask_inv);
+uint constant HIDE_FIELDS_FROM_MAKER_MASK = ~(tickPosInLeaf_mask_inv | level0_mask_inv | level1_mask_inv | level2_mask_inv | last_mask_inv);
 
 library LocalPackedExtra {
   function densityFromFixed(LocalPacked local, uint densityFixed) internal pure returns (LocalPacked) { unchecked {
@@ -334,7 +334,7 @@ library LocalPackedExtra {
     unchecked {
       return LocalPacked.wrap(
         LocalPacked.unwrap(local)
-        & hide_fields_from_maker_mask);
+        & HIDE_FIELDS_FROM_MAKER_MASK);
     }
   }
 }

--- a/src/IMangrove.sol
+++ b/src/IMangrove.sol
@@ -35,10 +35,20 @@ interface IMangrove is HasMgvEvents {
     view
     returns (MgvStructs.GlobalPacked _global, MgvStructs.LocalPacked _local);
 
+  function configGlobal()
+    external
+    view
+    returns (MgvStructs.GlobalPacked _global);
+
   function configInfo(OLKey memory olKey)
     external
     view
     returns (MgvStructs.GlobalUnpacked memory _global, MgvStructs.LocalUnpacked memory _local);
+
+  function configGlobalInfo()
+    external
+    view
+    returns (MgvStructs.GlobalUnpacked memory _global);
 
   function deactivate(OLKey memory olKey) external;
 

--- a/src/MgvHasOffers.sol
+++ b/src/MgvHasOffers.sol
@@ -19,33 +19,6 @@ import {MgvCommon} from "./MgvCommon.sol";
 
 /* `MgvHasOffers` contains the state variables and functions common to both market-maker operations and market-taker operations. Mostly: storing offers, removing them, updating market makers' provisions. */
 contract MgvHasOffers is MgvCommon {
-  /*
-  # Gatekeeping
-
-  Gatekeeping functions are safety checks called in various places.
-  */
-
-  /* `unlockedMarketOnly` protects modifying the market while an order is in progress. Since external contracts are called during orders, allowing reentrancy would, for instance, let a market maker replace offers currently on the book with worse ones. Note that the external contracts _will_ be called again after the order is complete, this time without any lock on the market.  */
-  function unlockedMarketOnly(MgvStructs.LocalPacked local) internal pure {
-    require(!local.lock(), "mgv/reentrancyLocked");
-  }
-
-  /* <a id="Mangrove/definition/liveMgvOnly"></a>
-     In case of emergency, Mangrove can be `kill`ed. It cannot be resurrected. When a Mangrove is dead, the following operations are disabled :
-       * Executing an offer
-       * Sending ETH to Mangrove the normal way. Usual [shenanigans](https://medium.com/@alexsherbuck/two-ways-to-force-ether-into-a-contract-1543c1311c56) are possible.
-       * Creating a new offer
-   */
-  function liveMgvOnly(MgvStructs.GlobalPacked _global) internal pure {
-    require(!_global.dead(), "mgv/dead");
-  }
-
-  /* When Mangrove is deployed, all offerLists are inactive by default (since `locals[outbound_tkn][inbound_tkn]` is 0 by default). Offers on inactive offerLists cannot be taken or created. They can be updated and retracted. */
-  function activeMarketOnly(MgvStructs.GlobalPacked _global, MgvStructs.LocalPacked _local) internal pure {
-    liveMgvOnly(_global);
-    require(_local.active(), "mgv/inactive");
-  }
-
   /* # Provision debit/credit utility functions */
   /* `balanceOf` is in wei of ETH. */
 

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -406,7 +406,21 @@ abstract contract MgvOfferTaking is MgvHasOffers {
        * `msg.sender` is Mangrove itself in those calls -- all operations related to the actual caller should be done outside of this call.
        * any spurious exception due to an error in Mangrove code will be falsely blamed on the Maker, and its provision for the offer will be unfairly taken away.
        */
-      (bool success, bytes memory retdata) = address(this).call(abi.encodeCall(this.flashloan, (sor, mor.taker)));
+      bool success;
+      bytes memory retdata;
+      {
+        // Clear fields that maker must not see
+        MgvStructs.OfferPacked offer = sor.offer;
+        sor.offer = offer.clearFieldsForMaker();
+        MgvStructs.LocalPacked local = sor.local;
+        sor.local = local.clearFieldsForMaker();
+
+        (success, retdata) = address(this).call(abi.encodeCall(this.flashloan, (sor, mor.taker)));
+
+        // Restore cleared fields
+        sor.offer = offer;
+        sor.local = local;
+      }
 
       /* `success` is true: trade is complete */
       if (success) {
@@ -463,18 +477,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
   function makerExecute(MgvLib.SingleOrder calldata sor) internal returns (uint gasused, bytes32 makerData) {
     unchecked {
-      // Clear fields that maker must not see
-      MgvLib.SingleOrder memory sorMem;
-      sorMem.olKey = sor.olKey;
-      sorMem.offerId = sor.offerId;
-      sorMem.offer = sor.offer.clearFieldsForMaker();
-      sorMem.wants = sor.wants;
-      sorMem.gives = sor.gives;
-      sorMem.offerDetail = sor.offerDetail;
-      sorMem.global = sor.global;
-      sorMem.local = sor.local.clearFieldsForMaker();
-
-      bytes memory cd = abi.encodeCall(IMaker.makerExecute, (sorMem));
+      bytes memory cd = abi.encodeCall(IMaker.makerExecute, (sor));
 
       uint gasreq = sor.offerDetail.gasreq();
       address maker = sor.offerDetail.maker();

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -456,6 +456,8 @@ abstract contract MgvOfferTaking is MgvHasOffers {
       bytes memory retdata;
       {
         // Clear fields that maker must not see
+        /* NB: It should be more efficient to do this in `makerExecute` instead as we would not have to restore the fields afterwards.
+         * However, for unknown reasons that solution consumes significantly more gas, so we do it here instead. */
         MgvStructs.OfferPacked offer = sor.offer;
         sor.offer = offer.clearFieldsForMaker();
         MgvStructs.LocalPacked local = sor.local;

--- a/src/MgvView.sol
+++ b/src/MgvView.sol
@@ -19,6 +19,17 @@ contract MgvView is MgvCommon {
     }
   }
 
+  /* Reading the global configuration. In addition, a parameter (`gasprice`) may be read from the oracle. */
+  function configGlobal()
+    public
+    view
+    returns (MgvStructs.GlobalPacked _global)
+  {
+    unchecked {
+      (_global,,) = _config(OLKey(address(0), address(0), 0));
+    }
+  }
+
   function balanceOf(address maker) external view returns (uint balance) {
     balance = _balanceOf[maker];
   }
@@ -71,6 +82,18 @@ contract MgvView is MgvCommon {
       unlockedMarketOnly(__local);
       _global = __global.to_struct();
       _local = __local.to_struct();
+    }
+  }
+
+  /* Returns the global configuration in an ABI-compatible struct. Should not be called internally. */
+  function configGlobalInfo()
+    external
+    view
+    returns (MgvStructs.GlobalUnpacked memory _global)
+  {
+    unchecked {
+      MgvStructs.GlobalPacked __global = configGlobal();
+      _global = __global.to_struct();
     }
   }
 

--- a/src/MgvView.sol
+++ b/src/MgvView.sol
@@ -15,6 +15,7 @@ contract MgvView is MgvCommon {
   {
     unchecked {
       (_global, _local,) = _config(olKey);
+      unlockedMarketOnly(_local);
     }
   }
 
@@ -23,12 +24,15 @@ contract MgvView is MgvCommon {
   }
 
   function leafs(OLKey memory olKey, int index) external view returns (Leaf) {
-    return offerLists[olKey.hash()].leafs[index];
+    OfferList storage offerList = offerLists[olKey.hash()];
+    unlockedMarketOnly(offerList.local);
+    return offerList.leafs[index];
   }
 
   function level0(OLKey memory olKey, int index) external view returns (Field) {
     OfferList storage offerList = offerLists[olKey.hash()];
     MgvStructs.LocalPacked local = offerList.local;
+    unlockedMarketOnly(local);
 
     if (local.bestTick().level0Index() == index) {
       return local.level0();
@@ -40,6 +44,7 @@ contract MgvView is MgvCommon {
   function level1(OLKey memory olKey, int index) external view returns (Field) {
     OfferList storage offerList = offerLists[olKey.hash()];
     MgvStructs.LocalPacked local = offerList.local;
+    unlockedMarketOnly(local);
 
     if (local.bestTick().level1Index() == index) {
       return local.level1();
@@ -49,7 +54,10 @@ contract MgvView is MgvCommon {
   }
 
   function level2(OLKey memory olKey) external view returns (Field) {
-    return offerLists[olKey.hash()].local.level2();
+    OfferList storage offerList = offerLists[olKey.hash()];
+    MgvStructs.LocalPacked local = offerList.local;
+    unlockedMarketOnly(local);
+    return local.level2();
   }
 
   /* Returns the configuration in an ABI-compatible struct. Should not be called internally, would be a huge memory copying waste. Use `config` instead. */
@@ -60,6 +68,7 @@ contract MgvView is MgvCommon {
   {
     unchecked {
       (MgvStructs.GlobalPacked __global, MgvStructs.LocalPacked __local) = config(olKey);
+      unlockedMarketOnly(__local);
       _global = __global.to_struct();
       _local = __local.to_struct();
     }
@@ -75,13 +84,17 @@ contract MgvView is MgvCommon {
   function best(OLKey memory olKey) external view returns (uint offerId) {
     unchecked {
       OfferList storage offerList = offerLists[olKey.hash()];
-      return offerList.leafs[offerList.local.bestTick().leafIndex()].getNextOfferId();
+      MgvStructs.LocalPacked local = offerList.local;
+      unlockedMarketOnly(local);
+      return offerList.leafs[local.bestTick().leafIndex()].getNextOfferId();
     }
   }
 
   /* Convenience function to get an offer in packed format */
   function offers(OLKey memory olKey, uint offerId) external view returns (MgvStructs.OfferPacked offer) {
-    return offerLists[olKey.hash()].offerData[offerId].offer;
+    OfferList storage offerList = offerLists[olKey.hash()];
+    unlockedMarketOnly(offerList.local);
+    return offerList.offerData[offerId].offer;
   }
 
   /* Convenience function to get an offer detail in packed format */
@@ -90,7 +103,9 @@ contract MgvView is MgvCommon {
     view
     returns (MgvStructs.OfferDetailPacked offerDetail)
   {
-    return offerLists[olKey.hash()].offerData[offerId].detail;
+    OfferList storage offerList = offerLists[olKey.hash()];
+    unlockedMarketOnly(offerList.local);
+    return offerList.offerData[offerId].detail;
   }
 
   /* Returns information about an offer in ABI-compatible structs. Do not use internally, would be a huge memory-copying waste. Use `offerLists[outbound_tkn][inbound_tkn].offers` and `offerLists[outbound_tkn][inbound_tkn].offerDetails` instead. */
@@ -100,7 +115,9 @@ contract MgvView is MgvCommon {
     returns (MgvStructs.OfferUnpacked memory offer, MgvStructs.OfferDetailUnpacked memory offerDetail)
   {
     unchecked {
-      OfferData storage offerData = offerLists[olKey.hash()].offerData[offerId];
+      OfferList storage offerList = offerLists[olKey.hash()];
+      unlockedMarketOnly(offerList.local);
+      OfferData storage offerData = offerList.offerData[offerId];
       offer = offerData.offer.to_struct();
       offerDetail = offerData.detail.to_struct();
     }

--- a/src/preprocessed/MgvLocal.post.sol
+++ b/src/preprocessed/MgvLocal.post.sol
@@ -39,6 +39,9 @@ import {Density, DensityLib} from "mgv_lib/DensityLib.sol";
 using LocalPackedExtra for LocalPacked global;
 using LocalUnpackedExtra for LocalUnpacked global;
 
+// cleanup-mask: 0s at location of fields to hide from maker, 1s elsewhere
+uint constant hide_fields_from_maker_mask = ~(tickPosInLeaf_mask_inv | level0_mask_inv | level1_mask_inv | level2_mask_inv | last_mask_inv);
+
 library LocalPackedExtra {
   function densityFromFixed(LocalPacked local, uint densityFixed) internal pure returns (LocalPacked) { unchecked {
     return local.density(DensityLib.fromFixed(densityFixed));
@@ -51,6 +54,13 @@ library LocalPackedExtra {
   }}
   function bestTick(LocalPacked local) internal pure returns (Tick) {
     return TickLib.tickFromBranch(local.tickPosInLeaf(),local.level0(),local.level1(),local.level2());
+  }
+  function clearFieldsForMaker(LocalPacked local) internal pure returns (LocalPacked) {
+    unchecked {
+      return LocalPacked.wrap(
+        LocalPacked.unwrap(local)
+        & hide_fields_from_maker_mask);
+    }
   }
 }
 

--- a/src/preprocessed/MgvLocal.post.sol
+++ b/src/preprocessed/MgvLocal.post.sol
@@ -40,7 +40,7 @@ using LocalPackedExtra for LocalPacked global;
 using LocalUnpackedExtra for LocalUnpacked global;
 
 // cleanup-mask: 0s at location of fields to hide from maker, 1s elsewhere
-uint constant hide_fields_from_maker_mask = ~(tickPosInLeaf_mask_inv | level0_mask_inv | level1_mask_inv | level2_mask_inv | last_mask_inv);
+uint constant HIDE_FIELDS_FROM_MAKER_MASK = ~(tickPosInLeaf_mask_inv | level0_mask_inv | level1_mask_inv | level2_mask_inv | last_mask_inv);
 
 library LocalPackedExtra {
   function densityFromFixed(LocalPacked local, uint densityFixed) internal pure returns (LocalPacked) { unchecked {
@@ -59,7 +59,7 @@ library LocalPackedExtra {
     unchecked {
       return LocalPacked.wrap(
         LocalPacked.unwrap(local)
-        & hide_fields_from_maker_mask);
+        & HIDE_FIELDS_FROM_MAKER_MASK);
     }
   }
 }

--- a/src/preprocessed/MgvOffer.post.sol
+++ b/src/preprocessed/MgvOffer.post.sol
@@ -33,6 +33,9 @@ import "mgv_lib/LogPriceConversionLib.sol";
 using OfferPackedExtra for OfferPacked global;
 using OfferUnpackedExtra for OfferUnpacked global;
 
+// cleanup-mask: 0s at location of fields to hide from maker, 1s elsewhere
+uint constant hide_fields_from_maker_mask = ~(prev_mask_inv | next_mask_inv);
+
 library OfferPackedExtra {
   // Compute wants from tick and gives
   function wants(OfferPacked offer) internal pure returns (uint) {
@@ -47,6 +50,13 @@ library OfferPackedExtra {
   }
   function tick(OfferPacked offer, uint tickScale) internal pure returns (Tick) {
     return TickLib.fromLogPrice(offer.logPrice(),tickScale);
+  }
+  function clearFieldsForMaker(OfferPacked offer) internal pure returns (OfferPacked) {
+    unchecked {
+      return OfferPacked.wrap(
+        OfferPacked.unwrap(offer)
+        & hide_fields_from_maker_mask);
+    }
   }
 }
 

--- a/src/preprocessed/MgvOffer.post.sol
+++ b/src/preprocessed/MgvOffer.post.sol
@@ -34,7 +34,7 @@ using OfferPackedExtra for OfferPacked global;
 using OfferUnpackedExtra for OfferUnpacked global;
 
 // cleanup-mask: 0s at location of fields to hide from maker, 1s elsewhere
-uint constant hide_fields_from_maker_mask = ~(prev_mask_inv | next_mask_inv);
+uint constant HIDE_FIELDS_FROM_MAKER_MASK = ~(prev_mask_inv | next_mask_inv);
 
 library OfferPackedExtra {
   // Compute wants from tick and gives
@@ -55,7 +55,7 @@ library OfferPackedExtra {
     unchecked {
       return OfferPacked.wrap(
         OfferPacked.unwrap(offer)
-        & hide_fields_from_maker_mask);
+        & HIDE_FIELDS_FROM_MAKER_MASK);
     }
   }
 }

--- a/test/core/Gatekeeping.t.sol
+++ b/test/core/Gatekeeping.t.sol
@@ -397,7 +397,7 @@ contract GatekeepingTest is MangroveTest {
 
     mkr.setPosthookCallback($(this), abi.encodeCall(this.newOfferOK, (olKey)));
     assertTrue(tkr.marketOrderWithSuccess(1 ether), "take must succeed or test is void");
-    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
+    assertTrue(mkr.makerPosthookWasCalled(ofr), "ofr posthook must be executed or test is void");
     assertTrue(mgv.best(olKey) == 2, "newOfferByVolume on posthook must work");
   }
 
@@ -445,7 +445,7 @@ contract GatekeepingTest is MangroveTest {
     mkr.setPosthookCallback($(this), abi.encodeCall(this.updateOfferOK, (olKey, other_ofr)));
     uint ofr = mkr.newOfferByLogPrice(olKey, 0, 1 ether, 300_000);
     assertTrue(tkr.marketOrderWithSuccess(1 ether), "market order must succeed or test is void");
-    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
+    assertTrue(mkr.makerPosthookWasCalled(ofr), "ofr posthook must be executed or test is void");
     assertTrue(mgv.offerDetails(olKey, other_ofr).gasreq() == 35_000, "updateOffer on posthook must work");
   }
 
@@ -495,7 +495,7 @@ contract GatekeepingTest is MangroveTest {
 
     uint ofr = mkr.newOfferByLogPrice(olKey, 0, 1 ether, 190_000);
     assertTrue(tkr.marketOrderWithSuccess(1 ether), "market order must succeed or test is void");
-    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
+    assertTrue(mkr.makerPosthookWasCalled(ofr), "ofr posthook must be executed or test is void");
     assertEq(mgv.best(olKey), 0, "retractOffer on posthook must work");
   }
 
@@ -551,7 +551,7 @@ contract GatekeepingTest is MangroveTest {
     uint ofr2 = other_mkr.newOfferByVolume(olKey, 0.5 ether, 0.5 ether, 1800_000);
     mkr.setPosthookCallback($(this), abi.encodeCall(this.marketOrderOK, (olKey)));
     assertTrue(tkr.marketOrderWithSuccess(0.5 ether), "market order must succeed or test is void");
-    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
+    assertTrue(mkr.makerPosthookWasCalled(ofr), "ofr posthook must be executed or test is void");
     assertTrue(other_mkr.makerExecuteWasCalled(ofr2), "ofr2 must be executed or test is void");
     assertTrue(mgv.best(olKey) == 0, "2nd market order must have emptied mgv");
   }
@@ -693,7 +693,7 @@ contract GatekeepingTest is MangroveTest {
     uint ofr = mkr.newOfferByVolume(olKey, 1 ether, 1 ether, 450_000);
 
     assertTrue(tkr.marketOrderWithSuccess(1 ether), "take must succeed or test is void");
-    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
+    assertTrue(mkr.makerPosthookWasCalled(ofr), "ofr posthook must be executed or test is void");
     assertTrue(mgv.best(olKey) == 0, "clean in posthook must work");
   }
 

--- a/test/core/MakerOperations.t.sol
+++ b/test/core/MakerOperations.t.sol
@@ -3,13 +3,28 @@
 pragma solidity ^0.8.10;
 
 import "mgv_test/lib/MangroveTest.sol";
-import {MgvStructs, Leaf, LogPriceLib} from "mgv_src/MgvLib.sol";
-import {DensityLib} from "mgv_lib/DensityLib.sol";
+import {MgvStructs, Leaf, LogPriceLib, IMgvMonitor} from "mgv_src/MgvLib.sol";
+import {Density, DensityLib} from "mgv_lib/DensityLib.sol";
+
+contract TestMonitor is IMgvMonitor {
+  function notifySuccess(MgvLib.SingleOrder calldata sor, address taker) external {}
+
+  function notifyFail(MgvLib.SingleOrder calldata sor, address taker) external {}
+
+  function read(OLKey memory olKey) external pure returns (uint gasprice, Density density) {
+    olKey; // shh
+    gasprice = 40;
+    density = Density.wrap(2 ** 32);
+  }
+}
 
 contract MakerOperationsTest is MangroveTest, IMaker {
   TestMaker mkr;
   TestMaker mkr2;
   TestTaker tkr;
+  TestMonitor monitor;
+  MgvStructs.LocalPacked localCopy;
+  MgvStructs.GlobalPacked globalCopy;
 
   function setUp() public override {
     super.setUp();
@@ -23,6 +38,78 @@ contract MakerOperationsTest is MangroveTest, IMaker {
 
     deal($(quote), address(tkr), 1 ether);
     tkr.approveMgv(quote, 1 ether);
+  }
+
+  // checks that exactly the right SOR fields are hidden from maker
+  function assertSORFieldsFilteredCorrectly(MgvLib.SingleOrder calldata order) public {
+    // OLKey is not filtered
+    assertEq(order.olKey.outbound, $(base), "olKey.base should not be hidden");
+    assertEq(order.olKey.inbound, $(quote), "olKey.quote should not be hidden");
+    assertEq(order.olKey.tickScale, olKey.tickScale, "olKey.tickScale should not be hidden");
+
+    // OfferPacked is partially filtered
+    //   hidden
+    assertEq(order.offer.prev(), 0, "offer.prev should be hidden");
+    assertEq(order.offer.next(), 0, "offer.next should be hidden");
+    //   not hidden
+    assertEq(order.offer.logPrice(), 1, "offer.logPrice should not be hidden");
+    assertEq(order.offer.gives(), 1 ether, "offer.gives should not be hidden");
+
+    // OfferPackedDetail is not filtered
+    assertEq(order.offerDetail.maker(), $(mkr), "offerDetail.maker should not be hidden");
+    assertEq(order.offerDetail.gasprice(), globalCopy.gasprice(), "offerDetail.gasprice should not be hidden");
+    assertEq(
+      order.offerDetail.kilo_offer_gasbase(),
+      localCopy.kilo_offer_gasbase(),
+      "offerDetail.kilo_offer_gasbase should not be hidden"
+    );
+    assertEq(order.offerDetail.gasreq(), 200_000, "offerDetail.gasreq should not be hidden");
+
+    // wants and gives are not filtered
+    assertEq(order.wants, 0.1 ether, "wants should not be hidden");
+    assertEq(order.gives, 0.10001 ether, "gives should not be hidden");
+
+    // GloablPacked is not filtered
+    assertEq(order.global.monitor(), address(monitor), "global.monitor should not be hidden");
+    assertTrue(order.global.useOracle(), "global.useOracle should not be hidden");
+    assertTrue(order.global.notify(), "global.notify should not be hidden");
+    assertEq(order.global.gasprice(), globalCopy.gasprice(), "global.gasprice should not be hidden");
+    assertEq(order.global.gasmax(), globalCopy.gasmax(), "global.gasmax should not be hidden");
+    assertFalse(order.global.dead(), "global.dead should not be hidden");
+
+    // LocalPacked is partially filtered
+    //   hidden
+    assertEq(order.local.tickPosInLeaf(), 0, "tickPosInLeaf should be hidden");
+    assertEq(order.local.level0(), FieldLib.EMPTY, "level0 should be hidden");
+    assertEq(order.local.level1(), FieldLib.EMPTY, "level1 should be hidden");
+    assertEq(order.local.level2(), FieldLib.EMPTY, "level2 should be hidden");
+    assertEq(order.local.last(), 0, "last should be hidden");
+    //   not hidden
+    assertTrue(order.local.active(), "active should not be hidden");
+    assertEq(order.local.fee(), localCopy.fee(), "fee should not be hidden");
+    assertTrue(order.local.density().eq(localCopy.density()), "density should not be hidden");
+    assertEq(
+      order.local.kilo_offer_gasbase(), localCopy.kilo_offer_gasbase(), "kilo_offer_gasbase should not be hidden"
+    );
+    assertTrue(order.local.lock(), "lock should not be hidden");
+  }
+
+  function test_fields_are_hidden_correctly_in_makerExecute() public {
+    monitor = new TestMonitor();
+    mgv.setMonitor(address(monitor));
+    mgv.setUseOracle(true);
+    mgv.setNotify(true);
+    mgv.setFee(olKey, 1);
+    localCopy = reader.local(olKey);
+    globalCopy = reader.global();
+
+    mkr.provisionMgv(1 ether);
+    mkr.setExecuteCallback($(this), this.assertSORFieldsFilteredCorrectly.selector);
+    deal($(base), $(mkr), 1 ether);
+
+    uint ofr = mkr.newOfferByLogPrice(1, 1 ether, 200_000);
+    require(tkr.marketOrderWithSuccess(0.1 ether), "take must work or test is void");
+    assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
   }
 
   function test_fund_maker_fn(address anyone, uint64 amount) public {

--- a/test/core/MakerOperations.t.sol
+++ b/test/core/MakerOperations.t.sol
@@ -152,7 +152,7 @@ contract MakerOperationsTest is MangroveTest, IMaker {
 
     assertEq(order.olKey.outbound, $(base), "wrong base");
     assertEq(order.olKey.inbound, $(quote), "wrong quote");
-    assertEq(order.olKey.tickScale, olKey.tickScale, "wrong quote");
+    assertEq(order.olKey.tickScale, olKey.tickScale, "wrong tickscale");
     assertEq(order.wants, 0.05 ether, "wrong takerWants");
     assertEq(order.gives, 0.05 ether, "wrong takerGives");
     assertEq(order.offerDetail.gasreq(), 200_000, "wrong gasreq");
@@ -160,7 +160,7 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     assertEq(order.offer.wants(), 0.05 ether, "wrong offerWants");
     assertEq(order.offer.gives(), 0.05 ether, "wrong offerGives");
     // test flashloan
-    assertEq(quote.balanceOf($(this)), 0.05 ether, "wrong quote balance");
+    assertEq(quote.balanceOf($(mkr)), 0.05 ether, "wrong quote balance");
     return "";
   }
 
@@ -168,6 +168,7 @@ contract MakerOperationsTest is MangroveTest, IMaker {
 
   function test_calldata_and_balance_in_makerExecute_are_correct() public {
     mkr.provisionMgv(1 ether);
+    mkr.setExecuteCallback($(this), this.makerExecute.selector);
     deal($(base), $(mkr), 1 ether);
     uint ofr = mkr.newOfferByVolume(olKey, 0.05 ether, 0.05 ether, 200_000);
     require(tkr.marketOrderWithSuccess(0.05 ether), "take must work or test is void");

--- a/test/lib/agents/TestMaker.sol
+++ b/test/lib/agents/TestMaker.sol
@@ -33,6 +33,8 @@ contract SimpleTestMaker is TrivialTestMaker, Script2 {
   bytes tradeCallback;
   address posthookCallbackContract; // the `posthookCallback` will be called on this contract during makerExecute
   bytes posthookCallback;
+  address executeCallbackContract; // the `executeCallbackSelector` will be called on this contract during makerExecute
+  bytes4 executeCallbackSelector; // this function must take a single argument of type `MgvLib.SingleOrder`
   ///@notice stores parameters for each posted offer
   ///@notice overrides global @shouldFail/shouldReturn if true
 
@@ -77,6 +79,11 @@ contract SimpleTestMaker is TrivialTestMaker, Script2 {
     return offersPosthookExecuted[_olKey.hash()][offerId];
   }
 
+  function setExecuteCallback(address _executeCallbackContract, bytes4 _executeCallbackSelector) external {
+    executeCallbackContract = _executeCallbackContract;
+    executeCallbackSelector = _executeCallbackSelector;
+  }
+
   function setTradeCallback(address _tradeCallbackContract, bytes calldata _tradeCallback) external {
     tradeCallbackContract = _tradeCallbackContract;
     tradeCallback = _tradeCallback;
@@ -117,6 +124,10 @@ contract SimpleTestMaker is TrivialTestMaker, Script2 {
 
   function makerExecute(MgvLib.SingleOrder calldata order) public virtual override returns (bytes32) {
     offersExecuted[order.olKey.hash()][order.offerId] = true;
+    if (executeCallbackContract != address(0) && executeCallbackSelector.length > 0) {
+      (bool success,) = executeCallbackContract.call(abi.encodeWithSelector(executeCallbackSelector, (order)));
+      require(success, "makerExecute executeCallback must work");
+    }
 
     if (_shouldRevert) {
       revert("testMaker/shouldRevert");

--- a/test/lib/agents/TestMaker.sol
+++ b/test/lib/agents/TestMaker.sol
@@ -415,11 +415,20 @@ contract SimpleTestMaker is TrivialTestMaker, Script2 {
   }
 
   function clean(uint offerId, uint takerWants) public returns (bool success) {
-    return clean(olKey, offerId, takerWants);
+    int logPrice = mgv.offers(olKey, offerId).logPrice();
+    return clean(olKey, offerId, logPrice, takerWants);
+  }
+
+  function clean(uint offerId, int logPrice, uint takerWants) public returns (bool success) {
+    return clean(olKey, offerId, logPrice, takerWants);
   }
 
   function clean(OLKey memory _olKey, uint offerId, uint takerWants) public returns (bool success) {
     int logPrice = mgv.offers(olKey, offerId).logPrice();
+    return clean(_olKey, offerId, logPrice, takerWants);
+  }
+
+  function clean(OLKey memory _olKey, uint offerId, int logPrice, uint takerWants) public returns (bool success) {
     (uint successes,) = mgv.cleanByImpersonation(
       _olKey, wrap_dynamic(MgvLib.CleanTarget(offerId, logPrice, type(uint48).max, takerWants)), address(this)
     );


### PR DESCRIPTION
This PR prevents makers from reading the offer list during `makerExecute`.

This is done for two reasons:
1. To prevent `makerExecute` from detecting cleaning
2. To avoid the gas cost of keeping the offer list up-to-date for `makerExecute`. A number of optimizations are in place which mean that `local`, leafs, and levels may not be up-to-date.

Two measures are implemented:
- The existing offer list lock is now enforced as a read-lock as well in all the view functions.
- All fields in the `SingleOrder` struct that pertain to the offer list/tick tree structure are cleared (set to zero) before it is passed to `makerExecute`.


Closes https://github.com/mangrovedao/mangrove-core/issues/503