### PR TITLE
Feat/ol key inverse mapping

### DIFF
--- a/src/IMangrove.sol
+++ b/src/IMangrove.sol
@@ -120,9 +120,9 @@ interface IMangrove is HasMgvEvents {
 
   function best(OLKey memory olKey) external view returns (uint offerId);
 
-  // # Offer view functions
-
   function olKeys(bytes32 olKeyHash) external view returns (OLKey memory olKey);
+
+  // # Offer view functions
 
   function offers(OLKey memory olKey, uint offerId) external view returns (MgvStructs.OfferPacked offer);
 

--- a/src/IMangrove.sol
+++ b/src/IMangrove.sol
@@ -122,6 +122,8 @@ interface IMangrove is HasMgvEvents {
 
   // # Offer view functions
 
+  function olKeys(bytes32 olKeyHash) external view returns (OLKey memory olKey);
+
   function offers(OLKey memory olKey, uint offerId) external view returns (MgvStructs.OfferPacked offer);
 
   function offerDetails(OLKey memory olKey, uint offerId)

--- a/src/MgvCommon.sol
+++ b/src/MgvCommon.sol
@@ -59,6 +59,8 @@ contract MgvCommon is HasMgvEvents {
 
   /* `offerLists` maps offer list id to offer list. */
   mapping(bytes32 => OfferList) internal offerLists;
+  /* Reverse mapping to fetch parameters from olKey hash */
+  mapping(bytes32 => OLKey) internal _olKeys;
 
   /* # State variables */
   /* Makers provision their possible penalties in the `balanceOf` mapping.

--- a/src/MgvGovernable.sol
+++ b/src/MgvGovernable.sol
@@ -31,9 +31,13 @@ contract MgvGovernable is MgvCommon {
   function activate(OLKey memory olKey, uint fee, uint densityFixed, uint offer_gasbase) public {
     unchecked {
       authOnly();
-      OfferList storage offerList = offerLists[olKey.hash()];
+      bytes32 olKeyHash = olKey.hash();
+      // save hash->key mapping
+      _olKeys[olKeyHash] = olKey;
+      OfferList storage offerList = offerLists[olKeyHash];
+      // activate market
       offerList.local = offerList.local.active(true);
-      emit SetActive(olKey.hash(), true);
+      emit SetActive(olKey.hash(), olKey.outbound, olKey.inbound, olKey.tickScale, true);
       setFee(olKey, fee);
       setDensityFixed(olKey, densityFixed);
       setGasbase(olKey, offer_gasbase);
@@ -44,7 +48,7 @@ contract MgvGovernable is MgvCommon {
     authOnly();
     OfferList storage offerList = offerLists[olKey.hash()];
     offerList.local = offerList.local.active(false);
-    emit SetActive(olKey.hash(), false);
+    emit SetActive(olKey.hash(), olKey.outbound, olKey.inbound, olKey.tickScale, false);
   }
 
   /* ### `fee` */

--- a/src/MgvLib.sol
+++ b/src/MgvLib.sol
@@ -141,11 +141,13 @@ interface HasMgvEvents {
   /*  
   This event is emitted when an offerList is activated or deactivated. Meaning one half of a market is opened.
 
-  It emits the `olKeyHash` and the boolean `value`. By emitting this, an indexer will be able to keep track of what offerLists are active.
+  It emits the `olKeyHash` and the boolean `value`. By emitting this, an indexer will be able to keep track of what offerLists are active and what their hash is.
 
-  The `olKeyHash` is indexed, so that we can filter on it when doing RPC calls.
+  The `olKeyHash` and both token addresses are indexed, so that we can filter on it when doing RPC calls.
   */
-  event SetActive(bytes32 indexed olKeyHash, bool value);
+  event SetActive(
+    bytes32 indexed olKeyHash, address indexed outbound_tkn, address indexed inbound_tkn, uint tickScale, bool value
+  );
 
   /*
   This event is emitted when the fee of an offerList is changed.

--- a/src/MgvView.sol
+++ b/src/MgvView.sol
@@ -106,14 +106,14 @@ contract MgvView is MgvCommon {
     }
   }
 
-  // # Offer view functions
-
   /* Get the olKey that corresponds to a hash, only works for offerLists that have been activated > 0 times */
   function olKeys(bytes32 olKeyHash) external view returns (OLKey memory olKey) {
     unchecked {
       olKey = _olKeys[olKeyHash];
     }
   }
+
+  // # Offer view functions
 
   /* Get an offer in packed format */
   function offers(OLKey memory olKey, uint offerId) external view returns (MgvStructs.OfferPacked offer) {

--- a/src/MgvView.sol
+++ b/src/MgvView.sol
@@ -108,6 +108,13 @@ contract MgvView is MgvCommon {
 
   // # Offer view functions
 
+  /* Get the olKey that corresponds to a hash, only works for offerLists that have been activated > 0 times */
+  function olKeys(bytes32 olKeyHash) external view returns (OLKey memory olKey) {
+    unchecked {
+      olKey = _olKeys[olKeyHash];
+    }
+  }
+
   /* Get an offer in packed format */
   function offers(OLKey memory olKey, uint offerId) external view returns (MgvStructs.OfferPacked offer) {
     unchecked {


### PR DESCRIPTION
* Add a `_olKeys: olKeyHash -> olKey` mapping for markets that have been activated at least once
* Expand SetActive to add the contents of `olKey`
  * `SetActive(...,false)` for deactivation also contains the info. Otherwise suppose there is an event `SetInactive(hash)` with no other info. An indexer that wants to know the state of all offerLists that relate to a specific token would need to do 2 passes: 1) collect all markets ever activated, save their hashes, 2) list all `SetInactive` events with that hash. 
  
It will be later easy to add an inheriting contract `Layer2Mangrove` (or to just update Mangrove) so that it contains functions such as
  
```solidity
  function marketOrderByLogPriceForL2(bytes32 olKeyHash, ...) public returns (...) {
    return generalMarketOrder(_olKeys[olKeyHash], maxLogPrice, fillVolume, fillWants, msg.sender, maxGasreqForFailingOffers);
  }
```
