### PR TITLE
feat: Post offers at nearest, higher tick for unaligned logPrices

### DIFF
--- a/lib/TickLib.sol
+++ b/lib/TickLib.sol
@@ -181,15 +181,21 @@ library TickLib {
     return Tick.unwrap(tick) >= MIN_TICK && Tick.unwrap(tick) <= MAX_TICK;
   }
 
-  // Returns the closest, lower tick to the given logPrice at the given tickScale
-  function closestLowerTickToLogPrice(int logPrice, uint tickScale) internal pure returns (Tick) {
+  // Returns the nearest, higher tick to the given logPrice at the given tickScale
+  function nearestHigherTickToLogPrice(int logPrice, uint tickScale) internal pure returns (Tick) {
     // Do not force logPrices to fit the tickScale (aka logPrice%tickScale==0)
-    // Round all prices down (aka cheaper for taker)
+    // Round maker prices up such that maker is always paid at least what they asked for
     int tick = logPrice / int(tickScale);
-    if (logPrice < 0 && logPrice % int(tickScale) != 0) {
-      tick = tick - 1;
+    if (logPrice > 0 && logPrice % int(tickScale) != 0) {
+      tick = tick + 1;
     }
     return Tick.wrap(tick);
+  }
+
+  // Optimized conversion for logPrices that are known to map exactly to a tick at the given tickScale,
+  // eg for offers in the offer list which are always written with a tick-aligned logPrice
+  function fromTickAlignedLogPrice(int logPrice, uint tickScale) internal pure returns (Tick) {
+    return Tick.wrap(logPrice / int(tickScale));
   }
 
   function tickFromBranch(uint tickPosInLeaf,Field level0, Field level1, Field level2, Field level3) internal pure returns (Tick) {

--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -134,7 +134,8 @@ library OfferPackedExtra {
     }
   }
   function tick(OfferPacked offer, uint tickScale) internal pure returns (Tick) {
-    return TickLib.closestLowerTickToLogPrice(offer.logPrice(),tickScale);
+    // Offers are always stored with a logPrice that corresponds exactly to a tick
+    return TickLib.fromTickAlignedLogPrice(offer.logPrice(), tickScale);
   }
   function clearFieldsForMaker(OfferPacked offer) internal pure returns (OfferPacked) {
     unchecked {
@@ -158,7 +159,8 @@ library OfferUnpackedExtra {
     }
   }
   function tick(OfferUnpacked memory offer, uint tickScale) internal pure returns (Tick) {
-    return TickLib.closestLowerTickToLogPrice(offer.logPrice,tickScale);
+    // Offers are always stored with a logPrice that corresponds exactly to a tick
+    return TickLib.fromTickAlignedLogPrice(offer.logPrice, tickScale);
   }
 
 }

--- a/src/MgvOfferMaking.sol
+++ b/src/MgvOfferMaking.sol
@@ -252,7 +252,7 @@ contract MgvOfferMaking is MgvHasOffers {
 
       uint tickScale = ofp.olKey.tickScale;
       // normalize logPrice to tickScale
-      Tick insertionTick = TickLib.closestLowerTickToLogPrice(insertionLogPrice, tickScale);
+      Tick insertionTick = TickLib.nearestHigherTickToLogPrice(insertionLogPrice, tickScale);
       insertionLogPrice = LogPriceLib.fromTick(insertionTick, tickScale);
       require(LogPriceLib.inRange(insertionLogPrice), "mgv/writeOffer/logPrice/outOfRange");
 

--- a/src/preprocessed/MgvOffer.post.sol
+++ b/src/preprocessed/MgvOffer.post.sol
@@ -49,7 +49,8 @@ library OfferPackedExtra {
     }
   }
   function tick(OfferPacked offer, uint tickScale) internal pure returns (Tick) {
-    return TickLib.closestLowerTickToLogPrice(offer.logPrice(),tickScale);
+    // Offers are always stored with a logPrice that corresponds exactly to a tick
+    return TickLib.fromTickAlignedLogPrice(offer.logPrice(), tickScale);
   }
   function clearFieldsForMaker(OfferPacked offer) internal pure returns (OfferPacked) {
     unchecked {
@@ -73,7 +74,8 @@ library OfferUnpackedExtra {
     }
   }
   function tick(OfferUnpacked memory offer, uint tickScale) internal pure returns (Tick) {
-    return TickLib.closestLowerTickToLogPrice(offer.logPrice,tickScale);
+    // Offers are always stored with a logPrice that corresponds exactly to a tick
+    return TickLib.fromTickAlignedLogPrice(offer.logPrice, tickScale);
   }
 
 }

--- a/test/core/DynamicTicks.t.sol
+++ b/test/core/DynamicTicks.t.sol
@@ -27,7 +27,7 @@ contract DynamicTicksTest is MangroveTest {
     assertEq(LogPriceLib.fromTick(tick, tickScale), int(_tick) * int(uint(tickScale)), "wrong tick -> logPrice");
   }
 
-  function test_logPrice_to_tick(int96 logPrice, uint16 _tickScale) public {
+  function test_logPrice_to_nearest_tick(int96 logPrice, uint16 _tickScale) public {
     vm.assume(_tickScale != 0);
     Tick tick = TickLib.nearestHigherTickToLogPrice(logPrice, _tickScale);
     assertGe(
@@ -40,6 +40,15 @@ contract DynamicTicksTest is MangroveTest {
       expectedTick = expectedTick + 1;
     }
     assertEq(Tick.unwrap(tick), expectedTick, "wrong logPrice -> tick");
+  }
+
+  function test_aligned_logPrice_to_tick(int96 logPrice, uint _tickScale) public {
+    vm.assume(_tickScale != 0);
+    vm.assume(logPrice % int(uint(_tickScale)) == 0);
+    Tick tick = TickLib.fromTickAlignedLogPrice(logPrice, _tickScale);
+    assertEq(
+      LogPriceLib.fromTick(tick, _tickScale), logPrice, "aligned logPrice -> tick -> logPrice must give same logPrice"
+    );
   }
 
   // get a valid logPrice from a random int24

--- a/test/core/DynamicTicks.t.sol
+++ b/test/core/DynamicTicks.t.sol
@@ -29,15 +29,15 @@ contract DynamicTicksTest is MangroveTest {
 
   function test_logPrice_to_tick(int96 logPrice, uint16 _tickScale) public {
     vm.assume(_tickScale != 0);
-    Tick tick = TickLib.closestLowerTickToLogPrice(logPrice, _tickScale);
-    assertLe(
+    Tick tick = TickLib.nearestHigherTickToLogPrice(logPrice, _tickScale);
+    assertGe(
       LogPriceLib.fromTick(tick, _tickScale), logPrice, "logPrice -> tick -> logPrice must give same or lower logPrice"
     );
 
     int tickScale = int(uint(_tickScale));
     int expectedTick = logPrice / tickScale;
-    if (logPrice < 0 && logPrice % tickScale != 0) {
-      expectedTick = expectedTick - 1;
+    if (logPrice > 0 && logPrice % tickScale != 0) {
+      expectedTick = expectedTick + 1;
     }
     assertEq(Tick.unwrap(tick), expectedTick, "wrong logPrice -> tick");
   }
@@ -59,7 +59,7 @@ contract DynamicTicksTest is MangroveTest {
     uint gives = 1 ether;
 
     int insertionLogPrice =
-      int24(LogPriceLib.fromTick(TickLib.closestLowerTickToLogPrice(logPrice, tickScale), tickScale));
+      int24(LogPriceLib.fromTick(TickLib.nearestHigherTickToLogPrice(logPrice, tickScale), tickScale));
 
     vm.assume(LogPriceLib.inRange(insertionLogPrice));
 
@@ -80,7 +80,7 @@ contract DynamicTicksTest is MangroveTest {
     uint gives = 1 ether;
 
     int insertionLogPrice =
-      int24(LogPriceLib.fromTick(TickLib.closestLowerTickToLogPrice(logPrice, tickScale), tickScale));
+      int24(LogPriceLib.fromTick(TickLib.nearestHigherTickToLogPrice(logPrice, tickScale), tickScale));
     vm.assume(LogPriceLib.inRange(insertionLogPrice));
 
     mgv.activate(olKey, 0, 100, 0);
@@ -113,7 +113,7 @@ contract DynamicTicksTest is MangroveTest {
     logPrice = boundLogPrice(logPrice);
     vm.assume(tickScale != 0);
     uint gives = 1 ether;
-    Tick insertionTick = TickLib.closestLowerTickToLogPrice(logPrice, tickScale);
+    Tick insertionTick = TickLib.nearestHigherTickToLogPrice(logPrice, tickScale);
     int insertionLogPrice = int24(LogPriceLib.fromTick(insertionTick, tickScale));
     vm.assume(LogPriceLib.inRange(insertionLogPrice));
 
@@ -167,14 +167,14 @@ contract DynamicTicksTest is MangroveTest {
     vm.assume(tickScale != 0);
     vm.assume(int(logPrice) % int(uint(tickScale)) != 0);
     logPrice = boundLogPrice(logPrice);
-    Tick insertionTick = TickLib.closestLowerTickToLogPrice(logPrice, tickScale);
+    Tick insertionTick = TickLib.nearestHigherTickToLogPrice(logPrice, tickScale);
     int insertionLogPrice = int24(LogPriceLib.fromTick(insertionTick, tickScale));
     vm.assume(LogPriceLib.inRange(insertionLogPrice));
     olKey.tickScale = tickScale;
 
     mgv.activate(olKey, 0, 100, 0);
     uint id = mgv.newOfferByLogPrice(olKey, logPrice, 1 ether, 100_00, 30);
-    assertEq(mgv.offers(olKey, id).logPrice(), insertionLogPrice, "recorded logPrice does not match closest lower tick");
+    assertEq(mgv.offers(olKey, id).logPrice(), insertionLogPrice, "recorded logPrice does not match nearest lower tick");
     assertEq(
       int(mgv.offers(olKey, id).logPrice()) % int(uint(tickScale)),
       0,


### PR DESCRIPTION
The maker API admits (log)Prices that do not correspond exactly to a tick. Frontends and other intermediaries should ensure offers aren't posted at such prices, but we cannot ensure this. So either the maker API should revert if given such an unaligned logPrice or the offer should be posted at either the nearest higher or lower tick.

We think that some integrations will be easier if the API is permissive and allows unaligned logPrices, so we opt for choosing one of the nearest ticks.

Previously, the nearest, lower tick was chosen when adding the offer to the book. This meant that makers would sell at a lower price than what they specified which seems wrong.

This PR therefore changes the maker API such that offers are posted at the nearest, higher tick when given an unaligned logPrice.

Also, this PR optimizes the conversion of offer logPrices to ticks, exploiting that offers are always stored with a tick-aligned logPrice.