### PR TITLE
Make tick tree tests run in CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -66,13 +66,17 @@ jobs:
 
     # Pinned forks are used in tests and utilize secrets. For PRs from forks these are not available
     # Let the tests attempt to run with demo endpoints which are more unstable.
-    - name: Mangrove Solidity Tests
-      run: yarn run test
+    - name: Mangrove Solidity Tests (fast)
+      run: yarn run test:fast
       env:
         POLYGON_NODE_URL: ${{ secrets.POLYGON_NODE_URL || 'https://polygon.llamarpc.com' }}
         MUMBAI_NODE_URL: ${{ secrets.MUMBAI_NODE_URL || 'unused' }}
 
-    # For push runs we also create a coverage report
+    # Memory intensive tests run without -vvv as GitHub actions otherwise cancels the step due to memory usage
+    - name: Mangrove Solidity Tests (memory intensive)
+      run: yarn run test:memory-intensive
+
+      # For push runs we also create a coverage report
     - name: Create coverage report for mangrove-solidity
       if: github.event_name != 'pull_request' 
       run: forge coverage --report lcov

--- a/foundry.toml
+++ b/foundry.toml
@@ -12,7 +12,6 @@ fs_permissions = [{ access = "read-write", path = "./addresses/"}, { access = "r
 solc_version="0.8.20"
 ffi=true
 optimizer=false
-memory_limit = 100000000 # 33554432 is default limit
 
 # via_ir=true
 # optimizer_runs=200

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "clean": "forge clean; rimraf index.js dist",
     "doc": "solcco -f doc/MgvDoc.html preprocessing/structs.ts src/MgvLib.sol src/MgvCommon.sol src/MgvHasOffers.sol src/MgvOfferMaking.sol src/MgvOfferTaking.sol src/MgvOfferTakingWithPermit.sol src/MgvGovernable.sol src/MgvView.sol src/MgvAppendix.sol src/AbstractMangrove.sol src/Mangrove.sol",
     "preproc": "ts-node preprocessing/run.ts",
-    "test": "forge test -vvv"
+    "test": "forge test -vvv",
+    "test:memory-intensive": "forge test --match-contract TickTree",
+    "test:fast": "forge test --no-match-contract TickTree -vvv"
   },
   "lint-staged": {
     "*.sol": "forge fmt",

--- a/test/core/ticktree/TickTreeNewOffer.t.sol
+++ b/test/core/ticktree/TickTreeNewOffer.t.sol
@@ -45,6 +45,15 @@ import "mgv_lib/Debug.sol";
 //     1. is empty
 //     2. non-empty
 contract TickTreeNewOfferTest is TickTreeTest {
+  struct NewOfferScenario {
+    TickScenario tickScenario;
+    uint insertionTickListSize;
+  }
+
+  uint[] tickListSizeScenarios = [0, 1, 2];
+  // size of {lower,higher}TickList if the tick is present in the scenario
+  uint[] otherTickListSizeScenarios = [1];
+
   // NB: We ran into this memory issue when running through all test ticks in one test: https://github.com/foundry-rs/foundry/issues/3971
   // We therefore have a test case per ToI instead.
 
@@ -68,27 +77,18 @@ contract TickTreeNewOfferTest is TickTreeTest {
     run_new_offer_scenarios_for_tick(TICK_MAX_ALLOWED);
   }
 
-  struct NewOfferScenario {
-    TickScenario tickScenario;
-    uint insertionTickListSize;
-  }
-
-  uint[] tickListSizeScenarios = [0, 1, 2];
-  // size of {lower,higher}TickList if the tick is present in the scenario
-  uint[] otherTickListSizeScenarios = [1];
-
   function run_new_offer_scenarios_for_tick(Tick tick) internal {
     vm.pauseGasMetering();
-    TickScenario[] memory tickScenarios =
-      generateTickScenarios(tick, otherTickListSizeScenarios, otherTickListSizeScenarios);
-    for (uint i = 0; i < tickScenarios.length; ++i) {
-      TickScenario memory tickScenario = tickScenarios[i];
-      for (uint j = 0; j < tickListSizeScenarios.length; ++j) {
-        uint insertionTickListSize = tickListSizeScenarios[j];
-        run_new_offer_scenario(
-          NewOfferScenario({tickScenario: tickScenario, insertionTickListSize: insertionTickListSize}), false
-        );
-      }
+    runTickScenarios(tick, otherTickListSizeScenarios, otherTickListSizeScenarios);
+    vm.resumeGasMetering();
+  }
+
+  function runTickScenario(TickScenario memory tickScenario) internal override {
+    NewOfferScenario memory scenario;
+    scenario.tickScenario = tickScenario;
+    for (uint j = 0; j < tickListSizeScenarios.length; ++j) {
+      scenario.insertionTickListSize = tickListSizeScenarios[j];
+      run_new_offer_scenario(scenario, false);
     }
     vm.resumeGasMetering();
   }

--- a/test/core/ticktree/TickTreeRetractOffer.t.sol
+++ b/test/core/ticktree/TickTreeRetractOffer.t.sol
@@ -75,21 +75,18 @@ contract TickTreeRetractOfferTest is TickTreeTest {
 
   function run_retract_offer_scenarios_for_tick(Tick tick) internal {
     vm.pauseGasMetering();
-    TickScenario[] memory tickScenarios =
-      generateTickScenarios(tick, otherTickListSizeScenarios, otherTickListSizeScenarios);
-    for (uint i = 0; i < tickScenarios.length; ++i) {
-      TickScenario memory tickScenario = tickScenarios[i];
-      for (uint j = 0; j < tickListScenarios.length; ++j) {
-        uint[2] storage tickListScenario = tickListScenarios[j];
-        run_retract_offer_scenario(
-          RetractOfferScenario({
-            tickScenario: tickScenario,
-            offerTickListSize: tickListScenario[0],
-            offerPos: tickListScenario[1]
-          }),
-          false
-        );
-      }
+    runTickScenarios(tick, otherTickListSizeScenarios, otherTickListSizeScenarios);
+    vm.resumeGasMetering();
+  }
+
+  function runTickScenario(TickScenario memory tickScenario) internal override {
+    RetractOfferScenario memory scenario;
+    scenario.tickScenario = tickScenario;
+    for (uint j = 0; j < tickListScenarios.length; ++j) {
+      uint[2] storage tickListScenario = tickListScenarios[j];
+      scenario.offerTickListSize = tickListScenario[0];
+      scenario.offerPos = tickListScenario[1];
+      run_retract_offer_scenario(scenario, false);
     }
   }
 

--- a/test/core/ticktree/TickTreeUpdateOffer.t.sol
+++ b/test/core/ticktree/TickTreeUpdateOffer.t.sol
@@ -190,46 +190,29 @@ contract TickTreeUpdateOfferTest is TickTreeTest {
     uint[] storage lowerTickListSizeScenarios
   ) internal {
     vm.pauseGasMetering();
-    TickScenario[] memory tickScenarios =
-      generateTickScenarios(tick, higherTickListSizeScenarios, lowerTickListSizeScenarios);
-    for (uint i = 0; i < tickScenarios.length; ++i) {
-      TickScenario memory tickScenario = tickScenarios[i];
-      for (uint j = 0; j < tickListScenarios.length; ++j) {
-        uint[2] storage tickListScenario = tickListScenarios[j];
-        run_update_offer_scenario(
-          UpdateOfferScenario({
-            tickScenario: tickScenario,
-            newTick: tickScenario.tick,
-            offerTickListSize: tickListScenario[0],
-            offerPos: tickListScenario[1]
-          }),
-          false
-        );
-        if (tickScenario.hasHigherTick) {
-          run_update_offer_scenario(
-            UpdateOfferScenario({
-              tickScenario: tickScenario,
-              newTick: tickScenario.higherTick,
-              offerTickListSize: tickListScenario[0],
-              offerPos: tickListScenario[1]
-            }),
-            false
-          );
-        }
-        if (tickScenario.hasLowerTick) {
-          run_update_offer_scenario(
-            UpdateOfferScenario({
-              tickScenario: tickScenario,
-              newTick: tickScenario.lowerTick,
-              offerTickListSize: tickListScenario[0],
-              offerPos: tickListScenario[1]
-            }),
-            false
-          );
-        }
+    runTickScenarios(tick, higherTickListSizeScenarios, lowerTickListSizeScenarios);
+    vm.resumeGasMetering();
+  }
+
+  function runTickScenario(TickScenario memory tickScenario) internal override {
+    UpdateOfferScenario memory scenario;
+    scenario.tickScenario = tickScenario;
+    for (uint j = 0; j < tickListScenarios.length; ++j) {
+      uint[2] storage tickListScenario = tickListScenarios[j];
+      scenario.offerTickListSize = tickListScenario[0];
+      scenario.offerPos = tickListScenario[1];
+
+      scenario.newTick = tickScenario.tick;
+      run_update_offer_scenario(scenario, false);
+      if (tickScenario.hasHigherTick) {
+        scenario.newTick = tickScenario.higherTick;
+        run_update_offer_scenario(scenario, false);
+      }
+      if (tickScenario.hasLowerTick) {
+        scenario.newTick = tickScenario.lowerTick;
+        run_update_offer_scenario(scenario, false);
       }
     }
-    vm.resumeGasMetering();
   }
 
   // This test is useful for debugging a single scneario


### PR DESCRIPTION
## Split CI test execution into "slow" and "memory intensive"
This PR splits test execution into fast and memory intensive tests as the new tick tree tests use too much memory for GitHub Actions when `-vvv` is used.

We therefore split test execution into:
- a fast step with all tests except tick tree tests. These are executed with `-vvv`
- a memory-intensive step that only execute tick tree tests. These are executed without `-vvv`.

Here's a run of the workflow: https://github.com/mangrovedao/mangrove-core/actions/runs/6187116412/job/16796248573

The failing tests are an unrelated rounding issue. However, they prevent the test coverage step from running, so this run does not demonstrate that it works.

This previous run of pretty much the same changes shows the test coverage step still working: https://github.com/mangrovedao/mangrove-core/actions/runs/6185411822/job/16790959799

## Reduced memory usage
Also, memory usage has been reduced in the tick tree tests:
- do not generate all `TickScenario`s in memory, but instead run each scenario when generated
- reuse `*Scenario` structs instead of allocating new ones

While not enough in itself to mitigate the CI issue, this means we no longer have to set a higher memory limit in foundry.toml.