### PR TITLE
tickScale testing analysis and tweaks

### DIFF
--- a/lib/TickLib.sol
+++ b/lib/TickLib.sol
@@ -181,7 +181,8 @@ library TickLib {
     return Tick.unwrap(tick) >= MIN_TICK && Tick.unwrap(tick) <= MAX_TICK;
   }
 
-  function fromLogPrice(int logPrice, uint tickScale) internal pure returns (Tick) {
+  // Returns the closest, lower tick to the given logPrice at the given tickScale
+  function closestLowerTickToLogPrice(int logPrice, uint tickScale) internal pure returns (Tick) {
     // Do not force logPrices to fit the tickScale (aka logPrice%tickScale==0)
     // Round all prices down (aka cheaper for taker)
     int tick = logPrice / int(tickScale);

--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -134,7 +134,7 @@ library OfferPackedExtra {
     }
   }
   function tick(OfferPacked offer, uint tickScale) internal pure returns (Tick) {
-    return TickLib.fromLogPrice(offer.logPrice(),tickScale);
+    return TickLib.closestLowerTickToLogPrice(offer.logPrice(),tickScale);
   }
   function clearFieldsForMaker(OfferPacked offer) internal pure returns (OfferPacked) {
     unchecked {
@@ -158,7 +158,7 @@ library OfferUnpackedExtra {
     }
   }
   function tick(OfferUnpacked memory offer, uint tickScale) internal pure returns (Tick) {
-    return TickLib.fromLogPrice(offer.logPrice,tickScale);
+    return TickLib.closestLowerTickToLogPrice(offer.logPrice,tickScale);
   }
 
 }

--- a/src/MgvOfferMaking.sol
+++ b/src/MgvOfferMaking.sol
@@ -252,7 +252,7 @@ contract MgvOfferMaking is MgvHasOffers {
 
       uint tickScale = ofp.olKey.tickScale;
       // normalize logPrice to tickScale
-      Tick insertionTick = TickLib.fromLogPrice(insertionLogPrice, tickScale);
+      Tick insertionTick = TickLib.closestLowerTickToLogPrice(insertionLogPrice, tickScale);
       insertionLogPrice = LogPriceLib.fromTick(insertionTick, tickScale);
       require(LogPriceLib.inRange(insertionLogPrice), "mgv/writeOffer/logPrice/outOfRange");
 

--- a/src/preprocessed/MgvOffer.post.sol
+++ b/src/preprocessed/MgvOffer.post.sol
@@ -49,7 +49,7 @@ library OfferPackedExtra {
     }
   }
   function tick(OfferPacked offer, uint tickScale) internal pure returns (Tick) {
-    return TickLib.fromLogPrice(offer.logPrice(),tickScale);
+    return TickLib.closestLowerTickToLogPrice(offer.logPrice(),tickScale);
   }
   function clearFieldsForMaker(OfferPacked offer) internal pure returns (OfferPacked) {
     unchecked {
@@ -73,7 +73,7 @@ library OfferUnpackedExtra {
     }
   }
   function tick(OfferUnpacked memory offer, uint tickScale) internal pure returns (Tick) {
-    return TickLib.fromLogPrice(offer.logPrice,tickScale);
+    return TickLib.closestLowerTickToLogPrice(offer.logPrice,tickScale);
   }
 
 }

--- a/test/core/DynamicTicks.t.sol
+++ b/test/core/DynamicTicks.t.sol
@@ -151,8 +151,6 @@ contract DynamicTicksTest is MangroveTest {
     mgv.newOfferByLogPrice(olKey, logPrice, gives, 100_00, 30);
   }
 
-  // FIXME think of more tests
-
   function test_id_is_correct(OLKey memory olKey) public {
     assertEq(olKey.hash(), keccak256(abi.encode(olKey)), "id() is hashing incorrect data");
   }

--- a/test/core/DynamicTicks.t.sol
+++ b/test/core/DynamicTicks.t.sol
@@ -28,7 +28,7 @@ contract DynamicTicksTest is MangroveTest {
 
   function test_tick_to_logPrice(int96 logPrice, uint16 _tickScale) public {
     vm.assume(_tickScale != 0);
-    Tick tick = TickLib.fromLogPrice(logPrice, _tickScale);
+    Tick tick = TickLib.closestLowerTickToLogPrice(logPrice, _tickScale);
     int tickScale = int(uint(_tickScale));
     int expectedTick = logPrice / tickScale;
     if (logPrice < 0 && logPrice % tickScale != 0) {
@@ -53,7 +53,8 @@ contract DynamicTicksTest is MangroveTest {
     logPrice = boundLogPrice(logPrice);
     uint gives = 1 ether;
 
-    int insertionLogPrice = int24(LogPriceLib.fromTick(TickLib.fromLogPrice(logPrice, tickScale), tickScale));
+    int insertionLogPrice =
+      int24(LogPriceLib.fromTick(TickLib.closestLowerTickToLogPrice(logPrice, tickScale), tickScale));
     vm.assume(LogPriceLib.inRange(insertionLogPrice));
     uint wants = LogPriceLib.inboundFromOutbound(insertionLogPrice, gives);
     vm.assume(wants > 0);
@@ -73,7 +74,8 @@ contract DynamicTicksTest is MangroveTest {
     OLKey memory ol2 = OLKey(olKey.outbound, olKey.inbound, tickScale2);
     uint gives = 1 ether;
 
-    int insertionLogPrice = int24(LogPriceLib.fromTick(TickLib.fromLogPrice(logPrice, tickScale), tickScale));
+    int insertionLogPrice =
+      int24(LogPriceLib.fromTick(TickLib.closestLowerTickToLogPrice(logPrice, tickScale), tickScale));
     vm.assume(LogPriceLib.inRange(insertionLogPrice));
     uint wants = LogPriceLib.inboundFromOutbound(insertionLogPrice, gives);
     vm.assume(wants > 0);
@@ -108,14 +110,15 @@ contract DynamicTicksTest is MangroveTest {
     logPrice = boundLogPrice(logPrice);
     vm.assume(tickScale != 0);
     uint gives = 1 ether;
-    int insertionLogPrice = int24(LogPriceLib.fromTick(TickLib.fromLogPrice(logPrice, tickScale), tickScale));
+    int insertionLogPrice =
+      int24(LogPriceLib.fromTick(TickLib.closestLowerTickToLogPrice(logPrice, tickScale), tickScale));
     vm.assume(LogPriceLib.inRange(insertionLogPrice));
     uint wants = LogPriceLib.inboundFromOutbound(insertionLogPrice, gives);
     vm.assume(wants > 0);
     vm.assume(wants <= type(uint96).max);
     mgv.activate(olKey, 0, 100, 0);
     mgv.newOfferByLogPrice(olKey, logPrice, gives, 100_000, 30);
-    Tick tick = TickLib.fromLogPrice(insertionLogPrice, tickScale);
+    Tick tick = TickLib.closestLowerTickToLogPrice(insertionLogPrice, tickScale);
     assertEq(mgv.leafs(olKey, tick.leafIndex()).firstOfferPosition(), tick.posInLeaf(), "wrong pos in leaf");
     assertEq(mgv.level0(olKey, tick.level0Index()).firstOnePosition(), tick.posInLevel0(), "wrong pos in level0");
     assertEq(mgv.level1(olKey, tick.level1Index()).firstOnePosition(), tick.posInLevel1(), "wrong pos in level1");
@@ -154,7 +157,8 @@ contract DynamicTicksTest is MangroveTest {
     vm.assume(tickScale != 0);
     vm.assume(int(logPrice) % int(uint(tickScale)) != 0);
     logPrice = boundLogPrice(logPrice);
-    int insertionLogPrice = int24(LogPriceLib.fromTick(TickLib.fromLogPrice(logPrice, tickScale), tickScale));
+    int insertionLogPrice =
+      int24(LogPriceLib.fromTick(TickLib.closestLowerTickToLogPrice(logPrice, tickScale), tickScale));
     vm.assume(LogPriceLib.inRange(insertionLogPrice));
     olKey.tickScale = tickScale;
     uint wants = LogPriceLib.inboundFromOutbound(insertionLogPrice, 1 ether);

--- a/test/core/DynamicTicks.t.sol
+++ b/test/core/DynamicTicks.t.sol
@@ -55,10 +55,9 @@ contract DynamicTicksTest is MangroveTest {
 
     int insertionLogPrice =
       int24(LogPriceLib.fromTick(TickLib.closestLowerTickToLogPrice(logPrice, tickScale), tickScale));
+
     vm.assume(LogPriceLib.inRange(insertionLogPrice));
-    uint wants = LogPriceLib.inboundFromOutbound(insertionLogPrice, gives);
-    vm.assume(wants > 0);
-    vm.assume(wants <= type(uint96).max);
+
     uint ofr = mgv.newOfferByLogPrice(olKey, logPrice, gives, 100_000, 30);
     assertTrue(mgv.offers(olKey, ofr).isLive(), "ofr created at tickScale but not found there");
     assertFalse(mgv.offers(ol2, ofr).isLive(), "ofr created at tickScale but found at tickScale2");
@@ -78,9 +77,7 @@ contract DynamicTicksTest is MangroveTest {
     int insertionLogPrice =
       int24(LogPriceLib.fromTick(TickLib.closestLowerTickToLogPrice(logPrice, tickScale), tickScale));
     vm.assume(LogPriceLib.inRange(insertionLogPrice));
-    uint wants = LogPriceLib.inboundFromOutbound(insertionLogPrice, gives);
-    vm.assume(wants > 0);
-    vm.assume(wants <= type(uint96).max);
+
     mgv.activate(olKey, 0, 100, 0);
     mgv.activate(ol2, 0, 100, 0);
     uint ofr = mgv.newOfferByLogPrice(ol2, 0, gives, 100_000, 30);
@@ -114,9 +111,7 @@ contract DynamicTicksTest is MangroveTest {
     Tick insertionTick = TickLib.closestLowerTickToLogPrice(logPrice, tickScale);
     int insertionLogPrice = int24(LogPriceLib.fromTick(insertionTick, tickScale));
     vm.assume(LogPriceLib.inRange(insertionLogPrice));
-    uint wants = LogPriceLib.inboundFromOutbound(insertionLogPrice, gives);
-    vm.assume(wants > 0);
-    vm.assume(wants <= type(uint96).max);
+
     mgv.activate(olKey, 0, 100, 0);
     mgv.newOfferByLogPrice(olKey, logPrice, gives, 100_000, 30);
     assertEq(
@@ -142,13 +137,11 @@ contract DynamicTicksTest is MangroveTest {
 
   // creating offer at zero tickScale is impossible
   function test_noOfferAtZeroTickScale(int24 logPrice, uint96 gives) public {
-    // TODO is it really necessary to constraint wants < 96 bits? Or can it go to any size no problem?
-    olKey.tickScale = 0;
+    vm.assume(gives > 0);
     logPrice = boundLogPrice(logPrice);
+    olKey.tickScale = 0;
     mgv.activate(olKey, 0, 100, 0);
-    uint wants = LogPriceLib.inboundFromOutbound(logPrice, gives);
-    vm.assume(wants > 0);
-    vm.assume(wants <= type(uint96).max);
+
     vm.expectRevert(stdError.divisionError);
     mgv.newOfferByLogPrice(olKey, logPrice, gives, 100_00, 30);
   }
@@ -175,9 +168,7 @@ contract DynamicTicksTest is MangroveTest {
     int insertionLogPrice = int24(LogPriceLib.fromTick(insertionTick, tickScale));
     vm.assume(LogPriceLib.inRange(insertionLogPrice));
     olKey.tickScale = tickScale;
-    uint wants = LogPriceLib.inboundFromOutbound(insertionLogPrice, 1 ether);
-    vm.assume(wants > 0);
-    vm.assume(wants <= type(uint96).max);
+
     mgv.activate(olKey, 0, 100, 0);
     uint id = mgv.newOfferByLogPrice(olKey, logPrice, 1 ether, 100_00, 30);
     assertEq(mgv.offers(olKey, id).logPrice(), insertionLogPrice, "recorded logPrice does not match closest lower tick");

--- a/test/core/DynamicTicks.t.sol
+++ b/test/core/DynamicTicks.t.sol
@@ -164,7 +164,7 @@ contract DynamicTicksTest is MangroveTest {
     assertEq(flipped.tickScale, olKey.tickScale, "flipped() is incorrect");
   }
 
-  // logPrice given by taker is normalized and aligned to chosen tickScale
+  // logPrice given by maker is normalized and aligned to chosen tickScale
   function test_insertionLogPrice_normalization(int24 logPrice, uint16 tickScale) public {
     vm.assume(tickScale != 0);
     vm.assume(int(logPrice) % int(uint(tickScale)) != 0);

--- a/test/core/DynamicTicks.t.sol
+++ b/test/core/DynamicTicks.t.sol
@@ -137,7 +137,7 @@ contract DynamicTicksTest is MangroveTest {
       insertionTick.posInLevel2(),
       "wrong pos in level2"
     );
-    assertEq(mgv.level3(olKey).firstOnePosition(), insertionTick.posInLevel3(), "wrong pos in level2");
+    assertEq(mgv.level3(olKey).firstOnePosition(), insertionTick.posInLevel3(), "wrong pos in level3");
   }
 
   // creating offer at zero tickScale is impossible


### PR DESCRIPTION
Reviewed the tests involving tick scale and tweaked them a bit.

## Analysis
The only thing that's actually interesting to test re. tick scale is the `logPrice -> tick` conversion that happens when makers post or update offers: There's potentially a rounding since the logPrice might not be representable and that rounding has to make sense; more on this below.

For takers, the logPrice is compared directly to offer prices, so tick scale isn't relevant nor used.

Internally, Mangrove only ever works with ticks and logPrices in 1-to-1 correspondence with ticks at the given tick scale. These conversions are trivial and lossless.

The range of supported logPrices is independent of tick scale, since (1) LogPriceLib math is what limits this range and (2) for all tick scales, `TickLib.fromLogPrice({MIN,MAX}_LOG_PRICE, tickScale)` fits in the tick tree.

All of this was already tested, so this PR only makes smaller adjustments and fixes to the already existing tests.


## A note on `logPrice -> tick` conversion for makers
`tickScale` limits the `logPrice`s that can be represented, that's the whole point of having different tick sizes. Makers should ensure to post offers a representable `logPrice`, but the API allows any `logPrice`. We therefore have three options if a makers specifies a `logPrice` that doesn't align with a tick:

1. Revert
2. Post the offer at the closest, lower tick, ie at a lower price
3. Post the offer at the closest, higher tick, ie at a higher price.

Mangrove currently does option 2, ie posts the makers offer at a better price than specified. It's not clear to me that this is desirable over reverting or option 3?

Whichever of the three options we end up with, it should be very clear in the `MgvOfferMaking` code. This wasn't the case before, where the choice was implemented in a function called `TickLib.fromLogPrice(logPrice, tickScale)`. This PR therefore renames that function to `closestLowerTickToLogPrice`.