### PR TITLE
feat: Add `--diff` option to ./gas-measurement.sh

### DIFF
--- a/gas-measurement.sh
+++ b/gas-measurement.sh
@@ -1,29 +1,126 @@
-#!/bin/sh
+#!/bin/bash
+set -x
 
-forge test --mp "test/core/gas/*" -vv --silent --json > out/gas-measurement.json
+out_dir="out"
+default_json_file="${out_dir}/gas-measurement.json"
 
-{
-  echo "file:class:test;file:class;test;gas;description"
-  jq -r 'to_entries[] |
-    .key as $file |
-    .value.test_results |
-    to_entries[] |
-    select(.value.decoded_logs) |
-    .key as $test |
-    {
-        gasLogs: (.value.decoded_logs | map(select(startswith("Gas used: "))) | if length == 0 then [null] else . end),
-        descLogs: (.value.decoded_logs | map(select(startswith("Description: "))) | if length == 0 then [null] else . end)
-    } |
-    "\($file):\($test);\($file);\($test);\(.gasLogs[0] // "MISSING-GAS-OR-SKIPPED" | sub("Gas used: "; ""));\(.descLogs[0] // "MISSING-DESCRIPTION" | sub("Description: "; ""))"' out/gas-measurement.json
- } > out/gas-measurement.csv
+function run_gas_measurement() {
+  local json_file=$1
+  local tmp_file="$1.tmp"
+  forge test --mp "test/core/gas/*" -vv --silent --json > "${json_file}"
+  # Forge is very verbose, so we filter the json to keep only the gas information
+  jq '
+    map_values(
+      {
+        test: .test_results | keys_unsorted[]?,
+        description: .test_results[]? | select(.decoded_logs) | .decoded_logs[] | select(startswith("Description: ")) | sub("Description: "; ""),
+        gas: .test_results[]? | select(.decoded_logs) | .decoded_logs[] | select(startswith("Gas used: ")) | sub("Gas used: "; "") | tonumber
+      }
+    )' "${json_file}" > "${tmp_file}"
+  mv "${tmp_file}" "${json_file}"
+}
 
-repeats=`cat out/gas-measurement.csv | cut -d ';' -f5 | grep -v "MISSING-DESCRIPTION" | sort | uniq -d`
+function compare_gas_measurement_json() {
+  local json_file_old=$1
+  local json_file_new=$2
+  local json_file_diff=$3
 
-echo "Gas measurement results: out/gas-measurement.csv"
+  jq -s 'flatten | group_by(.key + .value.test) | map({key: .[0].key, value: {test: .[0].value.test, description: .[0].value.description, gas_before: .[0].value.gas, gas_after: .[1].value.gas, gas_delta: (.[1].value.gas - .[0].value.gas)}})' \
+    <(jq 'to_entries | map({key: .key, value: .value, source: "before"})' "${json_file_old}") \
+    <(jq 'to_entries | map({key: .key, value: .value, source: "after"})' "${json_file_new}") \
+    | jq 'map({(.key): .value}) | add' > "${json_file_diff}"
+}
 
-if [ ! -z "$repeats" ]
-then
-  echo "Repeated descriptions:"
-  echo "$repeats"
-  exit 1
+function generate_csv_from_gas_measurement_json() {
+  local json_file=$1
+  local csv_file=$2
+  jq -r '# Add header row
+    [["file:class:test", "file:class", "test", "gas", "description"]]
+
+    # Union with the rest of the rows
+    + (
+      # Iterate over each key-value pair in the root object
+      to_entries |
+
+      # Create an array for each row
+      map(
+      [
+        (.key + ":" + .value.test),
+        .key,
+        .value.test,
+        .value.gas,
+        .value.description
+      ])
+    )
+
+    # Flatten the array and join array elements with semicolons to create each row
+    | .[] | @csv
+  ' "${json_file}" > "${csv_file}"
+  repeats=`cat out/gas-measurement.csv | cut -d ';' -f5 | grep -v "MISSING-DESCRIPTION" | sort | uniq -d`
+  if [ ! -z "$repeats" ]
+  then
+    echo "Repeated descriptions:"
+    echo "$repeats"
+    exit 1
+  fi
+}
+
+function generate_csv_from_diff_json() {
+  local json_file=$1
+  local csv_file=$2
+  jq -r '# Add header row
+    [["file:class:test", "file:class", "test", "gas before", "gas after", "gas delta", "description"]]
+
+    # Union with the rest of the rows
+    + (
+      # Iterate over each key-value pair in the root object
+      to_entries |
+
+      # Create an array for each row
+      map(
+      [
+        (.key + ":" + .value.test),
+        .key,
+        .value.test,
+        .value.gas_before,
+        .value.gas_after,
+        .value.gas_delta,
+        .value.description
+      ])
+    )
+
+    # Flatten the array and join array elements with semicolons to create each row
+    | .[] | @csv
+  ' "${json_file}" > "${csv_file}"
+}
+
+# Check for --diff parameter
+if [[ "$1" == "--diff" ]]; then
+  # Run measurements on current code
+  json_file_new="${out_dir}/gas-measurement-new.json"
+  csv_file_new="${out_dir}/gas-measurement-new.csv"
+  echo "Running gas measurement on current code..."
+  run_gas_measurement "${json_file_new}"
+  generate_csv_from_gas_measurement_json "${json_file_new}" "${csv_file_new}"
+  echo "   Gas measurement results for current code: ${csv_file_new}"
+  echo ""
+
+  # Compare to previous measurements
+  json_file_old="${default_json_file}"
+  json_file_diff="${out_dir}/gas-measurement-diff.json"
+  csv_file_diff="${out_dir}/gas-measurement-diff.csv"
+  echo "Comparing gas measurement results with previous code..."
+  echo "   Using gas measurement results from previous code: ${json_file_old}"
+  compare_gas_measurement_json "${json_file_old}" "${json_file_new}" "${json_file_diff}"
+  generate_csv_from_diff_json "${json_file_diff}" "${csv_file_diff}"
+  echo "   Gas measurement diff results: ${csv_file_diff}"
+else
+  json_file="${default_json_file}"
+  csv_file="${out_dir}/gas-measurement.csv"
+
+  run_gas_measurement "${json_file}"
+  generate_csv_from_gas_measurement_json "${json_file}" "${csv_file}"
+
+  echo "Gas measurement results: ${csv_file}"
 fi
