### PR TITLE
Save gas by not zeroing data structures

### DIFF
--- a/lib/Constants.sol
+++ b/lib/Constants.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.17;
 
+uint constant ONE = 1; // useful to name it for drawing attention sometimes
 uint constant ONES = type(uint).max;
 uint constant TOPBIT = 1 << 255;
+// can't write ~TOPBIT or ~uint(1 << 255) or constant cannot be referred to from assembly
+uint constant NOT_TOPBIT = 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
 
 // MIN_TICK and MAX_TICK should be inside the addressable range defined by the sizes of LEAF, LEVEL0, LEVEL1, LEVEL2
 int constant MIN_TICK = -524288;

--- a/lib/TickLib.sol
+++ b/lib/TickLib.sol
@@ -409,7 +409,7 @@ library FieldLib {
   // Will throw if field is empty
   function lastOnePosition(Field field) internal pure returns (uint) {
     // FIXME stop checking for 0 or integrate it into ctz function in assembly
-    require(!field.isEmpty() ,"field is 0");
+    require(!field.isEmpty(), "field is 0");
     return BitLib.fls(Field.unwrap(field));
   }
 

--- a/lib/TickLib.sol
+++ b/lib/TickLib.sol
@@ -292,6 +292,9 @@ library TickLib {
 
 // We use TOPBIT as the optimized in-storage value since 1 is a valid Field value
 library DirtyFieldLib {
+  DirtyField constant DIRTY_EMPTY = DirtyField.wrap(TOPBIT);
+  DirtyField constant CLEAN_EMPTY = DirtyField.wrap(0);
+
   // Return clean field with topbit set to 0
   function clean(DirtyField field) internal pure returns (Field) {
     unchecked {

--- a/lib/TickLib.sol
+++ b/lib/TickLib.sol
@@ -6,26 +6,68 @@ import {BitLib} from "mgv_lib/BitLib.sol";
 import {console2 as csf} from "forge-std/console2.sol";
 
 type Leaf is uint;
+type DirtyLeaf is uint;
 
 using LeafLib for Leaf global;
+using DirtyLeafLib for DirtyLeaf global;
 
 type Field is uint;
+type DirtyField is uint;
 
 using FieldLib for Field global;
+using DirtyFieldLib for DirtyField global;
 
 type Tick is int;
 
 using TickLib for Tick global;
 
+// Leafs are of the ford [id,id][id,id][id,id][id,id]
+// With the property that within a [id1,id2] pair, id1==0 iff id2==0
+// So 1 is not a valid leaf
+// We use that (for storage gas savings) yet the field is still considered empty
+// 1 is chosen as a special invalid leaf value to make dirty/clean more gas efficient
+library DirtyLeafLib {
+  // Return 0 if leaf is 1, leaf otherwise
+  function clean(DirtyLeaf leaf) internal pure returns (Leaf) {
+    unchecked {
+      assembly ("memory-safe") {
+        leaf := xor(eq(leaf,ONE),leaf)
+      }
+      return Leaf.wrap(DirtyLeaf.unwrap(leaf));
+    }
+  }
+  function isDirty(DirtyLeaf leaf) internal pure returns (bool) {
+    unchecked {
+      return DirtyLeaf.unwrap(leaf) == ONE;
+    }
+  }
+  function eq(DirtyLeaf leaf1, DirtyLeaf leaf2) internal pure returns (bool) {
+    unchecked {
+      return DirtyLeaf.unwrap(leaf1) == DirtyLeaf.unwrap(leaf2);
+    }
+  }
+}
+
 library LeafLib {
   Leaf constant EMPTY = Leaf.wrap(uint(0));
+
+  // Return 1 if leaf is 0, leaf otherwise
+  function dirty(Leaf leaf) internal pure returns (DirtyLeaf) {
+    unchecked {
+      assembly ("memory-safe") {
+        leaf := or(iszero(leaf),leaf)
+      }
+      return DirtyLeaf.wrap(Leaf.unwrap(leaf));
+    }
+  }
 
   function eq(Leaf leaf1, Leaf leaf2) internal pure returns (bool) {
     return Leaf.unwrap(leaf1) == Leaf.unwrap(leaf2);
   }
 
+  // Does not accept 1 as an empty value
   function isEmpty(Leaf leaf) internal pure returns (bool) {
-    return leaf.eq(EMPTY);
+    return Leaf.unwrap(leaf) == Leaf.unwrap(EMPTY);
   }
 
   function uint_of_bool(bool b) internal pure returns (uint u) {
@@ -86,7 +128,9 @@ library LeafLib {
     return uint(raw << (OFFER_BITS * ((index * 2) + 1)) >> (256 - OFFER_BITS));
   }
 
-  // TODO optimize with a hashmap
+  // TODO optimize with a hashmap, or:
+  // if > half: +=1; if += quarter: +=1, or:
+  // or nested if dichotomy
   function firstOfferPosition(Leaf leaf) internal pure returns (uint ret) {
     uint offerId = Leaf.unwrap(leaf) >> (OFFER_BITS * 7);
     if (offerId != 0) {
@@ -245,15 +289,52 @@ library TickLib {
 
 }
 
+
+// We use TOPBIT as the optimized in-storage value since 1 is a valid Field value
+library DirtyFieldLib {
+  // Return clean field with topbit set to 0
+  function clean(DirtyField field) internal pure returns (Field) {
+    unchecked {
+      assembly ("memory-safe") {
+        field := and(NOT_TOPBIT,field)
+      }
+      return Field.wrap(DirtyField.unwrap(field));
+    }
+  }
+  function isDirty(DirtyField field) internal pure returns (bool) {
+    unchecked {
+      return DirtyField.unwrap(field) & TOPBIT == TOPBIT;
+    }
+  }
+
+  function eq(DirtyField leaf1, DirtyField leaf2) internal pure returns (bool) {
+    unchecked {
+      return DirtyField.unwrap(leaf1) == DirtyField.unwrap(leaf2);
+    }
+  }
+}
+
 // In fields, positions are counted from the right
 library FieldLib {
   Field constant EMPTY = Field.wrap(uint(0));
+
+  // Return clean field with topbit set to 1
+  function dirty(Field field) internal pure returns (DirtyField) {
+    unchecked {
+      assembly ("memory-safe") {
+        field := or(TOPBIT,field)
+      }
+      return DirtyField.wrap(Field.unwrap(field));
+    }
+  }
+
   function eq(Field field1, Field field2) internal pure returns (bool) {
     return Field.unwrap(field1) == Field.unwrap(field2);
   }
 
+  // Does not accept TOPBIT as an empty value
   function isEmpty(Field field) internal pure returns (bool) {
-    return field.eq(EMPTY);
+    return Field.unwrap(field) == Field.unwrap(EMPTY);
   }
 
   // function unsetBitAtTick(Field field, Tick tick, uint level) internal pure returns (Field) {
@@ -313,19 +394,21 @@ library FieldLib {
     return Field.wrap(Field.unwrap(field) & mask);
   }
 
-  // Will throw with "field is 0" if field is empty
+  // Will throw if field is empty
   function firstOnePosition(Field field) internal pure returns (uint) {
     // FIXME stop checking for 0 or integrate it into ctz function in assembly
     require(!field.isEmpty(),"field is 0");
+    require(Field.unwrap(field) != TOPBIT,"field is optimized 0");
     unchecked {
       return BitLib.ctz(Field.unwrap(field));
     }
   }
 
-  // Will throw with "field is 0" if field is empty
+  // Will throw if field is empty
   function lastOnePosition(Field field) internal pure returns (uint) {
     // FIXME stop checking for 0 or integrate it into ctz function in assembly
-    require(!field.isEmpty(),"field is 0");
+    require(!field.isEmpty() ,"field is 0");
+    require(Field.unwrap(field) != TOPBIT,"field is optimized 0");
     return BitLib.fls(Field.unwrap(field));
   }
 

--- a/lib/TickLib.sol
+++ b/lib/TickLib.sol
@@ -401,7 +401,6 @@ library FieldLib {
   function firstOnePosition(Field field) internal pure returns (uint) {
     // FIXME stop checking for 0 or integrate it into ctz function in assembly
     require(!field.isEmpty(),"field is 0");
-    require(Field.unwrap(field) != TOPBIT,"field is optimized 0");
     unchecked {
       return BitLib.ctz(Field.unwrap(field));
     }
@@ -411,7 +410,6 @@ library FieldLib {
   function lastOnePosition(Field field) internal pure returns (uint) {
     // FIXME stop checking for 0 or integrate it into ctz function in assembly
     require(!field.isEmpty() ,"field is 0");
-    require(Field.unwrap(field) != TOPBIT,"field is optimized 0");
     return BitLib.fls(Field.unwrap(field));
   }
 

--- a/lib/preprocessed/ToString.post.sol
+++ b/lib/preprocessed/ToString.post.sol
@@ -86,6 +86,10 @@ function toString(Leaf leaf) pure returns (string memory ret) {
   }
 }
 
+function toString(DirtyLeaf leaf) pure returns (string memory ret) {
+  return string.concat("<dirty[",leaf.isDirty() ? "yes" : "no","]",toString(leaf.clean()),">");
+}
+
 function toString(Field field) pure returns (string memory res) {
   for (uint i = 0; i < 256; i++) {
     if (Field.unwrap(field) & (1 << i) > 0) {
@@ -94,6 +98,10 @@ function toString(Field field) pure returns (string memory res) {
     }
   }
   res = string.concat(bytes(res).length==0?unicode"【empty":res, unicode"】");
+}
+
+function toString(DirtyField field) pure returns (string memory ret) {
+  return string.concat("<dirty[",field.isDirty() ? "yes" : "no","]",toString(field.clean()),">");
 }
 
 function toString(OLKey memory olKey) pure returns (string memory res) {

--- a/preprocessing/ToString.pre.sol.ts
+++ b/preprocessing/ToString.pre.sol.ts
@@ -73,6 +73,10 @@ function toString(Leaf leaf) pure returns (string memory ret) {
   }
 }
 
+function toString(DirtyLeaf leaf) pure returns (string memory ret) {
+  return string.concat("<dirty[",leaf.isDirty() ? "yes" : "no","]",toString(leaf.clean()),">");
+}
+
 function toString(Field field) pure returns (string memory res) {
   for (uint i = 0; i < 256; i++) {
     if (Field.unwrap(field) & (1 << i) > 0) {
@@ -81,6 +85,10 @@ function toString(Field field) pure returns (string memory res) {
     }
   }
   res = string.concat(bytes(res).length==0?unicode"【empty":res, unicode"】");
+}
+
+function toString(DirtyField field) pure returns (string memory ret) {
+  return string.concat("<dirty[",field.isDirty() ? "yes" : "no","]",toString(field.clean()),">");
 }
 
 function toString(OLKey memory olKey) pure returns (string memory res) {

--- a/src/MgvCommon.sol
+++ b/src/MgvCommon.sol
@@ -20,7 +20,7 @@
 
 pragma solidity ^0.8.10;
 
-import {MgvStructs, Field, OLKey, HasMgvEvents, Density, IMgvMonitor, IERC20, Leaf} from "./MgvLib.sol";
+import {MgvStructs, DirtyField, OLKey, HasMgvEvents, Density, IMgvMonitor, IERC20, DirtyLeaf} from "./MgvLib.sol";
 
 /* `MgvRoot` contains state variables used everywhere in the operation of Mangrove and their related function. */
 contract MgvCommon is HasMgvEvents {
@@ -52,9 +52,9 @@ contract MgvCommon is HasMgvEvents {
   struct OfferList {
     MgvStructs.LocalPacked local;
     mapping(uint => OfferData) offerData;
-    mapping(int => Leaf) leafs;
-    mapping(int => Field) level0;
-    mapping(int => Field) level1;
+    mapping(int => DirtyLeaf) leafs;
+    mapping(int => DirtyField) level0;
+    mapping(int => DirtyField) level1;
   }
 
   /* `offerLists` maps offer list id to offer list. */

--- a/src/MgvHasOffers.sol
+++ b/src/MgvHasOffers.sol
@@ -12,7 +12,8 @@ import {
   LEVEL2_SIZE,
   LEVEL1_SIZE,
   LEVEL0_SIZE,
-  OLKey
+  OLKey,
+  DirtyFieldLib
 } from "./MgvLib.sol";
 import {MgvCommon} from "./MgvCommon.sol";
 
@@ -126,7 +127,9 @@ contract MgvHasOffers is MgvCommon {
           field = local.level0().flipBitAtLevel0(offerTick);
           local = local.level0(field);
           if (shouldUpdateBranch && field.isEmpty()) {
-            offerList.level0[index] = field.dirty();
+            if (!offerList.level0[index].eq(DirtyFieldLib.CLEAN_EMPTY)) {
+              offerList.level0[index] = DirtyFieldLib.DIRTY_EMPTY;
+            }
           }
         } else {
           // note: useless dirty/clean cycle here
@@ -139,7 +142,9 @@ contract MgvHasOffers is MgvCommon {
             field = local.level1().flipBitAtLevel1(offerTick);
             local = local.level1(field);
             if (shouldUpdateBranch && field.isEmpty()) {
-              offerList.level1[index] = field.dirty();
+              if (!offerList.level1[index].eq(DirtyFieldLib.CLEAN_EMPTY)) {
+                offerList.level1[index] = DirtyFieldLib.DIRTY_EMPTY;
+              }
             }
           } else {
             // note: useless dirty/clean cycle here

--- a/src/MgvOfferMaking.sol
+++ b/src/MgvOfferMaking.sol
@@ -340,7 +340,7 @@ contract MgvOfferMaking is MgvHasOffers {
       }
 
       // insertion
-      Leaf leaf = offerList.leafs[insertionTick.leafIndex()];
+      Leaf leaf = offerList.leafs[insertionTick.leafIndex()].clean();
       // if leaf was empty flip tick on at level0
       if (leaf.isEmpty()) {
         Field field;
@@ -348,21 +348,21 @@ contract MgvOfferMaking is MgvHasOffers {
         int currentIndex = cachedLocalTick.level0Index();
         // Get insertion level0
         if (insertionIndex != currentIndex) {
-          field = offerList.level0[insertionIndex];
+          field = offerList.level0[insertionIndex].clean();
         } else {
           field = ofp.local.level0();
         }
 
         // Save current level0
         if (insertionIndex < currentIndex) {
-          offerList.level0[currentIndex] = ofp.local.level0();
+          offerList.level0[currentIndex] = ofp.local.level0().dirty();
         }
 
         // Write insertion level0
         if (insertionIndex <= currentIndex) {
           ofp.local = ofp.local.level0(field.flipBitAtLevel0(insertionTick));
         } else {
-          offerList.level0[insertionIndex] = field.flipBitAtLevel0(insertionTick);
+          offerList.level0[insertionIndex] = field.flipBitAtLevel0(insertionTick).dirty();
         }
 
         if (field.isEmpty()) {
@@ -370,19 +370,19 @@ contract MgvOfferMaking is MgvHasOffers {
           currentIndex = cachedLocalTick.level1Index();
 
           if (insertionIndex != currentIndex) {
-            field = offerList.level1[insertionIndex];
+            field = offerList.level1[insertionIndex].clean();
           } else {
             field = ofp.local.level1();
           }
 
           if (insertionIndex < currentIndex) {
-            offerList.level1[currentIndex] = ofp.local.level1();
+            offerList.level1[currentIndex] = ofp.local.level1().dirty();
           }
 
           if (insertionIndex <= currentIndex) {
             ofp.local = ofp.local.level1(field.flipBitAtLevel1(insertionTick));
           } else {
-            offerList.level1[insertionIndex] = field.flipBitAtLevel1(insertionTick);
+            offerList.level1[insertionIndex] = field.flipBitAtLevel1(insertionTick).dirty();
           }
           // if level1 was empty, flip tick on at level2
           if (field.isEmpty()) {
@@ -404,7 +404,7 @@ contract MgvOfferMaking is MgvHasOffers {
 
       // store offer at the end of the tick
       leaf = leaf.setTickLast(insertionTick, ofrId);
-      offerList.leafs[insertionTick.leafIndex()] = leaf;
+      offerList.leafs[insertionTick.leafIndex()] = leaf.dirty();
 
       /* With the `prev`/`next` in hand, we finally store the offer in the `offers` map. */
       MgvStructs.OfferPacked ofr =

--- a/src/MgvOfferMaking.sol
+++ b/src/MgvOfferMaking.sol
@@ -259,8 +259,8 @@ contract MgvOfferMaking is MgvHasOffers {
       emit OfferWrite(ofp.olKey.hash(), msg.sender, insertionLogPrice, ofp.gives, ofp.gasprice, ofp.gasreq, ofrId);
 
       /* We now write the new `offerDetails` and remember the previous provision (0 by default, for new offers) to balance out maker's `balanceOf`. */
-      uint oldProvision;
       {
+        uint oldProvision;
         OfferData storage offerData = offerList.offerData[ofrId];
         MgvStructs.OfferDetailPacked offerDetail = offerData.detail;
         if (update) {
@@ -282,10 +282,8 @@ contract MgvOfferMaking is MgvHasOffers {
             __gasprice: ofp.gasprice
           });
         }
-      }
 
-      /* With every change to an offer, a maker may deduct provisions from its `balanceOf` balance. It may also get provisions back if the updated offer requires fewer provisions than before. */
-      {
+        /* With every change to an offer, a maker may deduct provisions from its `balanceOf` balance. It may also get provisions back if the updated offer requires fewer provisions than before. */
         uint provision = (ofp.gasreq + ofp.local.offer_gasbase()) * ofp.gasprice * 10 ** 9;
         if (provision > oldProvision) {
           debitWei(msg.sender, provision - oldProvision);
@@ -355,7 +353,14 @@ contract MgvOfferMaking is MgvHasOffers {
 
         // Save current level0
         if (insertionIndex < currentIndex) {
-          offerList.level0[currentIndex] = ofp.local.level0().dirty();
+          Field localLeve0 = ofp.local.level0();
+          bool shouldSaveLevel0 = !localLeve0.isEmpty();
+          if (!shouldSaveLevel0) {
+            shouldSaveLevel0 = !offerList.level0[currentIndex].eq(DirtyFieldLib.CLEAN_EMPTY);
+          }
+          if (shouldSaveLevel0) {
+            offerList.level0[currentIndex] = localLeve0.dirty();
+          }
         }
 
         // Write insertion level0
@@ -376,7 +381,14 @@ contract MgvOfferMaking is MgvHasOffers {
           }
 
           if (insertionIndex < currentIndex) {
-            offerList.level1[currentIndex] = ofp.local.level1().dirty();
+            Field localLevel1 = ofp.local.level1();
+            bool shouldSaveLevel1 = !localLevel1.isEmpty();
+            if (!shouldSaveLevel1) {
+              shouldSaveLevel1 = !offerList.level1[currentIndex].eq(DirtyFieldLib.CLEAN_EMPTY);
+            }
+            if (shouldSaveLevel1) {
+              offerList.level1[currentIndex] = localLevel1.dirty();
+            }
           }
 
           if (insertionIndex <= currentIndex) {

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -108,7 +108,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
           field = local.level1().flipBitAtLevel1(offerTick);
           if (field.isEmpty()) {
             if (!offerList.level1[index].eq(DirtyFieldLib.CLEAN_EMPTY)) {
-              offerList.level1[index] = DirtyFieldLib.CLEAN_EMPTY;
+              offerList.level1[index] = DirtyFieldLib.DIRTY_EMPTY;
             }
             field = local.level2().flipBitAtLevel2(offerTick);
             local = local.level2(field);

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -13,6 +13,7 @@ import {
   LeafLib,
   FieldLib,
   DirtyField,
+  DirtyFieldLib,
   DirtyLeaf,
   LogPriceLib,
   OLKey
@@ -100,11 +101,15 @@ abstract contract MgvOfferTaking is MgvHasOffers {
         int index = offerTick.level0Index();
         Field field = local.level0().flipBitAtLevel0(offerTick);
         if (field.isEmpty()) {
-          offerList.level0[index] = field.dirty();
+          if (!offerList.level0[index].eq(DirtyFieldLib.CLEAN_EMPTY)) {
+            offerList.level0[index] = DirtyFieldLib.DIRTY_EMPTY;
+          }
           index = offerTick.level1Index();
           field = local.level1().flipBitAtLevel1(offerTick);
           if (field.isEmpty()) {
-            offerList.level1[index] = field.dirty();
+            if (!offerList.level1[index].eq(DirtyFieldLib.CLEAN_EMPTY)) {
+              offerList.level1[index] = DirtyFieldLib.CLEAN_EMPTY;
+            }
             field = local.level2().flipBitAtLevel2(offerTick);
             local = local.level2(field);
             if (field.isEmpty()) {

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -12,6 +12,8 @@ import {
   Tick,
   LeafLib,
   FieldLib,
+  DirtyField,
+  DirtyLeaf,
   LogPriceLib,
   OLKey
 } from "./MgvLib.sol";
@@ -94,15 +96,15 @@ abstract contract MgvOfferTaking is MgvHasOffers {
       Leaf leaf = mor.leaf;
       leaf = leaf.setTickFirst(offerTick, 0).setTickLast(offerTick, 0);
       if (leaf.isEmpty()) {
-        offerList.leafs[offerTick.leafIndex()] = leaf;
+        offerList.leafs[offerTick.leafIndex()] = leaf.dirty();
         int index = offerTick.level0Index();
         Field field = local.level0().flipBitAtLevel0(offerTick);
         if (field.isEmpty()) {
-          offerList.level0[index] = field;
+          offerList.level0[index] = field.dirty();
           index = offerTick.level1Index();
           field = local.level1().flipBitAtLevel1(offerTick);
           if (field.isEmpty()) {
-            offerList.level1[index] = field;
+            offerList.level1[index] = field.dirty();
             field = local.level2().flipBitAtLevel2(offerTick);
             local = local.level2(field);
             if (field.isEmpty()) {
@@ -112,14 +114,16 @@ abstract contract MgvOfferTaking is MgvHasOffers {
               return (0, local);
             }
             index = field.firstLevel1Index();
-            field = offerList.level1[index];
+            // Top bit cleaning will be done by level1(field) + field cannot be empty
+            field = Field.wrap(DirtyField.unwrap(offerList.level1[index]));
           }
           local = local.level1(field);
           index = field.firstLevel0Index(index);
-          field = offerList.level0[index];
+          // Top bit cleaning will be done by level0(field) + field cannot be empty
+          field = Field.wrap(DirtyField.unwrap(offerList.level0[index]));
         }
         local = local.level0(field);
-        leaf = offerList.leafs[field.firstLeafIndex(index)];
+        leaf = offerList.leafs[field.firstLeafIndex(index)].clean();
       }
       mor.leaf = leaf;
       nextId = leaf.getNextOfferId();
@@ -162,7 +166,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
       /* Throughout the execution of the market order, the `sor`'s offer id and other parameters will change. We start with the current best offer id (0 if the book is empty). */
 
-      mor.leaf = offerList.leafs[sor.local.bestTick().leafIndex()];
+      mor.leaf = offerList.leafs[sor.local.bestTick().leafIndex()].clean();
       sor.offerId = mor.leaf.getNextOfferId();
       sor.offer = offerList.offerData[sor.offerId].offer;
       /* fillVolume evolves but is initially however much remains in the market order. */
@@ -277,24 +281,29 @@ abstract contract MgvOfferTaking is MgvHasOffers {
         // update leaf if necessary
         MgvStructs.OfferPacked offer = sor.offer;
         Tick tick = offer.tick(sor.olKey.tickScale);
-        if (offer.prev() != 0) {
-          offerList.offerData[sor.offerId].offer = sor.offer.prev(0);
-          mor.leaf = mor.leaf.setTickFirst(tick, sor.offerId);
-        }
 
-        // maybe some updates below are useless? if we don't update these we must take it into account elsewhere
-        // no need to test whether level2 has been reached since by default its stored in local
+        // Don't uselessly write empty leaf of tick 0
+        if (sor.offerId != 0) {
+          // Note: important to not update offer.prev before now or this test will fail spuriously
+          if (offer.prev() != 0) {
+            offerList.offerData[sor.offerId].offer = sor.offer.prev(0);
+            mor.leaf = mor.leaf.setTickFirst(tick, sor.offerId);
+          }
 
-        sor.local = sor.local.tickPosInLeaf(mor.leaf.firstOfferPosition());
-        // no need to test whether mor.level2 != offerList.level2 since update is ~free
-        // ! local.level0[sor.local.bestTick().level0Index()] is now wrong
-        // sor.local = sor.local.level0(mor.level0);
+          // no need to test whether level2 has been reached since by default its stored in local
 
-        int index = tick.leafIndex();
-        // leaf cached in memory is flushed to storage everytime it gets emptied, but at the end of a market order we need to store it correctly
-        // second conjunct is for when you did not ever read leaf
-        if (!offerList.leafs[index].eq(mor.leaf)) {
-          offerList.leafs[index] = mor.leaf;
+          sor.local = sor.local.tickPosInLeaf(mor.leaf.firstOfferPosition());
+          // no need to test whether mor.level2 != offerList.level2 since update is ~free
+          // ! local.level0[sor.local.bestTick().level0Index()] is now wrong
+          // sor.local = sor.local.level0(mor.level0);
+
+          int index = tick.leafIndex();
+          // leaf cached in memory is flushed to storage everytime it gets emptied, but at the end of a market order we need to store it correctly
+          // second conjunct is for when you did not ever read leaf
+          // If uselessly written, it's a hot write anyway
+          // Reading to check useless write would have same cost
+          // Caching info on staleness of mor.leaf is doable but makes code too complex
+          offerList.leafs[index] = mor.leaf.dirty();
         }
 
         /* <a id="internalMarketOrder/liftReentrancy"></a>Now that the market order is over, we can lift the lock on the book. In the same operation we

--- a/src/MgvView.sol
+++ b/src/MgvView.sol
@@ -46,7 +46,7 @@ contract MgvView is MgvCommon {
     unchecked {
       OfferList storage offerList = offerLists[olKey.hash()];
       unlockedMarketOnly(offerList.local);
-      return offerList.leafs[index];
+      return offerList.leafs[index].clean();
     }
   }
 
@@ -59,7 +59,7 @@ contract MgvView is MgvCommon {
       if (_local.bestTick().level0Index() == index) {
         return _local.level0();
       } else {
-        return offerList.level0[index];
+        return offerList.level0[index].clean();
       }
     }
   }
@@ -73,7 +73,7 @@ contract MgvView is MgvCommon {
       if (_local.bestTick().level1Index() == index) {
         return _local.level1();
       } else {
-        return offerList.level1[index];
+        return offerList.level1[index].clean();
       }
     }
   }
@@ -102,7 +102,7 @@ contract MgvView is MgvCommon {
       OfferList storage offerList = offerLists[olKey.hash()];
       MgvStructs.LocalPacked _local = offerList.local;
       unlockedMarketOnly(_local);
-      return offerList.leafs[_local.bestTick().leafIndex()].getNextOfferId();
+      return offerList.leafs[_local.bestTick().leafIndex()].clean().getNextOfferId();
     }
   }
 

--- a/test/core/Gatekeeping.t.sol
+++ b/test/core/Gatekeeping.t.sol
@@ -484,7 +484,7 @@ contract GatekeepingTest is MangroveTest {
     uint other_ofr = mkr.newOfferByVolume(lo, 1 ether, 1 ether, 90_000);
     mkr.setTradeCallback($(this), abi.encodeCall(this.retractOfferOK, (lo, other_ofr)));
 
-    uint ofr = mkr.newOfferByVolume(olKey, 1 ether, 1 ether, 90_000);
+    uint ofr = mkr.newOfferByVolume(olKey, 1 ether, 1 ether, 110_000);
     assertTrue(tkr.marketOrderWithSuccess(1 ether), "market order must succeed or test is void");
     assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertTrue(mgv.best(lo) == 0, "retractOffer on swapped offerList must work");

--- a/test/core/Leaf.t.sol
+++ b/test/core/Leaf.t.sol
@@ -88,6 +88,74 @@ contract LeafTest is Test2 {
     checkFirstOffer(leaf, 2);
   }
 
+  /* Leaf dirty/clean */
+
+  function test_clean_leaf_idempotent(DirtyLeaf leaf) public {
+    Leaf cleaned = leaf.clean();
+    assertTrue(cleaned.eq(DirtyLeaf.wrap(Leaf.unwrap(cleaned)).clean()));
+  }
+
+  function test_dirty_leaf_idempotent(Leaf leaf) public {
+    DirtyLeaf dirtied = leaf.dirty();
+    assertTrue(dirtied.eq(Leaf.wrap(DirtyLeaf.unwrap(dirtied)).dirty()));
+  }
+
+  function test_dirty_clean_inverse(DirtyLeaf leaf) public {
+    vm.assume(DirtyLeaf.unwrap(leaf) != 0);
+    DirtyLeaf inv = leaf.clean().dirty();
+    assertTrue(inv.eq(leaf));
+  }
+
+  function test_dirty_invariant_under_clean(uint leaf) public {
+    DirtyLeaf under = DirtyLeaf.wrap(leaf).clean().dirty();
+    assertTrue(under.eq(Leaf.wrap(leaf).dirty()));
+  }
+
+  function test_clean_dirty_inverse(Leaf leaf) public {
+    vm.assume(Leaf.unwrap(leaf) != 1);
+    Leaf inv = leaf.dirty().clean();
+    assertTrue(inv.eq(leaf));
+  }
+
+  function test_clean_invariant_under_dirty(uint leaf) public {
+    Leaf under = Leaf.wrap(leaf).dirty().clean();
+    assertTrue(under.eq(DirtyLeaf.wrap(leaf).clean()));
+  }
+
+  function test_clean_leaf_on_0() public {
+    uint uleaf = Leaf.unwrap(DirtyLeaf.wrap(0).clean());
+    assertEq(uleaf, 0);
+  }
+
+  function test_clean_leaf_on_1() public {
+    uint uleaf = Leaf.unwrap(DirtyLeaf.wrap(1).clean());
+    assertEq(uleaf, 0);
+  }
+
+  function test_clean_leaf_fuzz(uint leaf) public {
+    vm.assume(leaf != 1);
+    assertEq(Leaf.unwrap(DirtyLeaf.wrap(leaf).clean()), leaf);
+  }
+
+  function test_dirty_leaf_on_0() public {
+    uint uleaf = DirtyLeaf.unwrap(Leaf.wrap(0).dirty());
+    assertEq(uleaf, 1);
+  }
+
+  function test_dirty_leaf_on_1() public {
+    uint uleaf = DirtyLeaf.unwrap(Leaf.wrap(1).dirty());
+    assertEq(uleaf, 1);
+  }
+
+  function test_dirty_leaf_fuzz(uint leaf) public {
+    vm.assume(leaf != 0);
+    assertEq(DirtyLeaf.unwrap(Leaf.wrap(leaf).dirty()), leaf);
+  }
+
+  function leaf_isDirty(DirtyLeaf leaf) public {
+    assertEq(leaf.isDirty(), DirtyLeaf.unwrap(leaf) == ONE);
+  }
+
   // HELPER FUNCTIONS
   function checkFirstOffer(Leaf leaf, uint id) internal {
     assertEq(leaf.getNextOfferId(), id, toString(leaf));
@@ -297,5 +365,87 @@ contract FieldTest is Test {
     // should not revert
     (uint man,) = LogPriceConversionLib.priceFromVolumes(inbound, outbound);
     assertTrue(man != 0, "mantissa cannot be 0");
+  }
+
+  // Make sure no field is so big that the empty marker (top bit) would corrupt data
+  // Must be updated manually if new field sizes appear
+  function test_field_sizes() public {
+    assertLt(LEVEL0_SIZE, 256, "level0 too big");
+    assertLt(LEVEL1_SIZE, 256, "level1 too big");
+    assertLt(LEVEL2_SIZE, 256, "level2 too big");
+  }
+
+  // Since "Only direct number constants and references to such constants are supported by inline assembly", NOT_TOPBIT is not defined in terms of TOPBIT. Here we check that its definition is correct.
+  function test_not_topbit_is_negation_of_topbit() public {
+    assertEq(TOPBIT, ~NOT_TOPBIT, "TOPBIT != ~NOT_TOPBIT");
+  }
+
+  /* Field dirty/clean */
+
+  function test_clean_field_idempotent(DirtyField field) public {
+    Field cleaned = field.clean();
+    assertTrue(cleaned.eq(DirtyField.wrap(Field.unwrap(cleaned)).clean()));
+  }
+
+  function test_dirty_field_idempotent(Field field) public {
+    // field = Field.wrap(Field.unwrap(field)& NOT_TOPBIT);
+    DirtyField dirtied = field.dirty();
+    assertTrue(dirtied.eq(Field.wrap(DirtyField.unwrap(dirtied)).dirty()));
+  }
+
+  function test_dirty_clean_inverse(uint field) public {
+    vm.assume(DirtyField.wrap(field).isDirty());
+    DirtyField inv = DirtyField.wrap(field).clean().dirty();
+    assertTrue(inv.eq(DirtyField.wrap(field)));
+  }
+
+  function test_dirty_invariant_under_clean(uint field) public {
+    DirtyField under = DirtyField.wrap(field).clean().dirty();
+    assertTrue(under.eq(Field.wrap(field).dirty()));
+  }
+
+  function test_clean_dirty_inverse(uint field) public {
+    vm.assume(!DirtyField.wrap(field).isDirty());
+    Field inv = Field.wrap(field).dirty().clean();
+    assertTrue(inv.eq(Field.wrap(field)));
+  }
+
+  function test_clean_invariant_under_dirty(uint field) public {
+    Field under = Field.wrap(field).dirty().clean();
+    assertTrue(under.eq(DirtyField.wrap(field).clean()));
+  }
+
+  function test_clean_field_on_0() public {
+    uint ufield = Field.unwrap(DirtyField.wrap(0).clean());
+    assertEq(ufield, 0);
+  }
+
+  function test_clean_field_on_topbit() public {
+    uint ufield = Field.unwrap(DirtyField.wrap(TOPBIT).clean());
+    assertEq(ufield, 0);
+  }
+
+  function test_clean_field_fuzz(uint field) public {
+    vm.assume(!DirtyField.wrap(field).isDirty());
+    assertEq(Field.unwrap(DirtyField.wrap(field).clean()), field);
+  }
+
+  function test_dirty_field_on_0() public {
+    uint ufield = DirtyField.unwrap(Field.wrap(0).dirty());
+    assertEq(ufield, TOPBIT);
+  }
+
+  function test_dirty_field_on_topbit() public {
+    uint ufield = DirtyField.unwrap(Field.wrap(TOPBIT).dirty());
+    assertEq(ufield, TOPBIT);
+  }
+
+  function test_dirty_field_fuzz(uint field) public {
+    vm.assume(DirtyField.wrap(field).isDirty());
+    assertEq(DirtyField.unwrap(Field.wrap(field).dirty()), field);
+  }
+
+  function field_isDirty(DirtyField field) public {
+    assertEq(field.isDirty(), DirtyField.unwrap(field) & TOPBIT == TOPBIT);
   }
 }

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -786,7 +786,7 @@ contract TakerOperationsTest is MangroveTest {
     int logPrice = mgv.offers(olKey, ofr).logPrice();
 
     vm.expectRevert("mgv/notEnoughGasForMakerPosthook");
-    mgv.marketOrderByLogPrice{gas: 280_000}(olKey, logPrice, 1 ether, true);
+    mgv.marketOrderByLogPrice{gas: 291_000}(olKey, logPrice, 1 ether, true);
   }
 
   // FIXME Make a token that goes out of gas on transfer to taker


### PR DESCRIPTION
Close #522.

**For the reviewer** The first commit d9509afe196a8fbdad1e03735ffd0a180c26e190 restructures `dislodgeOffer` to save stack space. The second commit d45bc97d9dcfbc7600bbd1836cd3fe4a9c1ebda0 is thus easier to read than the full diff.

# How it works

* Whenever a value `v:Field` is written to a mapping, its top bit is set to 1.
* Whenever a value `v:Leaf` is written to a mapping, if `v==0` then 1 is written. 1 is not a valid leaf value.

Fields with top bit at 1 or leafs equal to 1 are "dirty". 

The type system prevents dealing with dirty values.

**There are additional gas costs in some cases; is it worth it anyway?**

# Some gas costs increase

_(Example with Fields but a similar scenario occurs with Leaves)_

The top bit of `Field` values in mappings (level0, level 1) is set to 1 whenever 

Some gas tests are showing extra costs of ~40k gas (classic/200 runs). This increase is due to the following scenario:

Step 1: A never-before-used level0/1 equal to 0 is cached in `local` when it receives an offer (the current best)
Step 2: That level0 or level1 becomes empty and is evicted from `local` and flushed to storage

This happens when a level0/11 become empty during a market order or a clean.
This includes the case of the entire book becoming empty and the last level0 and level1 are flushed (as empty levels) to storage.

Without this PR, the scenario above would be much cheaper. But by definition it can occur at most one per level0/1. 

Without this PR, however, the following scenario can repeat indefinitely:

Step 1: An _empty_ level0/1 equal to 0 is cached in `local` when it receives an offer `o1` (the current best)
Step 2: Another level0/1 receives an even better offer `o2`. The level0/1 mentioned in Step 1. is flushed to storage (~20k gas)
Step 3: A market order consumes both `o1` and `o2`. The level0/1 mentioned in Step 1 is _empty_ and written to storage.