### PR TITLE
Feat/max tick on empty level0

### DIFF
--- a/lib/TickLib.sol
+++ b/lib/TickLib.sol
@@ -146,6 +146,7 @@ library TickLib {
     return Tick.wrap(tick);
   }
 
+  // low-level function to get a tick from a branch, no protection against malformed branches
   function tickFromBranch(uint tickPosInLeaf,Field level0, Field level1, Field level2) internal pure returns (Tick) {
     unchecked {
       uint utick = tickPosInLeaf |

--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -327,8 +327,17 @@ library LocalPackedExtra {
   function offer_gasbase(LocalPacked local,uint val) internal pure returns (LocalPacked) { unchecked {
     return local.kilo_offer_gasbase(val/1e3);
   }}
+  // Returns MAX_TICK if branch in local is not valid (it has a field at zero)
+  // It should always be the case that a field is at zero if
+  // - the offerList is empty, in which case all levels are 0, or
+  // - local is in a temporary state in the middle of a call to writeOffer that retracts then reinserts an offers, in which case bestTick must not be called
   function bestTick(LocalPacked local) internal pure returns (Tick) {
-    return TickLib.tickFromBranch(local.tickPosInLeaf(),local.level0(),local.level1(),local.level2());
+    Field level0 = local.level0();
+    if (level0.isEmpty()) {
+      return Tick.wrap(MAX_TICK+1);
+    } else {
+      return TickLib.tickFromBranch(local.tickPosInLeaf(),level0,local.level1(),local.level2());
+    }
   }
   function clearFieldsForMaker(LocalPacked local) internal pure returns (LocalPacked) {
     unchecked {
@@ -350,7 +359,12 @@ library LocalUnpackedExtra {
     local.kilo_offer_gasbase = val/1e3;
   }}
   function bestTick(LocalUnpacked memory local) internal pure returns (Tick) {
-    return TickLib.tickFromBranch(local.tickPosInLeaf,local.level0,local.level1,local.level2);
+    Field level0 = local.level0;
+    if (level0.isEmpty()) {
+      return Tick.wrap(MAX_TICK+1);
+    } else {
+      return TickLib.tickFromBranch(local.tickPosInLeaf,level0,local.level1,local.level2);
+    }
   }
 }
 `,

--- a/test/core/Leaf.t.sol
+++ b/test/core/Leaf.t.sol
@@ -220,6 +220,11 @@ contract TickTest is Test {
     assertEq(tick.posInLevel2(), BitLib.ctz(Field.unwrap(level2)), "wrong pos in level2");
   }
 
+  function test_bestTick_returns_maxTick_on_empty_level0(MgvStructs.LocalPacked local) public {
+    local = local.level0(FieldLib.EMPTY);
+    assertEq(local.bestTick(), MAX_TICK + 1);
+  }
+
   // HELPER FUNCTIONS
   function assertEq(Tick tick, int ticknum) internal {
     assertEq(Tick.unwrap(tick), ticknum);


### PR DESCRIPTION
_On pause: maybe there's a better way to be consistent, and `local.bestTick` should just never be called on an invalid/empty branch._
Make explicit the fact that on empty level0, the tick returned by `local.bestTick` should be higher than max tick.