+

--- a/gas-measurement.sh
+++ b/gas-measurement.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x
 
 out_dir="out"
 default_json_file="${out_dir}/gas-measurement.json"

--- a/test/core/gas/README.md
+++ b/test/core/gas/README.md
@@ -4,7 +4,7 @@ Gas tests be run with `-vv` so correct gas estimates are shown.
 
 To list gas usage for all scenarios run `./gas-measurement.sh`. This generates `gas-measurement.{json,csv}` files with the gas measurements in the `out` folder.
 
-To get a diff in gas measurements (eg with different optimization settings or different code versions) first run `./gas-measurement.sh` in the before setup, and then run `./gas-measurement --diff` in the after setup. This will generate `out/gas-measurement-diff.{json,csv}` files with the gas measurements before and after as well as the delta for each test.
+To get a diff in gas measurements (eg with different optimization settings or different code versions) first run `./gas-measurement.sh` in the before setup, and then run `./gas-measurement.sh --diff` in the after setup. This will generate `out/gas-measurement-diff.{json,csv}` files with the gas measurements before and after as well as the delta for each test.
 
 We test gas usage for various scenarios. This can be used to determine gas usage for a strat's `makerExecute` or `makerPosthook` functions. The absolute values are rarely used, instead a strat builder should verify their gas usage in some specific scenario (e.g. with posthook updating the same offer list as its taken on, where the offer list has other offers on the same tick as a new offer is created on) and then compare deltas to other scenarios tested here and use it to set a `gasreq` for their strat which covers the desired worst-case scenarios. The gas measurements are for the inner-most operation.
 

--- a/test/core/gas/README.md
+++ b/test/core/gas/README.md
@@ -2,7 +2,9 @@
 
 Gas tests be run with `-vv` so correct gas estimates are shown.
 
-To list gas usage for all scenarios run `./gas-measurement.sh`.
+To list gas usage for all scenarios run `./gas-measurement.sh`. This generates `gas-measurement.{json,csv}` files with the gas measurements in the `out` folder.
+
+To get a diff in gas measurements (eg with different optimization settings or different code versions) first run `./gas-measurement.sh` in the before setup, and then run `./gas-measurement --diff` in the after setup. This will generate `out/gas-measurement-diff.{json,csv}` files with the gas measurements before and after as well as the delta for each test.
 
 We test gas usage for various scenarios. This can be used to determine gas usage for a strat's `makerExecute` or `makerPosthook` functions. The absolute values are rarely used, instead a strat builder should verify their gas usage in some specific scenario (e.g. with posthook updating the same offer list as its taken on, where the offer list has other offers on the same tick as a new offer is created on) and then compare deltas to other scenarios tested here and use it to set a `gasreq` for their strat which covers the desired worst-case scenarios. The gas measurements are for the inner-most operation.
 


### PR DESCRIPTION
This PR adds a `--diff` option to `./gas-measurement.sh`, similar to `forge snapshot --diff`, which runs the gas measurement tests and compares the results to previous measurements.

To get a diff in gas measurements (eg with different optimization settings or different code versions) do the following:

1. first run `./gas-measurement.sh` in the before setup.
   - This generates `gas-measurement.{json,csv}` files with the gas measurements in the `out` folder.
2. then run `./gas-measurement.sh --diff` in the after setup.
   - This generates:
      - `gas-measurement-new.{json,csv}` files with the new gas measurements in the `out` folder.
      - `out/gas-measurement-diff.{json,csv}` files with the gas measurements before and after as well as the delta for each test.
