### PR TITLE
feat(terminology): Change wants/gives to takerWants/takerGives in SingleOrder

### DIFF
--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -162,17 +162,6 @@ library OfferUnpackedExtra {
   }
 
 }
-
-// Alternative pack function to derive tick from gives/wants
-// May be removed
-function pack(uint __prev, uint __next, uint __wants, uint __gives) pure returns (OfferPacked) { unchecked {
-  return pack({
-    __prev: __prev,
-    __next: __next,
-    __logPrice: LogPriceConversionLib.logPriceFromVolumes(__wants,__gives),
-    __gives: __gives
-  });
-}}
 `
   },
 

--- a/src/InvertedMangrove.sol
+++ b/src/InvertedMangrove.sol
@@ -33,7 +33,7 @@ contract InvertedMangrove is AbstractMangrove {
   function beforePosthook(MgvLib.SingleOrder memory sor) internal override {
     unchecked {
       /* If `transferToken` returns false here, we're in a special (and bad) situation. The taker is returning part of their total loan to a maker, but the maker can't receive the tokens. Only case we can see: maker is blacklisted. In that case, we keep the tokens, so things have a chance of getting sorted out later. If that transfer fails there's nothing we can do -- reverting would punish the taker for the maker's blacklisting. */
-      transferToken(sor.olKey.inbound, sor.offerDetail.maker(), sor.gives);
+      transferToken(sor.olKey.inbound, sor.offerDetail.maker(), sor.takerGives);
     }
   }
 

--- a/src/Mangrove.sol
+++ b/src/Mangrove.sol
@@ -34,8 +34,8 @@ contract Mangrove is AbstractMangrove {
        mgv->maker. With a direct taker->maker transfer, if one of taker/maker
        is blacklisted, we can't tell which one. We need to know which one:
        if we incorrectly blame the taker, a blacklisted maker can block an offer list forever; if we incorrectly blame the maker, a blacklisted taker can unfairly make makers fail all the time. Of course we assume that Mangrove is not blacklisted. This 2-step transfer is incompatible with tokens that have transfer fees (more accurately, it uselessly incurs fees twice). */
-      if (transferTokenFrom(sor.olKey.inbound, taker, address(this), sor.gives)) {
-        if (transferToken(sor.olKey.inbound, sor.offerDetail.maker(), sor.gives)) {
+      if (transferTokenFrom(sor.olKey.inbound, taker, address(this), sor.takerGives)) {
+        if (transferToken(sor.olKey.inbound, sor.offerDetail.maker(), sor.takerGives)) {
           (gasused, makerData) = makerExecute(sor);
         } else {
           innerRevert([bytes32("mgv/makerReceiveFail"), bytes32(0), ""]);

--- a/src/MgvLib.sol
+++ b/src/MgvLib.sol
@@ -50,8 +50,8 @@ library MgvLib {
     uint offerId;
     MgvStructs.OfferPacked offer;
     /* `wants`/`gives` mutate over execution. Initially the `wants`/`gives` from the taker's pov, then actual `wants`/`gives` adjusted by offer's price and volume. */
-    uint wants;
-    uint gives;
+    uint takerWants;
+    uint takerGives;
     /* `offerDetail` is only populated when necessary. */
     MgvStructs.OfferDetailPacked offerDetail;
     MgvStructs.GlobalPacked global;

--- a/src/preprocessed/MgvOffer.post.sol
+++ b/src/preprocessed/MgvOffer.post.sol
@@ -78,17 +78,6 @@ library OfferUnpackedExtra {
 
 }
 
-// Alternative pack function to derive tick from gives/wants
-// May be removed
-function pack(uint __prev, uint __next, uint __wants, uint __gives) pure returns (OfferPacked) { unchecked {
-  return pack({
-    __prev: __prev,
-    __next: __next,
-    __logPrice: LogPriceConversionLib.logPriceFromVolumes(__wants,__gives),
-    __gives: __gives
-  });
-}}
-
 ////////////// END OF ADDITIONAL DEFINITIONS /////////////////
 
 // number of bits in each field

--- a/test/core/MakerOperations.t.sol
+++ b/test/core/MakerOperations.t.sol
@@ -67,8 +67,8 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     assertEq(order.offerDetail.gasreq(), 200_000, "offerDetail.gasreq should not be hidden");
 
     // wants and gives are not filtered
-    assertEq(order.wants, 0.1 ether, "wants should not be hidden");
-    assertEq(order.gives, 0.10001 ether, "gives should not be hidden");
+    assertEq(order.takerWants, 0.1 ether, "wants should not be hidden");
+    assertEq(order.takerGives, 0.10001 ether, "gives should not be hidden");
 
     // GloablPacked is not filtered
     assertEq(order.global.monitor(), address(monitor), "global.monitor should not be hidden");
@@ -154,8 +154,8 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     assertEq(order.olKey.outbound, $(base), "wrong base");
     assertEq(order.olKey.inbound, $(quote), "wrong quote");
     assertEq(order.olKey.tickScale, olKey.tickScale, "wrong tickscale");
-    assertEq(order.wants, 0.05 ether, "wrong takerWants");
-    assertEq(order.gives, 0.05 ether, "wrong takerGives");
+    assertEq(order.takerWants, 0.05 ether, "wrong takerWants");
+    assertEq(order.takerGives, 0.05 ether, "wrong takerGives");
     assertEq(order.offerDetail.gasreq(), 200_000, "wrong gasreq");
     assertEq(order.offerId, 1, "wrong offerId");
     assertEq(order.offer.wants(), 0.05 ether, "wrong offerWants");

--- a/test/core/MakerPosthook.t.sol
+++ b/test/core/MakerPosthook.t.sol
@@ -19,12 +19,12 @@ contract MakerPosthookTest is MangroveTest, IMaker {
 
   event Execute(address mgv, address base, address quote, uint offerId, uint takerWants, uint takerGives);
 
-  function makerExecute(MgvLib.SingleOrder calldata trade) external override returns (bytes32) {
+  function makerExecute(MgvLib.SingleOrder calldata sor) external override returns (bytes32) {
     require(msg.sender == $(mgv));
     if (makerRevert) {
       revert(sExecuteRevertData);
     }
-    emit Execute(msg.sender, trade.olKey.outbound, trade.olKey.inbound, trade.offerId, trade.wants, trade.gives);
+    emit Execute(msg.sender, sor.olKey.outbound, sor.olKey.inbound, sor.offerId, sor.takerWants, sor.takerGives);
     return executeReturnData;
   }
 
@@ -435,8 +435,8 @@ contract MakerPosthookTest is MangroveTest, IMaker {
   uint expectedGives;
 
   function checkSorWantsPosthook(MgvLib.SingleOrder calldata sor, MgvLib.OrderResult calldata) internal {
-    assertApproxEqRel(sor.gives, expectedGives, relError({basis_points: 10}), "sor.gives not as expected");
-    assertApproxEqRel(sor.wants, expectedWants, relError({basis_points: 10}), "sor.wants not as expected");
+    assertApproxEqRel(sor.takerGives, expectedGives, relError({basis_points: 10}), "sor.takerGives not as expected");
+    assertApproxEqRel(sor.takerWants, expectedWants, relError({basis_points: 10}), "sor.takerWants not as expected");
   }
 
   // Check that a previously-executed posthook does not corrupt the current posthook (when fillWants=true)

--- a/test/core/Monitor.t.sol
+++ b/test/core/Monitor.t.sol
@@ -104,8 +104,8 @@ contract MonitorTest is MangroveTest {
       olKey: olKey,
       offerId: ofrId,
       offer: offer,
-      wants: 0.04 ether,
-      gives: 0.04 ether, // price is 1
+      takerWants: 0.04 ether,
+      takerGives: 0.04 ether, // price is 1
       offerDetail: mgv.offerDetails(olKey, ofrId),
       global: _global,
       local: _local
@@ -135,8 +135,8 @@ contract MonitorTest is MangroveTest {
       olKey: olKey,
       offerId: ofrId,
       offer: offer,
-      wants: 0.04 ether,
-      gives: 0.04 ether, // price is 1
+      takerWants: 0.04 ether,
+      takerGives: 0.04 ether, // price is 1
       offerDetail: offerDetail, // gasprice logged will still be as before failure
       global: _global,
       local: _local

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -1154,7 +1154,7 @@ contract TakerOperationsTest is MangroveTest {
   }
 
   /* 
-  An attempt to check for overflow when accumulating sor.gives into mor.totalGave.
+  An attempt to check for overflow when accumulating sor.takerGives into mor.totalGave.
   I have not found a way to actually trigger it by mutating state somewhere.
   This test just considers as many offers as possible that each have a maximal `wants` and makes sure the error will be about stack overflow, not uint overflow. 
   */
@@ -1163,7 +1163,8 @@ contract TakerOperationsTest is MangroveTest {
     unchecked {
       uint recp = mgv.global().maxRecursionDepth() + 1;
       assertTrue(
-        maxOfferWants * recp / recp == maxOfferWants, "mor.totalGave += sor.gives could overflow, check MgvOfferTaking"
+        maxOfferWants * recp / recp == maxOfferWants,
+        "mor.totalGave += sor.takerGives could overflow, check MgvOfferTaking"
       );
     }
   }

--- a/test/core/gas/OfferPosthookFailGasDelta.t.sol
+++ b/test/core/gas/OfferPosthookFailGasDelta.t.sol
@@ -50,8 +50,8 @@ contract BeforePosthookGasMeasuringMangrove is AbstractMangrove, Test2 {
        mgv->maker. With a direct taker->maker transfer, if one of taker/maker
        is blacklisted, we can't tell which one. We need to know which one:
        if we incorrectly blame the taker, a blacklisted maker can block an offer list forever; if we incorrectly blame the maker, a blacklisted taker can unfairly make makers fail all the time. Of course we assume that Mangrove is not blacklisted. This 2-step transfer is incompatible with tokens that have transfer fees (more accurately, it uselessly incurs fees twice). */
-      if (transferTokenFrom(sor.olKey.inbound, taker, address(this), sor.gives)) {
-        if (transferToken(sor.olKey.inbound, sor.offerDetail.maker(), sor.gives)) {
+      if (transferTokenFrom(sor.olKey.inbound, taker, address(this), sor.takerGives)) {
+        if (transferToken(sor.olKey.inbound, sor.offerDetail.maker(), sor.takerGives)) {
           (gasused, makerData) = makerExecute(sor);
         } else {
           innerRevert([bytes32("mgv/makerReceiveFail"), bytes32(0), ""]);

--- a/test/lib/agents/TestMaker.sol
+++ b/test/lib/agents/TestMaker.sol
@@ -141,7 +141,7 @@ contract SimpleTestMaker is TrivialTestMaker {
       revert("testMaker/shouldRevert");
     }
 
-    if (_shouldRevertOnNonZeroGives && order.gives > 0) {
+    if (_shouldRevertOnNonZeroGives && order.takerGives > 0) {
       revert("testMaker/shouldRevertOnNonZeroGives");
     }
 
@@ -166,8 +166,8 @@ contract SimpleTestMaker is TrivialTestMaker {
       order.olKey.inbound,
       order.olKey.tickScale,
       order.offerId,
-      order.wants,
-      order.gives
+      order.takerWants,
+      order.takerGives
     );
 
     return bytes32(bytes(offerData.executeData));


### PR DESCRIPTION
SingleOrder contains multiple offer-related fields, which depending on context makes it unclear whether it is the taker or maker side for the gives/wants. This commit makes it explicit.