### PR TITLE
Feat/return update branch status

### DIFF
--- a/src/MgvHasOffers.sol
+++ b/src/MgvHasOffers.sol
@@ -69,7 +69,7 @@ contract MgvHasOffers is MgvCommon {
     MgvStructs.LocalPacked local,
     Tick bestTick,
     bool shouldUpdateBranch
-  ) internal returns (MgvStructs.LocalPacked) {
+  ) internal returns (MgvStructs.LocalPacked, bool) {
     unchecked {
       Leaf leaf;
       uint prevId = offer.prev();
@@ -145,7 +145,7 @@ contract MgvHasOffers is MgvCommon {
               // FIXME: should I let log2 not revert, but just return 0 if x is 0?
               // Why am I setting tick to 0 before I return?
               if (local.level2().isEmpty()) {
-                return local;
+                return (local, shouldUpdateBranch); // shouldUpdateBranch always true here
               }
               // no need to check for level2.isEmpty(), if it's the case then shouldUpdateBranch is false, because the
               if (shouldUpdateBranch) {
@@ -168,7 +168,7 @@ contract MgvHasOffers is MgvCommon {
           local = local.tickPosInLeaf(leaf.firstOfferPosition());
         }
       }
-      return local;
+      return (local, shouldUpdateBranch);
     }
   }
 }

--- a/src/MgvOfferMaking.sol
+++ b/src/MgvOfferMaking.sol
@@ -164,7 +164,7 @@ contract MgvOfferMaking is MgvHasOffers {
       /* Here, we are about to un-live an offer, so we start by taking it out of the book by stitching together its previous and next offers. Note that unconditionally calling `stitchOffers` would break the book since it would connect offers that may have since moved. */
       if (offer.isLive()) {
         MgvStructs.LocalPacked oldLocal = local;
-        local = dislodgeOffer(offerList, olKey.tickScale, offer, local, local.bestTick(), true);
+        (local,) = dislodgeOffer(offerList, olKey.tickScale, offer, local, local.bestTick(), true);
         /* If calling `stitchOffers` has changed the current `best` offer, we update the storage. */
         if (!oldLocal.eq(local)) {
           offerList.local = local;
@@ -328,10 +328,9 @@ contract MgvOfferMaking is MgvHasOffers {
           // bool updateLocal = tick.strictlyBetter(ofp.local.bestTick().strictlyBetter(tick)
           bool shouldUpdateBranch = !insertionTick.strictlyBetter(ofp.local.bestTick());
 
-          ofp.local =
+          (ofp.local, shouldUpdateBranch) =
             dislodgeOffer(offerList, ofp.olKey.tickScale, ofp.oldOffer, ofp.local, cachedLocalTick, shouldUpdateBranch);
           // If !shouldUpdateBranch, then ofp.local.level0 and ofp.local.level1 reflect the removed tick's branch post-removal, so one cannot infer the tick by reading those fields. If shouldUpdateBranch, then the new tick must be inferred from the new info in local.
-          // FIXME check if shouldUpdateBranch was true but became false inside dislodgeOffer
           if (shouldUpdateBranch) {
             // force control flow through gas-saving path if retraction emptied the offer list
             if (ofp.local.level0().isEmpty()) {

--- a/src/MgvOfferMaking.sol
+++ b/src/MgvOfferMaking.sol
@@ -326,7 +326,7 @@ contract MgvOfferMaking is MgvHasOffers {
             - Otherwise yes because maybe current tick = insertion tick
           */
           // bool updateLocal = tick.strictlyBetter(ofp.local.bestTick().strictlyBetter(tick)
-          bool shouldUpdateBranch = !insertionTick.strictlyBetter(ofp.local.bestTick());
+          bool shouldUpdateBranch = !insertionTick.strictlyBetter(cachedLocalTick);
 
           (ofp.local, shouldUpdateBranch) =
             dislodgeOffer(offerList, ofp.olKey.tickScale, ofp.oldOffer, ofp.local, cachedLocalTick, shouldUpdateBranch);

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -418,7 +418,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
         require(mgvData != "mgv/tradeSuccess", "mgv/clean/offerDidNotFail");
 
         /* In the market order, we were able to avoid stitching back offers after every `execute` since we knew a continuous segment starting at best would be consumed. Here, we cannot do this optimisation since the offer may be anywhere in the book. So we stitch together offers immediately after `execute`. */
-        sor.local = dislodgeOffer(offerList, sor.olKey.tickScale, sor.offer, sor.local, sor.local.bestTick(), true);
+        (sor.local,) = dislodgeOffer(offerList, sor.olKey.tickScale, sor.offer, sor.local, sor.local.bestTick(), true);
 
         /* <a id="internalSnipes/liftReentrancy"></a> Now that the current snipe is over, we can lift the lock on the book. In the same operation we
         * lift the reentrancy lock, and


### PR DESCRIPTION
for consistency, check that the tree branch was actually updated before recomputing

also, opportunistically: use cached local tick in one more place