### PR TITLE
POC: tick shift

### DIFF
--- a/lib/LogPriceLib.sol
+++ b/lib/LogPriceLib.sol
@@ -12,8 +12,8 @@ library LogPriceLib {
   }
   // 
   // FIXME ensure that you only called tick*tickScale if you previously stored the tick as a result of logPrice/tickScale. Otherwise you may go beyond the MAX/MIN.
-  function fromTick(Tick tick, uint tickScale) internal pure returns (int) {
-    return Tick.unwrap(tick) * int(tickScale);
+  function fromTick(Tick tick, uint tickScale, int tickShift) internal pure returns (int) {
+    return (Tick.unwrap(tick) + tickShift) * int(tickScale);
   }
 
   // tick underestimates the price, so we underestimate  inbound here, i.e. the inbound/outbound price will again be underestimated

--- a/lib/TickLib.sol
+++ b/lib/TickLib.sol
@@ -137,10 +137,10 @@ library TickLib {
     return Tick.unwrap(tick) >= MIN_TICK && Tick.unwrap(tick) <= MAX_TICK;
   }
 
-  function fromLogPrice(int logPrice, uint tickScale) internal pure returns (Tick) {
+  function fromLogPrice(int logPrice, uint tickScale, int tickShift) internal pure returns (Tick) {
     // Do not force logPrices to fit the tickScale (aka logPrice%tickScale==0)
     // Round all prices down (aka cheaper for taker)
-    int tick = logPrice / int(tickScale);
+    int tick = logPrice / int(tickScale) - tickShift;
     if (logPrice < 0 && logPrice % int(tickScale) != 0) {
       tick = tick - 1;
     }

--- a/lib/preprocessed/ToString.post.sol
+++ b/lib/preprocessed/ToString.post.sol
@@ -62,10 +62,10 @@ function tickBranchToString(Tick tick) pure returns (string memory) {
 
 function toString(Tick tick) pure returns (string memory ret) {
   string memory suffix;
-  if (MIN_TICK > Tick.unwrap(tick) || Tick.unwrap(tick) > MAX_TICK) {
-    suffix = "out of range";
+  if (tick.inRange()) {
+    suffix = logPriceToString(LogPriceLib.fromTick(tick,1,0));
   } else {
-    suffix = logPriceToString(LogPriceLib.fromTick(tick,1));
+    suffix = "out of range";
   }
 
   ret = string.concat(unicode"「", vm.toString(Tick.unwrap(tick))," (default: " ,suffix, ") {tree branch: ", tickBranchToString(tick), "}", unicode"」");

--- a/preprocessing/ToString.pre.sol.ts
+++ b/preprocessing/ToString.pre.sol.ts
@@ -49,10 +49,10 @@ function tickBranchToString(Tick tick) pure returns (string memory) {
 
 function toString(Tick tick) pure returns (string memory ret) {
   string memory suffix;
-  if (MIN_TICK > Tick.unwrap(tick) || Tick.unwrap(tick) > MAX_TICK) {
-    suffix = "out of range";
+  if (tick.inRange()) {
+    suffix = logPriceToString(LogPriceLib.fromTick(tick,1,0));
   } else {
-    suffix = logPriceToString(LogPriceLib.fromTick(tick,1));
+    suffix = "out of range";
   }
 
   ret = string.concat(unicode"「", vm.toString(Tick.unwrap(tick))," (default: " ,suffix, ") {tree branch: ", tickBranchToString(tick), "}", unicode"」");

--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -133,8 +133,8 @@ library OfferPackedExtra {
       resp := iszero(iszero(gives))
     }
   }
-  function tick(OfferPacked offer, uint tickScale) internal pure returns (Tick) {
-    return TickLib.fromLogPrice(offer.logPrice(),tickScale);
+  function tick(OfferPacked offer, uint tickScale, int tickShift) internal pure returns (Tick) {
+    return TickLib.fromLogPrice(offer.logPrice(), tickScale, tickShift);
   }
   function clearFieldsForMaker(OfferPacked offer) internal pure returns (OfferPacked) {
     unchecked {
@@ -157,8 +157,8 @@ library OfferUnpackedExtra {
       resp := iszero(iszero(gives))
     }
   }
-  function tick(OfferUnpacked memory offer, uint tickScale) internal pure returns (Tick) {
-    return TickLib.fromLogPrice(offer.logPrice,tickScale);
+  function tick(OfferUnpacked memory offer, uint tickScale, int tickShift) internal pure returns (Tick) {
+    return TickLib.fromLogPrice(offer.logPrice, tickScale, tickShift);
   }
 
 }

--- a/script/core/ActivateMarket.s.sol
+++ b/script/core/ActivateMarket.s.sol
@@ -22,7 +22,12 @@ contract ActivateMarket is Deployer {
     innerRun({
       mgv: IMangrove(envAddressOrName("MGV", "Mangrove")),
       reader: MgvReader(envAddressOrName("MGV_READER", "MgvReader")),
-      market: Market({tkn0: envAddressOrName("TKN1"), tkn1: envAddressOrName("TKN2"), tickScale: vm.envUint("TICK_SCALE")}),
+      market: Market({
+        tkn0: envAddressOrName("TKN1"),
+        tkn1: envAddressOrName("TKN2"),
+        tickScale: vm.envUint("TICK_SCALE"),
+        tickShift: vm.envInt("TICK_SHIFT")
+      }),
       tkn1_in_gwei: vm.envUint("TKN1_IN_GWEI"),
       tkn2_in_gwei: vm.envUint("TKN2_IN_GWEI"),
       fee: vm.envUint("FEE")

--- a/script/core/ActivateSemibook.s.sol
+++ b/script/core/ActivateSemibook.s.sol
@@ -28,7 +28,8 @@ contract ActivateSemibook is Test2, Deployer {
       olKey: OLKey({
         outbound: envAddressOrName("OUTBOUND_TKN"),
         inbound: envAddressOrName("INBOUND_TKN"),
-        tickScale: vm.envUint("TICK_SCALE")
+        tickScale: vm.envUint("TICK_SCALE"),
+        tickShift: vm.envInt("TICK_SHIFT")
       }),
       outbound_in_gwei: vm.envUint("OUTBOUND_IN_GWEI"),
       fee: vm.envUint("FEE")

--- a/script/core/DeactivateMarket.s.sol
+++ b/script/core/DeactivateMarket.s.sol
@@ -14,7 +14,12 @@ contract DeactivateMarket is Deployer {
     innerRun({
       mgv: IMangrove(envAddressOrName("MGV", "Mangrove")),
       reader: MgvReader(envAddressOrName("MGV_READER", "MgvReader")),
-      market: Market({tkn0: envAddressOrName("TKN0"), tkn1: envAddressOrName("TKN1"), tickScale: vm.envUint("TICK_SCALE")})
+      market: Market({
+        tkn0: envAddressOrName("TKN0"),
+        tkn1: envAddressOrName("TKN1"),
+        tickScale: vm.envUint("TICK_SCALE"),
+        tickShift: vm.envInt("TICK_SHIFT")
+      })
     });
     outputDeployment();
   }

--- a/script/core/monitors/EvalSnipeOffer.s.sol
+++ b/script/core/monitors/EvalSnipeOffer.s.sol
@@ -21,7 +21,9 @@ contract EvalSnipeOffer is Test2, Deployer {
   function run() public {
     innerRun({
       mgv: IMangrove(envAddressOrName("MGV", "Mangrove")),
-      olKey: OLKey(envAddressOrName("TKN_OUT"), envAddressOrName("TKN_IN"), vm.envUint("TICK_SCALE")),
+      olKey: OLKey(
+        envAddressOrName("TKN_OUT"), envAddressOrName("TKN_IN"), vm.envUint("TICK_SCALE"), vm.envInt("TICK_SHIFT")
+        ),
       offerId: vm.envUint("OFFER_ID")
     });
   }

--- a/script/core/monitors/MarketHealth.s.sol
+++ b/script/core/monitors/MarketHealth.s.sol
@@ -60,7 +60,7 @@ contract MarketHealth is Test2, Deployer {
     innerRun({
       mgv: IMangrove(envAddressOrName("MGV", "Mangrove")),
       reader: MgvReader(envAddressOrName("MGV_READER", "MgvReader")),
-      olKey: OLKey(envAddressOrName("TKN_OUT"), address(inbTkn), vm.envUint("TICK_SCALE")),
+      olKey: OLKey(envAddressOrName("TKN_OUT"), address(inbTkn), vm.envUint("TICK_SCALE"), vm.envInt("TICK_SHIFT")),
       outboundTknVolume: vm.envUint("VOLUME"),
       densityOverrides: densityOverrides
     });

--- a/script/periphery/UpdateMarket.s.sol
+++ b/script/periphery/UpdateMarket.s.sol
@@ -17,18 +17,16 @@ contract UpdateMarket is Deployer {
   function run() public {
     innerRun({
       reader: MgvReader(envAddressOrName("MGV_READER", "MgvReader")),
-      market: Market(envAddressOrName("TKN0"), envAddressOrName("TKN1"), vm.envUint("TICK_SCALE"))
+      market: Market(
+        envAddressOrName("TKN0"), envAddressOrName("TKN1"), vm.envUint("TICK_SCALE"), vm.envInt("TICK_SHIFT")
+        )
     });
     outputDeployment();
   }
 
   function innerRun(MgvReader reader, Market memory market) public {
-    console.log(
-      "Updating Market on MgvReader.  tkn0: %s, tkn1: %s",
-      vm.toString(market.tkn0),
-      vm.toString(market.tkn1),
-      vm.toString(market.tickScale)
-    );
+    console.log("Updating Market on MgvReader.  tkn0: %s, tkn1: %s", vm.toString(market.tkn0), vm.toString(market.tkn1));
+    console.log("    tick scale: %s, tick shift: %s", vm.toString(market.tickScale), vm.toString(market.tickShift));
     logReaderState("[before script]", reader, market);
 
     broadcast();

--- a/src/MgvGovernable.sol
+++ b/src/MgvGovernable.sol
@@ -29,6 +29,7 @@ contract MgvGovernable is MgvCommon {
   /* ## Locals */
   /* ### `active` */
   function activate(OLKey memory olKey, uint fee, uint densityFixed, uint offer_gasbase) public {
+    // FIXME: Validate that tick shift is within the supported range? logPrice range vs tick range
     unchecked {
       authOnly();
       bytes32 olKeyHash = olKey.hash();

--- a/src/MgvHasOffers.sol
+++ b/src/MgvHasOffers.sol
@@ -64,7 +64,7 @@ contract MgvHasOffers is MgvCommon {
   // shouldUpdateBest is true if we may want to update best, false if there is no way we want to update it (eg if we know we are about to reinsert the offer anyway and will update best then?)
   function dislodgeOffer(
     OfferList storage offerList,
-    uint tickScale,
+    Tick offerTick,
     MgvStructs.OfferPacked offer,
     MgvStructs.LocalPacked local,
     Tick bestTick,
@@ -74,7 +74,6 @@ contract MgvHasOffers is MgvCommon {
       Leaf leaf;
       uint prevId = offer.prev();
       uint nextId = offer.next();
-      Tick offerTick = offer.tick(tickScale);
       if (prevId == 0 || nextId == 0) {
         leaf = offerList.leafs[offerTick.leafIndex()];
       }

--- a/src/MgvLib.sol
+++ b/src/MgvLib.sol
@@ -18,6 +18,7 @@ struct OLKey {
   address outbound;
   address inbound;
   uint tickScale;
+  int tickShift;
 }
 
 library OLLib {
@@ -26,13 +27,13 @@ library OLLib {
   // If the memory layout changes, this function must be updated
   function hash(OLKey memory olKey) internal pure returns (bytes32 _id) {
     assembly ("memory-safe") {
-      _id := keccak256(olKey, 96)
+      _id := keccak256(olKey, 128)
     }
   }
 
   // Creates a flipped copy of the `olKey` with same `tickScale`.
   function flipped(OLKey memory olKey) internal pure returns (OLKey memory) {
-    return OLKey(olKey.inbound, olKey.outbound, olKey.tickScale);
+    return OLKey(olKey.inbound, olKey.outbound, olKey.tickScale, olKey.tickShift);
   }
 }
 
@@ -145,6 +146,7 @@ interface HasMgvEvents {
 
   The `olKeyHash` and both token addresses are indexed, so that we can filter on it when doing RPC calls.
   */
+  //FIXME: Emit tick shift
   event SetActive(
     bytes32 indexed olKeyHash, address indexed outbound_tkn, address indexed inbound_tkn, uint tickScale, bool value
   );

--- a/src/MgvView.sol
+++ b/src/MgvView.sol
@@ -30,7 +30,7 @@ contract MgvView is MgvCommon {
   /* Reading the global configuration. In addition, a parameter (`gasprice`) may be read from the oracle. */
   function global() external view returns (MgvStructs.GlobalPacked _global) {
     unchecked {
-      (_global,,) = _config(OLKey(address(0), address(0), 0));
+      (_global,,) = _config(OLKey(address(0), address(0), 0, 0));
     }
   }
 

--- a/src/periphery/MgvReader.sol
+++ b/src/periphery/MgvReader.sol
@@ -15,6 +15,7 @@ struct Market {
   address tkn0;
   address tkn1;
   uint tickScale;
+  int tickShift;
 }
 
 /// @notice Config of a market. Assumes a context where `tkn0` and `tkn1` are defined. `config01` is the local config of the `tkn0/tkn1` offer list. `config10` is the config of the `tkn1/tkn0` offer list.
@@ -39,13 +40,13 @@ function order(Market memory market) pure {
 // flip tkn0/tkn1 of a market. Useful before conversion to OLKey
 // creates a copy
 function flipped(Market memory market) pure returns (Market memory) {
-  return Market(market.tkn1, market.tkn0, market.tickScale);
+  return Market(market.tkn1, market.tkn0, market.tickScale, market.tickShift);
 }
 
 // convert Market to OLKey
 // creates a copy
 function toOLKey(Market memory market) pure returns (OLKey memory) {
-  return OLKey(market.tkn0, market.tkn1, market.tickScale);
+  return OLKey(market.tkn0, market.tkn1, market.tickScale, market.tickShift);
 }
 
 contract MgvReader {
@@ -241,7 +242,7 @@ contract MgvReader {
     // if (offer.gives() == 0) {
     //   revert("Offer is not live, prev/next meaningless.");
     // }
-    Tick offerTick = offer.tick(olKey.tickScale);
+    Tick offerTick = offer.tick(olKey.tickScale, olKey.tickShift);
     uint nextId = offer.next();
     if (nextId == 0) {
       int index = offerTick.leafIndex();
@@ -287,7 +288,7 @@ contract MgvReader {
     // if (offer.gives() == 0) {
     //   revert("Offer is not live, prev/next meaningless.");
     // }
-    Tick offerTick = offer.tick(olKey.tickScale);
+    Tick offerTick = offer.tick(olKey.tickScale, olKey.tickShift);
     uint prevId = offer.prev();
     if (prevId == 0) {
       int index = offerTick.leafIndex();
@@ -551,8 +552,9 @@ contract MgvReader {
         address tkn0 = _openMarkets[from + i].tkn0;
         address tkn1 = _openMarkets[from + i].tkn1;
         uint tickScale = _openMarkets[from + i].tickScale;
+        int tickShift = _openMarkets[from + i].tickShift;
         // copy
-        markets[i] = Market({tkn0: tkn0, tkn1: tkn1, tickScale: tickScale});
+        markets[i] = Market({tkn0: tkn0, tkn1: tkn1, tickScale: tickScale, tickShift: tickShift});
 
         if (withConfig) {
           configs[i].config01 = localUnpacked(toOLKey(markets[i]));

--- a/src/preprocessed/MgvOffer.post.sol
+++ b/src/preprocessed/MgvOffer.post.sol
@@ -48,8 +48,8 @@ library OfferPackedExtra {
       resp := iszero(iszero(gives))
     }
   }
-  function tick(OfferPacked offer, uint tickScale) internal pure returns (Tick) {
-    return TickLib.fromLogPrice(offer.logPrice(),tickScale);
+  function tick(OfferPacked offer, uint tickScale, int tickShift) internal pure returns (Tick) {
+    return TickLib.fromLogPrice(offer.logPrice(), tickScale, tickShift);
   }
   function clearFieldsForMaker(OfferPacked offer) internal pure returns (OfferPacked) {
     unchecked {
@@ -72,8 +72,8 @@ library OfferUnpackedExtra {
       resp := iszero(iszero(gives))
     }
   }
-  function tick(OfferUnpacked memory offer, uint tickScale) internal pure returns (Tick) {
-    return TickLib.fromLogPrice(offer.logPrice,tickScale);
+  function tick(OfferUnpacked memory offer, uint tickScale, int tickShift) internal pure returns (Tick) {
+    return TickLib.fromLogPrice(offer.logPrice, tickScale, tickShift);
   }
 
 }

--- a/test/core/DynamicTicks.t.sol
+++ b/test/core/DynamicTicks.t.sol
@@ -108,14 +108,16 @@ contract DynamicTicksTest is MangroveTest {
     logPrice = boundLogPrice(logPrice);
     vm.assume(tickScale != 0);
     uint gives = 1 ether;
-    int insertionLogPrice = int24(LogPriceLib.fromTick(TickLib.fromLogPrice(logPrice, tickScale, 0), tickScale, 0)); // FIXME: tickShift parameter?
+    int insertionLogPrice = int24(
+      LogPriceLib.fromTick(TickLib.fromLogPrice(logPrice, tickScale, olKey.tickShift), tickScale, olKey.tickShift)
+    ); // FIXME: tickShift parameter?
     vm.assume(LogPriceLib.inRange(insertionLogPrice));
     uint wants = LogPriceLib.inboundFromOutbound(insertionLogPrice, gives);
     vm.assume(wants > 0);
     vm.assume(wants <= type(uint96).max);
     mgv.activate(olKey, 0, 100, 0);
     mgv.newOfferByLogPrice(olKey, logPrice, gives, 100_000, 30);
-    Tick tick = TickLib.fromLogPrice(insertionLogPrice, tickScale, 0); // FIXME: tickShift parameter?
+    Tick tick = TickLib.fromLogPrice(insertionLogPrice, tickScale, olKey.tickShift); // FIXME: tickShift parameter?
     assertEq(mgv.leafs(olKey, tick.leafIndex()).firstOfferPosition(), tick.posInLeaf(), "wrong pos in leaf");
     assertEq(mgv.level0(olKey, tick.level0Index()).firstOnePosition(), tick.posInLevel0(), "wrong pos in level0");
     assertEq(mgv.level1(olKey, tick.level1Index()).firstOnePosition(), tick.posInLevel1(), "wrong pos in level1");
@@ -152,7 +154,7 @@ contract DynamicTicksTest is MangroveTest {
     vm.assume(tickScale != 0);
     vm.assume(int(logPrice) % int(uint(tickScale)) != 0);
     logPrice = boundLogPrice(logPrice);
-    int insertionLogPrice = int24(LogPriceLib.fromTick(TickLib.fromLogPrice(logPrice, tickScale, 0), tickScale, 0));
+    int insertionLogPrice = int24(LogPriceLib.fromTick(TickLib.fromLogPrice(logPrice, tickScale, 0), tickScale, 0)); // FIXME: tickShift parameter?
     vm.assume(LogPriceLib.inRange(insertionLogPrice));
     olKey.tickScale = tickScale;
     uint wants = LogPriceLib.inboundFromOutbound(insertionLogPrice, 1 ether);

--- a/test/core/DynamicTicks.t.sol
+++ b/test/core/DynamicTicks.t.sol
@@ -23,12 +23,12 @@ contract DynamicTicksTest is MangroveTest {
 
   function test_logPrice_to_tick(int96 logPrice, uint16 tickScale) public {
     Tick tick = Tick.wrap(logPrice);
-    assertEq(LogPriceLib.fromTick(tick, tickScale), int(logPrice) * int(uint(tickScale)), "wrong tick -> logPrice");
+    assertEq(LogPriceLib.fromTick(tick, tickScale, 0), int(logPrice) * int(uint(tickScale)), "wrong tick -> logPrice"); // FIXME: tickShift parameter?
   }
 
   function test_tick_to_logPrice(int96 logPrice, uint16 _tickScale) public {
     vm.assume(_tickScale != 0);
-    Tick tick = TickLib.fromLogPrice(logPrice, _tickScale);
+    Tick tick = TickLib.fromLogPrice(logPrice, _tickScale, 0); // FIXME: tickShift parameter?
     int tickScale = int(uint(_tickScale));
     int expectedTick = logPrice / tickScale;
     if (logPrice < 0 && logPrice % tickScale != 0) {
@@ -47,13 +47,13 @@ contract DynamicTicksTest is MangroveTest {
     vm.assume(tickScale != tickScale2);
     vm.assume(tickScale != 0);
     olKey.tickScale = tickScale;
-    OLKey memory ol2 = OLKey(olKey.outbound, olKey.inbound, tickScale2);
+    OLKey memory ol2 = OLKey(olKey.outbound, olKey.inbound, tickScale2, 0); // FIXME: tickShift parameter?
     mgv.activate(olKey, 0, 100, 0);
     mgv.activate(ol2, 0, 100, 0);
     logPrice = boundLogPrice(logPrice);
     uint gives = 1 ether;
 
-    int insertionLogPrice = int24(LogPriceLib.fromTick(TickLib.fromLogPrice(logPrice, tickScale), tickScale));
+    int insertionLogPrice = int24(LogPriceLib.fromTick(TickLib.fromLogPrice(logPrice, tickScale, 0), tickScale, 0)); // FIXME: tickShift parameter?
     vm.assume(LogPriceLib.inRange(insertionLogPrice));
     uint wants = LogPriceLib.inboundFromOutbound(insertionLogPrice, gives);
     vm.assume(wants > 0);
@@ -70,10 +70,10 @@ contract DynamicTicksTest is MangroveTest {
     vm.assume(tickScale != 0);
     vm.assume(tickScale2 != 0);
     olKey.tickScale = tickScale;
-    OLKey memory ol2 = OLKey(olKey.outbound, olKey.inbound, tickScale2);
+    OLKey memory ol2 = OLKey(olKey.outbound, olKey.inbound, tickScale2, 0); // FIXME: tickShift parameter?
     uint gives = 1 ether;
 
-    int insertionLogPrice = int24(LogPriceLib.fromTick(TickLib.fromLogPrice(logPrice, tickScale), tickScale));
+    int insertionLogPrice = int24(LogPriceLib.fromTick(TickLib.fromLogPrice(logPrice, tickScale, 0), tickScale, 0)); // FIXME: tickShift parameter?
     vm.assume(LogPriceLib.inRange(insertionLogPrice));
     uint wants = LogPriceLib.inboundFromOutbound(insertionLogPrice, gives);
     vm.assume(wants > 0);
@@ -108,14 +108,14 @@ contract DynamicTicksTest is MangroveTest {
     logPrice = boundLogPrice(logPrice);
     vm.assume(tickScale != 0);
     uint gives = 1 ether;
-    int insertionLogPrice = int24(LogPriceLib.fromTick(TickLib.fromLogPrice(logPrice, tickScale), tickScale));
+    int insertionLogPrice = int24(LogPriceLib.fromTick(TickLib.fromLogPrice(logPrice, tickScale, 0), tickScale, 0)); // FIXME: tickShift parameter?
     vm.assume(LogPriceLib.inRange(insertionLogPrice));
     uint wants = LogPriceLib.inboundFromOutbound(insertionLogPrice, gives);
     vm.assume(wants > 0);
     vm.assume(wants <= type(uint96).max);
     mgv.activate(olKey, 0, 100, 0);
     mgv.newOfferByLogPrice(olKey, logPrice, gives, 100_000, 30);
-    Tick tick = TickLib.fromLogPrice(insertionLogPrice, tickScale);
+    Tick tick = TickLib.fromLogPrice(insertionLogPrice, tickScale, 0); // FIXME: tickShift parameter?
     assertEq(mgv.leafs(olKey, tick.leafIndex()).firstOfferPosition(), tick.posInLeaf(), "wrong pos in leaf");
     assertEq(mgv.level0(olKey, tick.level0Index()).firstOnePosition(), tick.posInLevel0(), "wrong pos in level0");
     assertEq(mgv.level1(olKey, tick.level1Index()).firstOnePosition(), tick.posInLevel1(), "wrong pos in level1");
@@ -136,7 +136,6 @@ contract DynamicTicksTest is MangroveTest {
   }
 
   // FIXME think of more tests
-
   function test_id_is_correct(OLKey memory olKey) public {
     assertEq(olKey.hash(), keccak256(abi.encode(olKey)), "id() is hashing incorrect data");
   }
@@ -153,7 +152,7 @@ contract DynamicTicksTest is MangroveTest {
     vm.assume(tickScale != 0);
     vm.assume(int(logPrice) % int(uint(tickScale)) != 0);
     logPrice = boundLogPrice(logPrice);
-    int insertionLogPrice = int24(LogPriceLib.fromTick(TickLib.fromLogPrice(logPrice, tickScale), tickScale));
+    int insertionLogPrice = int24(LogPriceLib.fromTick(TickLib.fromLogPrice(logPrice, tickScale, 0), tickScale, 0));
     vm.assume(LogPriceLib.inRange(insertionLogPrice));
     olKey.tickScale = tickScale;
     uint wants = LogPriceLib.inboundFromOutbound(insertionLogPrice, 1 ether);

--- a/test/core/MakerOperations.t.sol
+++ b/test/core/MakerOperations.t.sol
@@ -146,7 +146,7 @@ contract MakerOperationsTest is MangroveTest, IMaker {
   // since we check calldata, execute must be internal
   function makerExecute(MgvLib.SingleOrder calldata order) external returns (bytes32 ret) {
     ret; // silence unused function parameter warning
-    uint num_args = 10; // UPDATE IF SIZE OF SingleOrder changes
+    uint num_args = 11; // UPDATE IF SIZE OF SingleOrder changes
     uint selector_bytes = 4;
     uint length = selector_bytes + num_args * 32;
     assertEq(msg.data.length, length, "calldata length in execute is incorrect");
@@ -958,14 +958,18 @@ contract MakerOperationsTest is MangroveTest, IMaker {
   function test_update_branch_on_insert_posInLeaf() public {
     mkr.provisionMgv(10 ether);
     Tick tick0 = Tick.wrap(0);
-    mkr.newOfferByLogPrice(LogPriceLib.fromTick(tick0, olKey.tickScale), 1 ether, 100_000, 0);
+    mkr.newOfferByLogPrice(LogPriceLib.fromTick(tick0, olKey.tickScale, olKey.tickShift), 1 ether, 100_000, 0);
     uint ofr = mkr.newOfferByLogPrice(-46055, 100 ether, 100_000, 0);
     MgvStructs.OfferPacked offer = mgv.offers(olKey, ofr);
     assertTrue(
-      offer.tick(olKey.tickScale).posInLeaf() != Tick.wrap(0).posInLeaf(),
+      offer.tick(olKey.tickScale, olKey.tickShift).posInLeaf() != Tick.wrap(0).posInLeaf(),
       "test void if posInLeaf of second offer is not different"
     );
-    assertEq(mgv.local(olKey).tickPosInLeaf(), offer.tick(olKey.tickScale).posInLeaf(), "posInLeaf should have changed");
+    assertEq(
+      mgv.local(olKey).tickPosInLeaf(),
+      offer.tick(olKey.tickScale, olKey.tickShift).posInLeaf(),
+      "posInLeaf should have changed"
+    );
   }
   /* 
   When an offer ofr is updated, ofr is removed then re-added. In that case, if

--- a/test/core/MakerOperations.t.sol
+++ b/test/core/MakerOperations.t.sol
@@ -959,10 +959,11 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     mkr.provisionMgv(10 ether);
     Tick tick0 = Tick.wrap(0);
     mkr.newOfferByLogPrice(LogPriceLib.fromTick(tick0, olKey.tickScale, olKey.tickShift), 1 ether, 100_000, 0);
-    uint ofr = mkr.newOfferByLogPrice(-46055, 100 ether, 100_000, 0);
+    // FIXME: This logPrice should be derived - as is, the test is fragile
+    uint ofr = mkr.newOfferByLogPrice(-46055 + olKey.tickShift, 100 ether, 100_000, 0);
     MgvStructs.OfferPacked offer = mgv.offers(olKey, ofr);
     assertTrue(
-      offer.tick(olKey.tickScale, olKey.tickShift).posInLeaf() != Tick.wrap(0).posInLeaf(),
+      offer.tick(olKey.tickScale, olKey.tickShift).posInLeaf() != tick0.posInLeaf(),
       "test void if posInLeaf of second offer is not different"
     );
     assertEq(
@@ -1044,9 +1045,10 @@ contract MakerOperationsTest is MangroveTest, IMaker {
   function test_higher_tick() public {
     mgv.newOfferByLogPrice(olKey, 2, 1 ether, 100_000, 0);
     (, MgvStructs.LocalPacked local) = mgv.config(olKey);
+    uint posInLeafBefore = local.tickPosInLeaf();
 
     mgv.newOfferByLogPrice(olKey, 3, 1 ether, 100_000, 0);
     (, local) = mgv.config(olKey);
-    assertEq(local.tickPosInLeaf(), 2);
+    assertEq(local.tickPosInLeaf(), posInLeafBefore);
   }
 }

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -1131,15 +1131,17 @@ contract TakerOperationsTest is MangroveTest {
   ) public {
     quote.approve($(mgv), 10_000 ether);
     _tick = int24(bound(_tick, -100, 100));
-    int24 _firstPostedTick = crossTick ? _tick - 1 : _tick;
-    mkr.newOfferByLogPrice(_firstPostedTick, 1 ether, 100_000);
-    mkr.newOfferByLogPrice(_tick, 1 ether, 100_000);
-    uint ofr3 = mkr.newOfferByLogPrice(_tick, 1 ether, 100_000);
-    uint ofr4 = mkr.newOfferByLogPrice(_tick, 1 ether, 100_000);
-    uint volume = leaveOneOnly ? 3 ether : 2 ether;
-    mgv.marketOrderByLogPrice(olKey, _tick, volume, true);
-
     Tick tick = Tick.wrap(_tick);
+    Tick firstPostedTick = Tick.wrap(crossTick ? _tick - 1 : _tick);
+
+    int logPrice = LogPriceLib.fromTick(tick, olKey.tickScale, olKey.tickShift);
+    int firstPostedLogPrice = LogPriceLib.fromTick(firstPostedTick, olKey.tickScale, olKey.tickShift);
+    mkr.newOfferByLogPrice(firstPostedLogPrice, 1 ether, 100_000);
+    mkr.newOfferByLogPrice(logPrice, 1 ether, 100_000);
+    uint ofr3 = mkr.newOfferByLogPrice(logPrice, 1 ether, 100_000);
+    uint ofr4 = mkr.newOfferByLogPrice(logPrice, 1 ether, 100_000);
+    uint volume = leaveOneOnly ? 3 ether : 2 ether;
+    mgv.marketOrderByLogPrice(olKey, logPrice, volume, true);
 
     uint bestId = leaveOneOnly ? ofr4 : ofr3;
     MgvStructs.OfferPacked best = mgv.offers(olKey, bestId);

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -585,7 +585,7 @@ contract TakerOperationsTest is MangroveTest {
   //   uint ofr = mkr.newOfferByVolume(makerWants, makerGives, 100_000, 0);
   //   MgvStructs.OfferPacked offer = mgv.offers(olKey,ofr);
   //   pc = uint16(bound(pc, 0, 10_000));
-  //   Tick takerTick = offer.tick(olKey.tickScale);
+  //   Tick takerTick = offer.tick(olKey.tickScale, olKey.tickShift);
   //   // if I round down takerGives: what? well I reudce the price allowed, and so might mistakenly think (in execute()) that the taker is not ok with the offer (because I reduced the price more here, than I reduced it when I stored the offer?).
   //   // but then if I round it up, somehow I get also a roudned down takerGave in execute(), that is even lower a.... ahhh?
 
@@ -1143,7 +1143,7 @@ contract TakerOperationsTest is MangroveTest {
 
     uint bestId = leaveOneOnly ? ofr4 : ofr3;
     MgvStructs.OfferPacked best = mgv.offers(olKey, bestId);
-    Leaf leaf = mgv.leafs(olKey, best.tick(olKey.tickScale).leafIndex());
+    Leaf leaf = mgv.leafs(olKey, best.tick(olKey.tickScale, olKey.tickShift).leafIndex());
     assertEq(leaf.firstOfIndex(tick.posInLeaf()), bestId, "wrong first of tick");
     assertEq(leaf.lastOfIndex(tick.posInLeaf()), ofr4, "wrong last of tick");
     (, MgvStructs.LocalPacked local) = mgv.config(olKey);

--- a/test/core/gas/MarketOrderOtherOfferList.t.sol
+++ b/test/core/gas/MarketOrderOtherOfferList.t.sol
@@ -119,7 +119,7 @@ abstract contract ExternalMarketOrderOtherOfferList_WithOtherOfferGasTest is Gas
     mgv.marketOrderByLogPrice(_olKey, MIDDLE_LOG_PRICE, 1, false);
     gas_();
     (, MgvStructs.LocalPacked local) = mgv.config(_olKey);
-    assertEq(logPrice, LogPriceLib.fromTick(local.bestTick(), _olKey.tickScale));
+    assertEq(logPrice, LogPriceLib.fromTick(local.bestTick(), _olKey.tickScale, _olKey.tickShift));
     printDescription();
   }
 }
@@ -189,7 +189,7 @@ abstract contract ExternalMarketOrderOtherOfferList_WithMultipleOffersAtSameTick
     mgv.marketOrderByLogPrice(_olKey, MIDDLE_LOG_PRICE, 2 ** 96, false);
     gas_();
     (, MgvStructs.LocalPacked local) = mgv.config(_olKey);
-    assertEq(MIDDLE_LOG_PRICE + 1, LogPriceLib.fromTick(local.bestTick(), _olKey.tickScale));
+    assertEq(MIDDLE_LOG_PRICE + 1, LogPriceLib.fromTick(local.bestTick(), _olKey.tickScale, _olKey.tickShift));
     printDescription();
   }
 }
@@ -234,6 +234,6 @@ contract ExternalMarketOrderOtherOfferList_WithMultipleOffersAtManyTicks is Tick
     mgv.marketOrderByLogPrice(_olKey, _logPrice, 2 ** 96, false);
     gas_();
     (, MgvStructs.LocalPacked local) = mgv.config(_olKey);
-    assertLt(_logPrice, LogPriceLib.fromTick(local.bestTick(), _olKey.tickScale));
+    assertLt(_logPrice, LogPriceLib.fromTick(local.bestTick(), _olKey.tickScale, _olKey.tickShift));
   }
 }

--- a/test/core/gas/OfferGasBase.t.sol
+++ b/test/core/gas/OfferGasBase.t.sol
@@ -55,8 +55,8 @@ abstract contract OfferGasBaseBaseTest is MangroveTest, GasTestBaseStored {
     base = TestToken(baseAddress);
     quote = TestToken(quoteAddress);
     gasDeltaTest.setUpTokens(base, quote);
-    olKey = OLKey($(base), $(quote), options.defaultTickScale);
-    lo = OLKey($(quote), $(base), options.defaultTickScale);
+    olKey = OLKey($(base), $(quote), options.defaultTickScale, options.defaultTickShift);
+    lo = OLKey($(quote), $(base), options.defaultTickScale, -options.defaultTickShift);
     setupMarket(olKey);
     setupMarket(lo);
 

--- a/test/core/gas/OfferPosthookFailGasDelta.t.sol
+++ b/test/core/gas/OfferPosthookFailGasDelta.t.sol
@@ -98,8 +98,8 @@ contract OfferPosthookFailGasDeltaTest is MangroveTest, IMaker {
     base = _base;
     quote = _quote;
 
-    olKey = OLKey($(base), $(quote), options.defaultTickScale);
-    lo = OLKey($(quote), $(base), options.defaultTickScale);
+    olKey = OLKey($(base), $(quote), options.defaultTickScale, options.defaultTickShift);
+    lo = OLKey($(quote), $(base), options.defaultTickScale, -options.defaultTickShift);
 
     setupMarket(olKey);
     setupMarket(lo);

--- a/test/core/ticktree/TickTreeNewOffer.t.sol
+++ b/test/core/ticktree/TickTreeNewOffer.t.sol
@@ -156,7 +156,7 @@ contract TickTreeNewOfferTest is TickTreeTest {
 
     // 4. Create new offer and add it to tick tree
     Tick _insertionTick = Tick.wrap(scenario.tickScenario.tick);
-    int logPrice = LogPriceLib.fromTick(_insertionTick, olKey.tickScale);
+    int logPrice = LogPriceLib.fromTick(_insertionTick, olKey.tickScale, olKey.tickShift);
     uint gives = getAcceptableGivesForTick(_insertionTick, 50_000);
     mkr.newOfferByLogPrice(logPrice, gives, 50_000, 50);
     tickTree.addOffer(_insertionTick, gives, 50_000, 50, $(mkr));

--- a/test/core/ticktree/TickTreeTest.t.sol
+++ b/test/core/ticktree/TickTreeTest.t.sol
@@ -75,7 +75,7 @@ abstract contract TickTreeTest is MangroveTest {
     // First, try minVolume
     gives = reader.minVolume(olKey, gasreq);
     gives = gives == 0 ? 1 : gives;
-    uint wants = LogPriceLib.inboundFromOutbound(LogPriceLib.fromTick(tick, olKey.tickScale), gives);
+    uint wants = LogPriceLib.inboundFromOutbound(LogPriceLib.fromTick(tick, olKey.tickScale, olKey.tickShift), gives);
     if (wants > 0 && uint96(wants) == wants) {
       return gives;
     }
@@ -223,7 +223,7 @@ abstract contract TickTreeTest is MangroveTest {
     returns (uint[] memory offerIds, uint gives)
   {
     Tick _tick = Tick.wrap(tick);
-    int logPrice = LogPriceLib.fromTick(_tick, olKey.tickScale);
+    int logPrice = LogPriceLib.fromTick(_tick, olKey.tickScale, olKey.tickShift);
     uint gasreq = 1_300_000;
     gives = getAcceptableGivesForTick(_tick, gasreq);
     offerIds = new uint[](n);

--- a/test/core/ticktree/TickTreeUpdateOffer.t.sol
+++ b/test/core/ticktree/TickTreeUpdateOffer.t.sol
@@ -324,7 +324,11 @@ contract TickTreeUpdateOfferTest is TickTreeTest {
     Tick newTick = Tick.wrap(scenario.newTick);
     uint newGives = getAcceptableGivesForTick(newTick, offerDetail.gasreq());
     mkr.updateOfferByLogPrice(
-      LogPriceLib.fromTick(newTick, olKey.tickScale), newGives, offerDetail.gasreq(), offerDetail.gasprice(), offerId
+      LogPriceLib.fromTick(newTick, olKey.tickScale, olKey.tickShift),
+      newGives,
+      offerDetail.gasreq(),
+      offerDetail.gasprice(),
+      offerId
     );
     tickTree.updateOffer(offerId, newTick, newGives, offerDetail.gasreq(), offerDetail.gasprice(), $(mkr));
     if (printToConsole) {

--- a/test/lib/MangroveTest.sol
+++ b/test/lib/MangroveTest.sol
@@ -78,7 +78,7 @@ contract MangroveTest is Test2, HasMgvEvents {
     quote: TokenOptions({name: "Quote Token", symbol: "$(B)", decimals: 18}),
     defaultFee: 0,
     defaultTickScale: 1,
-    defaultTickShift: 0,
+    defaultTickShift: 101,
     gasprice: 40,
     //Update `gasbase` by measuring using the test run `forge test --mc OfferGasBaseTest_Generic_A_B -vv`
     gasbase: 184048,

--- a/test/lib/MangroveTest.sol
+++ b/test/lib/MangroveTest.sol
@@ -58,6 +58,7 @@ contract MangroveTest is Test2, HasMgvEvents {
     TokenOptions quote;
     uint defaultFee;
     uint defaultTickScale;
+    int defaultTickShift;
     uint gasprice;
     uint gasbase;
     uint gasmax;
@@ -77,6 +78,7 @@ contract MangroveTest is Test2, HasMgvEvents {
     quote: TokenOptions({name: "Quote Token", symbol: "$(B)", decimals: 18}),
     defaultFee: 0,
     defaultTickScale: 1,
+    defaultTickShift: 0,
     gasprice: 40,
     //Update `gasbase` by measuring using the test run `forge test --mc OfferGasBaseTest_Generic_A_B -vv`
     gasbase: 184048,
@@ -103,8 +105,8 @@ contract MangroveTest is Test2, HasMgvEvents {
     base = new TestToken($(this), options.base.name, options.base.symbol, options.base.decimals);
     quote = new TestToken($(this), options.quote.name, options.quote.symbol, options.quote.decimals);
     // mangrove deploy
-    olKey = OLKey($(base), $(quote), options.defaultTickScale);
-    lo = OLKey($(quote), $(base), options.defaultTickScale);
+    olKey = OLKey($(base), $(quote), options.defaultTickScale, options.defaultTickShift);
+    lo = OLKey($(quote), $(base), options.defaultTickScale, -options.defaultTickShift);
 
     mgv = setupMangrove(olKey, options.invertedMangrove);
     reader = new MgvReader($(mgv));

--- a/test/lib/TestTickTree.sol
+++ b/test/lib/TestTickTree.sol
@@ -175,7 +175,7 @@ contract TestTickTree is MangroveTest {
             do {
               MgvStructs.OfferPacked offer = mgv.offers(olKey, offerId);
               assertEq(
-                offer.tick(olKey.tickScale),
+                offer.tick(olKey.tickScale, olKey.tickShift),
                 tick,
                 string.concat(
                   "offer[", vm.toString(offerId), "] tick does not match location in tick tree | tick: ", toString(tick)
@@ -410,7 +410,7 @@ contract TestTickTree is MangroveTest {
     // console.log("leaf after: %s", toString(leafs[tick.leafIndex()]));
 
     // Create offer
-    int logPrice = LogPriceLib.fromTick(tick, olKey.tickScale);
+    int logPrice = LogPriceLib.fromTick(tick, olKey.tickScale, olKey.tickShift);
     offers[offerId].offer = MgvStructs.Offer.pack({__prev: lastId, __next: 0, __logPrice: logPrice, __gives: gives});
     offers[offerId].detail = MgvStructs.OfferDetail.pack({
       __maker: maker,
@@ -432,7 +432,7 @@ contract TestTickTree is MangroveTest {
 
   function removeOffer(uint offerId) public {
     MgvCommon.OfferData storage offer = offers[offerId];
-    Tick tick = offer.offer.tick(olKey.tickScale);
+    Tick tick = offer.offer.tick(olKey.tickScale, olKey.tickShift);
 
     // Update leaf and tick list
     Leaf leaf = leafs[tick.leafIndex()];

--- a/test/periphery/MgvOracle.t.sol
+++ b/test/periphery/MgvOracle.t.sol
@@ -160,7 +160,7 @@ contract MgvOracleTest is Test2 {
     mgvOracle.setGasPrice(30);
     vm.stopPrank();
 
-    (uint gas, Density density) = mgvOracle.read(OLKey(address(0), address(0), 0));
+    (uint gas, Density density) = mgvOracle.read(OLKey(address(0), address(0), 0, 0));
 
     assertEq(gas, 30, "gas should be 30");
     assertEq(

--- a/test/periphery/MgvReader.t.sol
+++ b/test/periphery/MgvReader.t.sol
@@ -382,9 +382,9 @@ contract MgvReaderTest is MangroveTest {
   }
 
   function test_multi_add_triangle(address tkn0, address tkn1, address tkn2, uint tickScale) public {
-    Market memory mktA = Market(tkn0, tkn1, tickScale);
-    Market memory mktB = Market(tkn1, tkn2, tickScale);
-    Market memory mktC = Market(tkn2, tkn0, tickScale);
+    Market memory mktA = Market(tkn0, tkn1, tickScale, 0); // FIXME tickShift parameter?
+    Market memory mktB = Market(tkn1, tkn2, tickScale, 0); // FIXME tickShift parameter?
+    Market memory mktC = Market(tkn2, tkn0, tickScale, 0); // FIXME tickShift parameter?
     activateMarket(mktA);
     activateMarket(mktB);
     activateMarket(mktC);
@@ -538,8 +538,8 @@ contract MgvReaderTest is MangroveTest {
 
   function test_openMarkets_overloads(address tknA, address tknB, address tkn0, address tkn1, uint tickScale) public {
     assumeDifferentPairs(tknA, tknB, tkn0, tkn1);
-    Market memory mktA = Market(tknA, tknB, tickScale);
-    Market memory mktB = Market(tkn0, tkn1, tickScale);
+    Market memory mktA = Market(tknA, tknB, tickScale, 0); // FIXME tickShift parameter?
+    Market memory mktB = Market(tkn0, tkn1, tickScale, 0); // FIXME tickShift parameter?
     activateMarket(mktB);
     reader.updateMarket(mktB);
     activateMarket(mktA);
@@ -584,8 +584,8 @@ contract MgvReaderTest is MangroveTest {
   function test_no_double_remove_long_swap(address tknA, address tknB, address tkn0, address tkn1, uint tickScale)
     public
   {
-    Market memory mktA = Market(tknA, tknB, tickScale);
-    Market memory mktB = Market(tkn0, tkn1, tickScale);
+    Market memory mktA = Market(tknA, tknB, tickScale, 0); // FIXME tickShift parameter?
+    Market memory mktB = Market(tkn0, tkn1, tickScale, 0); // FIXME tickShift parameter?
     assumeDifferentPairs(tknA, tknB, tkn0, tkn1);
     activateMarket(mktA);
     reader.updateMarket(mktA);
@@ -609,8 +609,8 @@ contract MgvReaderTest is MangroveTest {
   }
 
   function test_market_slice_zero(address tknA, address tknB, address tkn0, address tkn1, uint tickScale) public {
-    Market memory mktA = Market(tknA, tknB, tickScale);
-    Market memory mktB = Market(tkn0, tkn1, tickScale);
+    Market memory mktA = Market(tknA, tknB, tickScale, 0); // FIXME tickShift parameter?
+    Market memory mktB = Market(tkn0, tkn1, tickScale, 0); // FIXME tickShift parameter?
     activateMarket(mktA);
     activateMarket(mktB);
     reader.updateMarket(mktA);
@@ -620,8 +620,8 @@ contract MgvReaderTest is MangroveTest {
   }
 
   function test_market_slice_multi(address tknA, address tknB, address tkn0, address tkn1, uint tickScale) public {
-    Market memory mktA = Market(tknA, tknB, tickScale);
-    Market memory mktB = Market(tkn0, tkn1, tickScale);
+    Market memory mktA = Market(tknA, tknB, tickScale, 0); // FIXME tickShift parameter?
+    Market memory mktB = Market(tkn0, tkn1, tickScale, 0); // FIXME tickShift parameter?
     activateMarket(mktA);
     activateMarket(mktB);
     reader.updateMarket(mktA);
@@ -656,8 +656,8 @@ contract MgvReaderTest is MangroveTest {
   }
 
   function test_market_slice_revert(address tknA, address tknB, address tkn0, address tkn1, uint tickScale) public {
-    Market memory mktA = Market(tknA, tknB, tickScale);
-    Market memory mktB = Market(tkn0, tkn1, tickScale);
+    Market memory mktA = Market(tknA, tknB, tickScale, 0); // FIXME tickShift parameter?
+    Market memory mktB = Market(tkn0, tkn1, tickScale, 0); // FIXME tickShift parameter?
     activateMarket(mktA);
     activateMarket(mktB);
     reader.updateMarket(mktA);
@@ -668,8 +668,8 @@ contract MgvReaderTest is MangroveTest {
 
   function test_remove_2nd_to_last(address tknA, address tknB, address tkn0, address tkn1, uint tickScale) public {
     assumeDifferentPairs(tknA, tknB, tkn0, tkn1);
-    Market memory mktA = Market(tknA, tknB, tickScale);
-    Market memory mktB = Market(tkn0, tkn1, tickScale);
+    Market memory mktA = Market(tknA, tknB, tickScale, 0); // FIXME tickShift parameter?
+    Market memory mktB = Market(tkn0, tkn1, tickScale, 0); // FIXME tickShift parameter?
     activateOfferList(toOLKey(mktA));
     activateOfferList(toOLKey(mktB));
     // remove 2nd-to-last
@@ -691,8 +691,8 @@ contract MgvReaderTest is MangroveTest {
   }
 
   function test_remove_last_not_only(address tknA, address tknB, address tkn0, address tkn1, uint tickScale) public {
-    Market memory mktA = Market(tknA, tknB, tickScale);
-    Market memory mktB = Market(tkn0, tkn1, tickScale);
+    Market memory mktA = Market(tknA, tknB, tickScale, 0); // FIXME tickShift parameter?
+    Market memory mktB = Market(tkn0, tkn1, tickScale, 0); // FIXME tickShift parameter?
     activateOfferList(toOLKey(mktA));
     activateOfferList(toOLKey(mktB));
     // remove 2nd-to-last
@@ -705,8 +705,8 @@ contract MgvReaderTest is MangroveTest {
   }
 
   function test_update_already_absent(address tknA, address tknB, address tkn0, address tkn1, uint tickScale) public {
-    Market memory mktA = Market(tknA, tknB, tickScale);
-    Market memory mktB = Market(tkn0, tkn1, tickScale);
+    Market memory mktA = Market(tknA, tknB, tickScale, 0); // FIXME tickShift parameter?
+    Market memory mktB = Market(tkn0, tkn1, tickScale, 0); // FIXME tickShift parameter?
     activateOfferList(toOLKey(mktA));
     reader.updateMarket(mktA);
     reader.updateMarket(mktB);

--- a/test/script/core/UpdateMarket.t.sol
+++ b/test/script/core/UpdateMarket.t.sol
@@ -31,7 +31,7 @@ contract UpdateMarketTest is Test2 {
   }
 
   function test_updater(OLKey memory olKey) public {
-    Market memory market = Market(olKey.outbound, olKey.inbound, olKey.tickScale);
+    Market memory market = Market(olKey.outbound, olKey.inbound, olKey.tickScale, olKey.tickShift);
     IMangrove mgv = deployer.mgv();
     MgvReader reader = deployer.reader();
 

--- a/test/script/core/deployers/BaseMangroveDeployer.t.sol
+++ b/test/script/core/deployers/BaseMangroveDeployer.t.sol
@@ -29,7 +29,7 @@ abstract contract BaseMangroveDeployerTest is Deployer, Test2 {
   }
 
   function test_contracts_instantiated_correctly(uint tickScale) public {
-    OLKey memory olKey = OLKey(freshAddress("oubtound_tkn"), freshAddress("inbound_tkn"), tickScale);
+    OLKey memory olKey = OLKey(freshAddress("oubtound_tkn"), freshAddress("inbound_tkn"), tickScale, 0); // FIXME tickShift parameter?
 
     // Oracle - verify expected values have been passed in. We read from storage slots - alternatively, we should poke admin methods to verify correct setup.
     MgvOracle oracle = mgvDeployer.oracle();


### PR DESCRIPTION
## Summary
This is a POC of expanding the `logPrice` range that can be mapped into the tick tree without expanding the tree: By shifting the location of ticks in the tick tree by a per-offer list constant (`tickShift`) we shift the `logPrice` range for that offer list.

Gas measurement diff: [gas-measurement-diff.csv](https://github.com/mangrovedao/mangrove-core/files/12586145/gas-measurement-diff.csv)


### Todo

- [ ] Address FIXMEs


## 👍 Pros

- Simple code

- Choice of optimal mid-price tick
	- Besides extending, or rather *shifting*, the logPrice range, tick shifts allows placing the mid price of stable markets at a location in the tick tree where price movements will be unlikely to move outside of `level0` and `level1` thereby reducing gas costs for both makers and takers.

- Eases smaller "base tick size" than 1 bps
	- If the "base tick size" were to be made smaller than 1bps (eg 0.1bps), the combination of `tickScale` and `tickShift` should allow the existing tick tree to be used for both stable markets with small tick sizes (due to a small base tick size), volatile markets with large tick sizes (due to `tickScale`), and for tokens with a 0 to 18 difference in the number of decimals (due to `tickShift`).


## 👎 Cons

- `tickShift` is a purely technical parameter that leaks into the API. One could argue that this is similar to the `tickScale` parameter, but tick scale isn't purely technical: One could imagine having parallel markets with different tick sizes and `tickScale` enables this.


# How it works
Offer list keys are extended with a `tickShift` parameter which shifts the location of ticks in the tick tree:

```
tick        = logPrice / tickScale
shiftedTick = tick - tickShift = logPrice / tickScale - tickShift
logPrice    = tick * tickScale = (shiftedTick + tickShift) * tickScale
```

This in turn shifts the ranges of ticks and logPrices that fit in the tick tree as follows:

```
Tick tree (holds shifted ticks):
	MIN_SHIFTED_TICK = -524,288
	MAX_SHIFTED_TICK = -MIN_TICK - 1

Unshifted ticks:
	MIN_TICK = -524,288 + tickShift
	MAX_TICK = -MIN_TICK - 1 + tickShift

Log prices:
	MIN_LOG_PRICE = (-524,288 + tickShift) * tickScale
	MAX_LOG_PRICE = (-MIN_TICK - 1 + tickShift) * tickScale
```

## Range of `tickShift`

The logPrice range supported by `LogPriceLib` is restricted to
```
MIN_LOG_PRICE = -((1 << 20)-1) = -1,048,575
MAX_LOG_PRICE = -MIN_LOG_PRICE =  1,048,575;
```

For `tickScale = 1` this means tick shifts should be within this range to avoid having ticks in the tree that correspond to unsupported logPrices:

```
MIN_LOG_PRICE  =       (-524,288 + MIN_TICK_SHIFT) * tickScale  =  -1,048,575
     <=>                       (-524,288 + MIN_TICK_SHIFT) * 1  =  -1,048,575
     <=>                                        MIN_TICK_SHIFT  =  -1,048,575 + 524,288  =  -524,287

MAX_LOG_PRICE  =  (-MIN_TICK - 1 + MAX_TICK_SHIFT) * tickScale  =   1,048,575
     <=>                        (524,287 + MAX_TICK_SHIFT) * 1  =   1,048,575
     <=>                                        MAX_TICK_SHIFT  =   1,048,575 - 524,287  =   524,288
```

Note that for `tickScale > 1`, the supported `tickShift` range becomes smaller IF all ticks in the tick tree should correspond to a supported logPrice.

However, even without `tickShift`, `tickScale > 1` means not all ticks in the tick tree correspond to a supported logPrice. Already at `tickScale = 2`, `MIN_TICK` gives a logPrice that is outside the supported range:

```
logPrice(MIN_TICK)  =  MIN_TICK * tickScale  =  -524,288 * 2  =  -1,048,576  
                                                              <  -1,048,575  =  MIN_LOG_PRICE
```


# Notes

## Terminology
I think the terminology we use around ticks is a bit confusing and possibly ambiguous. A glossary would be useful and I think we should try to align our terminology with common definitions (to the extent possible); Perhaps we can check with Hamza.

Some thoughts on terminology:

- "tick": *a minimal movement from a given price*
	- in some sources, *tick* appears to be a synonym for *tick size*
	- in others, a *tick* sounds like it's a minimal movement from a given price
		- https://www.investopedia.com/ask/answers/032615/what-difference-between-pips-points-and-ticks.asp
	- in Mangrove, a *tick* is currently an index into the lowest level of the tick tree and corresponds to a certain `logPrice`.
		- perhaps a more apt name could be "tickIndex"?

- "tick size": *the minimum, relative price movement in a market*
	- adapted from https://www.investopedia.com/terms/t/tick-size.asp
	- in Mangrove, this is currently $1.0001^{tickScale} - 1$ for a given `tickScale > 0`.

- "tick scale": ?
	- I couldn't find clearly relevant definitions of this. Google mostly gave results related to charting ticks while ChatGPT said "tick scale" and "tick size" are mostly synonymous.
	- in Mangrove, it is the number of "base ticks"/"basis point ticks" between two ticks
		- perhaps a more apt name could be "baseTicksPerTick"?

- "tick shift": ?
	- This is a purely technical term
	- in Mangrove, "tick shift" describes a shift of the *tick (index) range*
		- perhaps a more apt name could be "tickIndexShift"