### PR TITLE
optimize ctz

### DIFF
--- a/lib/Constants.sol
+++ b/lib/Constants.sol
@@ -14,6 +14,7 @@ int constant MAX_TICK = -MIN_TICK-1;
 // sizes must match field sizes in structs.ts where relevant
 uint constant TICK_BITS = 24;
 uint constant OFFER_BITS = 32;
+uint constant MAX_LEVEL_SIZE = 64; // Constraint given by BitLib.ctz64
 
 // only power-of-two sizes are supported for LEAF_SIZE and LEVEL*_SIZE
 uint constant LEAF_SIZE_BITS = 2; 

--- a/lib/TickLib.sol
+++ b/lib/TickLib.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.17;
 import "mgv_lib/Constants.sol";
 import {BitLib} from "mgv_lib/BitLib.sol";
 import {console2 as csf} from "forge-std/console2.sol";
+import {LocalPacked} from "mgv_src/preprocessed/MgvLocal.post.sol";
 
 type Leaf is uint;
 type DirtyLeaf is uint;
@@ -198,13 +199,23 @@ library TickLib {
     return Tick.wrap(logPrice / int(tickScale));
   }
 
+  // Utility for tests&unpacked structs, less gas-optimal
+  // Must not be called with any of level0, level1, level2 or level3 empty
   function tickFromBranch(uint tickPosInLeaf,Field level0, Field level1, Field level2, Field level3) internal pure returns (Tick) {
+    LocalPacked local;
+    local = local.tickPosInLeaf(tickPosInLeaf).level0(level0).level1(level1).level2(level2).level3(level3);
+    return tickFromLocal(local);
+  }
+
+  // Must not be called with a local that has any of level0, level1, level2 or level3 empty
+  function tickFromLocal(LocalPacked local) internal pure returns (Tick) {
     unchecked {
-      uint utick = tickPosInLeaf |
-        ((BitLib.ctz(Field.unwrap(level0)) |
-          (BitLib.ctz(Field.unwrap(level1)) |
-            (BitLib.ctz(Field.unwrap(level2)) |
-              uint((int(BitLib.ctz(Field.unwrap(level3)))-LEVEL3_SIZE/2) << LEVEL2_SIZE_BITS)) 
+      uint utick = local.tickPosInLeaf() |
+        ((BitLib.ctz64(Field.unwrap(local.level0())) |
+          (BitLib.ctz64(Field.unwrap(local.level1())) |
+            (BitLib.ctz64(Field.unwrap(local.level2())) |
+              uint(
+                (int(BitLib.ctz64(Field.unwrap(local.level3())))-LEVEL3_SIZE/2) << LEVEL2_SIZE_BITS)) 
               << LEVEL1_SIZE_BITS)
             << LEVEL0_SIZE_BITS)
           << LEAF_SIZE_BITS);
@@ -420,7 +431,7 @@ library FieldLib {
     // FIXME stop checking for 0 or integrate it into ctz function in assembly
     require(!field.isEmpty(),"field is 0");
     unchecked {
-      return BitLib.ctz(Field.unwrap(field));
+      return BitLib.ctz64(Field.unwrap(field));
     }
   }
 

--- a/lib/TickLib.sol
+++ b/lib/TickLib.sol
@@ -129,9 +129,8 @@ library LeafLib {
     return uint(raw << (OFFER_BITS * ((index * 2) + 1)) >> (256 - OFFER_BITS));
   }
 
-  // TODO optimize with a hashmap, or:
-  // if > half: +=1; if += quarter: +=1, or:
-  // or nested if dichotomy
+  // Will check for the first position (0,1,2 or 3) that has a nonzero first-of-tick or a nonzero last-of-tick offer. Leafs where only one of those is nonzero are invalid anyway.
+  // Offers are ordered msb to lsb
   function firstOfferPosition(Leaf leaf) internal pure returns (uint ret) {
     uint offerId = Leaf.unwrap(leaf) >> (OFFER_BITS * 7);
     if (offerId != 0) {
@@ -201,14 +200,15 @@ library TickLib {
 
   // Utility for tests&unpacked structs, less gas-optimal
   // Must not be called with any of level0, level1, level2 or level3 empty
-  function tickFromBranch(uint tickPosInLeaf,Field level0, Field level1, Field level2, Field level3) internal pure returns (Tick) {
-    LocalPacked local;
-    local = local.tickPosInLeaf(tickPosInLeaf).level0(level0).level1(level1).level2(level2).level3(level3);
-    return tickFromLocal(local);
+  function bestTickFromBranch(uint tickPosInLeaf,Field level0, Field level1, Field level2, Field level3) internal pure returns (Tick) {
+    unchecked {
+      LocalPacked local;
+      local = local.tickPosInLeaf(tickPosInLeaf).level0(level0).level1(level1).level2(level2).level3(level3);
+      return bestTickFromLocal(local);
+    }
   }
 
-  // Must not be called with a local that has any of level0, level1, level2 or level3 empty
-  function tickFromLocal(LocalPacked local) internal pure returns (Tick) {
+  function bestTickFromLocal(LocalPacked local) internal pure returns (Tick) {
     unchecked {
       uint utick = local.tickPosInLeaf() |
         ((BitLib.ctz64(Field.unwrap(local.level0())) |

--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -324,7 +324,7 @@ library LocalPackedExtra {
     return local.kilo_offer_gasbase(val/1e3);
   }}
   function bestTick(LocalPacked local) internal pure returns (Tick) {
-    return TickLib.tickFromLocal(local);
+    return TickLib.bestTickFromLocal(local);
   }
   function clearFieldsForMaker(LocalPacked local) internal pure returns (LocalPacked) {
     unchecked {
@@ -346,7 +346,7 @@ library LocalUnpackedExtra {
     local.kilo_offer_gasbase = val/1e3;
   }}
   function bestTick(LocalUnpacked memory local) internal pure returns (Tick) {
-    return TickLib.tickFromBranch(local.tickPosInLeaf,local.level0,local.level1,local.level2,local.level3);
+    return TickLib.bestTickFromBranch(local.tickPosInLeaf,local.level0,local.level1,local.level2,local.level3);
   }
 }
 `,

--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -324,7 +324,7 @@ library LocalPackedExtra {
     return local.kilo_offer_gasbase(val/1e3);
   }}
   function bestTick(LocalPacked local) internal pure returns (Tick) {
-    return TickLib.tickFromBranch(local.tickPosInLeaf(),local.level0(),local.level1(),local.level2(),local.level3());
+    return TickLib.tickFromLocal(local);
   }
   function clearFieldsForMaker(LocalPacked local) internal pure returns (LocalPacked) {
     unchecked {

--- a/src/preprocessed/MgvLocal.post.sol
+++ b/src/preprocessed/MgvLocal.post.sol
@@ -54,7 +54,7 @@ library LocalPackedExtra {
     return local.kilo_offer_gasbase(val/1e3);
   }}
   function bestTick(LocalPacked local) internal pure returns (Tick) {
-    return TickLib.tickFromBranch(local.tickPosInLeaf(),local.level0(),local.level1(),local.level2(),local.level3());
+    return TickLib.tickFromLocal(local);
   }
   function clearFieldsForMaker(LocalPacked local) internal pure returns (LocalPacked) {
     unchecked {

--- a/src/preprocessed/MgvLocal.post.sol
+++ b/src/preprocessed/MgvLocal.post.sol
@@ -54,7 +54,7 @@ library LocalPackedExtra {
     return local.kilo_offer_gasbase(val/1e3);
   }}
   function bestTick(LocalPacked local) internal pure returns (Tick) {
-    return TickLib.tickFromLocal(local);
+    return TickLib.bestTickFromLocal(local);
   }
   function clearFieldsForMaker(LocalPacked local) internal pure returns (LocalPacked) {
     unchecked {
@@ -76,7 +76,7 @@ library LocalUnpackedExtra {
     local.kilo_offer_gasbase = val/1e3;
   }}
   function bestTick(LocalUnpacked memory local) internal pure returns (Tick) {
-    return TickLib.tickFromBranch(local.tickPosInLeaf,local.level0,local.level1,local.level2,local.level3);
+    return TickLib.bestTickFromBranch(local.tickPosInLeaf,local.level0,local.level1,local.level2,local.level3);
   }
 }
 

--- a/test/core/Leaf.t.sol
+++ b/test/core/Leaf.t.sol
@@ -473,8 +473,12 @@ contract FieldTest is Test {
   // Some BitLib.ctz64 relies on specific level sizes
   function test_level_sizes() public {
     assertLe(LEVEL3_SIZE, int(MAX_LEVEL_SIZE), "bad level3 size");
+    assertGt(LEVEL3_SIZE, 0);
     assertLe(LEVEL2_SIZE, int(MAX_LEVEL_SIZE), "bad level2 size");
+    assertGt(LEVEL2_SIZE, 0);
     assertLe(LEVEL1_SIZE, int(MAX_LEVEL_SIZE), "bad level1 size");
+    assertGt(LEVEL1_SIZE, 0);
     assertLe(LEVEL0_SIZE, int(MAX_LEVEL_SIZE), "bad level0 size");
+    assertGt(LEVEL0_SIZE, 0);
   }
 }

--- a/test/core/Leaf.t.sol
+++ b/test/core/Leaf.t.sol
@@ -286,12 +286,18 @@ contract TickTest is Test {
     Field level1 = Field.wrap(bound(_level1, 1, uint(LEVEL1_SIZE) - 1));
     Field level2 = Field.wrap(bound(_level2, 1, uint(LEVEL2_SIZE) - 1));
     Field level3 = Field.wrap(bound(_level3, 1, uint(LEVEL3_SIZE) - 1));
-    Tick tick = TickLib.tickFromBranch(tickPosInLeaf, level0, level1, level2, level3);
+    MgvStructs.LocalPacked local;
+    local = local.tickPosInLeaf(tickPosInLeaf);
+    local = local.level0(level0);
+    local = local.level1(level1);
+    local = local.level2(level2);
+    local = local.level3(level3);
+    Tick tick = TickLib.tickFromLocal(local);
     assertEq(tick.posInLeaf(), tickPosInLeaf, "wrong pos in leaf");
-    assertEq(tick.posInLevel0(), BitLib.ctz(Field.unwrap(level0)), "wrong pos in level0");
-    assertEq(tick.posInLevel1(), BitLib.ctz(Field.unwrap(level1)), "wrong pos in level1");
-    assertEq(tick.posInLevel2(), BitLib.ctz(Field.unwrap(level2)), "wrong pos in level2");
-    assertEq(tick.posInLevel3(), BitLib.ctz(Field.unwrap(level3)), "wrong pos in level3");
+    assertEq(tick.posInLevel0(), BitLib.ctz64(Field.unwrap(level0)), "wrong pos in level0");
+    assertEq(tick.posInLevel1(), BitLib.ctz64(Field.unwrap(level1)), "wrong pos in level1");
+    assertEq(tick.posInLevel2(), BitLib.ctz64(Field.unwrap(level2)), "wrong pos in level2");
+    assertEq(tick.posInLevel3(), BitLib.ctz64(Field.unwrap(level3)), "wrong pos in level3");
   }
 
   // HELPER FUNCTIONS
@@ -351,7 +357,7 @@ contract FieldTest is Test {
     for (; i < 256; i++) {
       if (uint(b >> i) % 2 == 1) break;
     }
-    assertFirstOnePosition(uint(b), i);
+    assertFirstOnePosition(uint(b), i > MAX_LEVEL_SIZE ? MAX_LEVEL_SIZE : i);
   }
 
   function assertFirstOnePosition(uint field, uint pos) internal {
@@ -462,5 +468,13 @@ contract FieldTest is Test {
 
   function field_isDirty(DirtyField field) public {
     assertEq(field.isDirty(), DirtyField.unwrap(field) & TOPBIT == TOPBIT);
+  }
+
+  // Some BitLib.ctz64 relies on specific level sizes
+  function test_level_sizes() public {
+    assertLe(LEVEL3_SIZE, int(MAX_LEVEL_SIZE), "bad level3 size");
+    assertLe(LEVEL2_SIZE, int(MAX_LEVEL_SIZE), "bad level2 size");
+    assertLe(LEVEL1_SIZE, int(MAX_LEVEL_SIZE), "bad level1 size");
+    assertLe(LEVEL0_SIZE, int(MAX_LEVEL_SIZE), "bad level0 size");
   }
 }

--- a/test/core/Leaf.t.sol
+++ b/test/core/Leaf.t.sol
@@ -292,7 +292,7 @@ contract TickTest is Test {
     local = local.level1(level1);
     local = local.level2(level2);
     local = local.level3(level3);
-    Tick tick = TickLib.tickFromLocal(local);
+    Tick tick = TickLib.bestTickFromLocal(local);
     assertEq(tick.posInLeaf(), tickPosInLeaf, "wrong pos in leaf");
     assertEq(tick.posInLevel0(), BitLib.ctz64(Field.unwrap(level0)), "wrong pos in level0");
     assertEq(tick.posInLevel1(), BitLib.ctz64(Field.unwrap(level1)), "wrong pos in level1");

--- a/test/core/Leaf.t.sol
+++ b/test/core/Leaf.t.sol
@@ -274,7 +274,7 @@ contract TickTest is Test {
     assertEq(Tick.wrap(tick).level1Index(), index);
   }
 
-  function test_bestTickFromBranch_matches_positions_accessor(
+  function test_tickFromBranch_matches_positions_accessor(
     uint tickPosInLeaf,
     uint _level0,
     uint _level1,

--- a/test/core/Leaf.t.sol
+++ b/test/core/Leaf.t.sol
@@ -274,7 +274,7 @@ contract TickTest is Test {
     assertEq(Tick.wrap(tick).level1Index(), index);
   }
 
-  function test_tickFromBranch_matches_positions_accessor(
+  function test_bestTickFromBranch_matches_positions_accessor(
     uint tickPosInLeaf,
     uint _level0,
     uint _level1,

--- a/test/core/gas/MarketOrderOtherOfferList.t.sol
+++ b/test/core/gas/MarketOrderOtherOfferList.t.sol
@@ -234,7 +234,7 @@ contract ExternalMarketOrderOtherOfferList_WithMultipleOffersAtManyTicks is Tick
     mgv.marketOrderByLogPrice(_olKey, _logPrice, 2 ** 96, false);
     gas_();
     (, MgvStructs.LocalPacked local) = mgv.config(_olKey);
-    // In some tests the market order takes all offers, in others not
+    // In some tests the market order takes all offers, in others not. `local.bestTick()` must only be called when the book is non-empty
     if (!local.level3().isEmpty()) {
       assertLt(_logPrice, LogPriceLib.fromTick(local.bestTick(), _olKey.tickScale));
     }

--- a/test/core/gas/MarketOrderOtherOfferList.t.sol
+++ b/test/core/gas/MarketOrderOtherOfferList.t.sol
@@ -234,6 +234,9 @@ contract ExternalMarketOrderOtherOfferList_WithMultipleOffersAtManyTicks is Tick
     mgv.marketOrderByLogPrice(_olKey, _logPrice, 2 ** 96, false);
     gas_();
     (, MgvStructs.LocalPacked local) = mgv.config(_olKey);
-    assertLt(_logPrice, LogPriceLib.fromTick(local.bestTick(), _olKey.tickScale));
+    // In some tests the market order takes all offers, in others not
+    if (!local.level3().isEmpty()) {
+      assertLt(_logPrice, LogPriceLib.fromTick(local.bestTick(), _olKey.tickScale));
+    }
   }
 }

--- a/test/core/ticktree/TickTreeTest.t.sol
+++ b/test/core/ticktree/TickTreeTest.t.sol
@@ -70,17 +70,17 @@ abstract contract TickTreeTest is MangroveTest {
   // We use this tick to test the case where the tick is at the max position in all levels except level3:
   // Max in all positions isn't supported by (log)price math.
   Tick immutable TICK_MIN_L3_MAX_OTHERS =
-    TickTreeUtil.tickFromBranch(MIN_LEVEL3_POS, MAX_LEVEL2_POS, MAX_LEVEL1_POS, MAX_LEVEL0_POS, MAX_LEAF_POS);
+    TickTreeUtil.bestTickFromBranch(MIN_LEVEL3_POS, MAX_LEVEL2_POS, MAX_LEVEL1_POS, MAX_LEVEL0_POS, MAX_LEAF_POS);
 
   // max L3, min L2-0, min leaf
   // We use this tick to test the case where the tick is at the min position in all levels except level3:
   // Min in all positions isn't supported by (log)price math.
   Tick immutable TICK_MAX_L3_MIN_OTHERS =
-    TickTreeUtil.tickFromBranch(MAX_LEVEL3_POS, MIN_LEVEL2_POS, MIN_LEVEL1_POS, MIN_LEVEL0_POS, MIN_LEAF_POS);
+    TickTreeUtil.bestTickFromBranch(MAX_LEVEL3_POS, MIN_LEVEL2_POS, MIN_LEVEL1_POS, MIN_LEVEL0_POS, MIN_LEAF_POS);
 
   // middle L3-0, middle leaf
   Tick immutable TICK_MIDDLE =
-    TickTreeUtil.tickFromBranch(MID_LEVEL3_POS, MID_LEVEL2_POS, MID_LEVEL1_POS, MID_LEVEL0_POS, MID_LEAF_POS);
+    TickTreeUtil.bestTickFromBranch(MID_LEVEL3_POS, MID_LEVEL2_POS, MID_LEVEL1_POS, MID_LEVEL0_POS, MID_LEAF_POS);
 
   // min tick allowed by (log)price math
   Tick immutable TICK_MIN_ALLOWED = Tick.wrap(MIN_TICK_ALLOWED);
@@ -140,7 +140,7 @@ abstract contract TickTreeTest is MangroveTest {
     Tick[] memory ticks = new Tick[](10);
     if (tick.posInLeaf() < MAX_LEAF_POS) {
       // higher leaf position
-      ticks[next++] = TickTreeUtil.tickFromBranch(
+      ticks[next++] = TickTreeUtil.bestTickFromBranch(
         tick.posInLevel3(), tick.posInLevel2(), tick.posInLevel1(), tick.posInLevel0(), tick.posInLeaf() + 1
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -149,7 +149,7 @@ abstract contract TickTreeTest is MangroveTest {
     }
     if (tick.posInLevel0() < MAX_LEVEL0_POS) {
       // higher level0 position
-      ticks[next++] = TickTreeUtil.tickFromBranch(
+      ticks[next++] = TickTreeUtil.bestTickFromBranch(
         tick.posInLevel3(), tick.posInLevel2(), tick.posInLevel1(), tick.posInLevel0() + 1, tick.posInLeaf()
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -158,7 +158,7 @@ abstract contract TickTreeTest is MangroveTest {
     }
     if (tick.posInLevel1() < MAX_LEVEL1_POS) {
       // higher level1 position
-      ticks[next++] = TickTreeUtil.tickFromBranch(
+      ticks[next++] = TickTreeUtil.bestTickFromBranch(
         tick.posInLevel3(), tick.posInLevel2(), tick.posInLevel1() + 1, tick.posInLevel0(), tick.posInLeaf()
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -167,7 +167,7 @@ abstract contract TickTreeTest is MangroveTest {
     }
     if (tick.posInLevel2() < MAX_LEVEL2_POS) {
       // higher level2 position
-      ticks[next++] = TickTreeUtil.tickFromBranch(
+      ticks[next++] = TickTreeUtil.bestTickFromBranch(
         tick.posInLevel3(), tick.posInLevel2() + 1, tick.posInLevel1(), tick.posInLevel0(), tick.posInLeaf()
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -178,7 +178,7 @@ abstract contract TickTreeTest is MangroveTest {
       // higher level3 position
       // Choosing MIN POSITION for level2, level1, level0, leaf to avoid hitting logPrice limits.
       // The important thing is to have a higher position in level3.
-      ticks[next++] = TickTreeUtil.tickFromBranch(tick.posInLevel3() + 1, 0, 0, 0, 0);
+      ticks[next++] = TickTreeUtil.bestTickFromBranch(tick.posInLevel3() + 1, 0, 0, 0, 0);
       if (!isAllowedByPriceMath(ticks[next - 1])) {
         next--;
       }
@@ -196,7 +196,7 @@ abstract contract TickTreeTest is MangroveTest {
     Tick[] memory ticks = new Tick[](10);
     if (tick.posInLeaf() > 0) {
       // lower leaf position
-      ticks[next++] = TickTreeUtil.tickFromBranch(
+      ticks[next++] = TickTreeUtil.bestTickFromBranch(
         tick.posInLevel3(), tick.posInLevel2(), tick.posInLevel1(), tick.posInLevel0(), tick.posInLeaf() - 1
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -205,7 +205,7 @@ abstract contract TickTreeTest is MangroveTest {
     }
     if (tick.posInLevel0() > 0) {
       // lower level0 position
-      ticks[next++] = TickTreeUtil.tickFromBranch(
+      ticks[next++] = TickTreeUtil.bestTickFromBranch(
         tick.posInLevel3(), tick.posInLevel2(), tick.posInLevel1(), tick.posInLevel0() - 1, tick.posInLeaf()
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -214,7 +214,7 @@ abstract contract TickTreeTest is MangroveTest {
     }
     if (tick.posInLevel1() > 0) {
       // lower level1 position
-      ticks[next++] = TickTreeUtil.tickFromBranch(
+      ticks[next++] = TickTreeUtil.bestTickFromBranch(
         tick.posInLevel3(), tick.posInLevel2(), tick.posInLevel1() - 1, tick.posInLevel0(), tick.posInLeaf()
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -223,7 +223,7 @@ abstract contract TickTreeTest is MangroveTest {
     }
     if (tick.posInLevel2() > 0) {
       // lower level2 position
-      ticks[next++] = TickTreeUtil.tickFromBranch(
+      ticks[next++] = TickTreeUtil.bestTickFromBranch(
         tick.posInLevel3(), tick.posInLevel2() - 1, tick.posInLevel1(), tick.posInLevel0(), tick.posInLeaf()
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -234,7 +234,7 @@ abstract contract TickTreeTest is MangroveTest {
       // lower level3 position
       // Choosing MAX POSITION for level2, level1, level0, leaf to avoid hitting logPrice limits.
       // The important thing is to have a lower position in level3.
-      ticks[next++] = TickTreeUtil.tickFromBranch(
+      ticks[next++] = TickTreeUtil.bestTickFromBranch(
         tick.posInLevel3() - 1, MAX_LEVEL2_POS, MAX_LEVEL1_POS, MAX_LEVEL0_POS, MAX_LEAF_POS
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {

--- a/test/core/ticktree/TickTreeTest.t.sol
+++ b/test/core/ticktree/TickTreeTest.t.sol
@@ -70,17 +70,17 @@ abstract contract TickTreeTest is MangroveTest {
   // We use this tick to test the case where the tick is at the max position in all levels except level3:
   // Max in all positions isn't supported by (log)price math.
   Tick immutable TICK_MIN_L3_MAX_OTHERS =
-    TickTreeUtil.bestTickFromBranch(MIN_LEVEL3_POS, MAX_LEVEL2_POS, MAX_LEVEL1_POS, MAX_LEVEL0_POS, MAX_LEAF_POS);
+    TickTreeUtil.tickFromBranch(MIN_LEVEL3_POS, MAX_LEVEL2_POS, MAX_LEVEL1_POS, MAX_LEVEL0_POS, MAX_LEAF_POS);
 
   // max L3, min L2-0, min leaf
   // We use this tick to test the case where the tick is at the min position in all levels except level3:
   // Min in all positions isn't supported by (log)price math.
   Tick immutable TICK_MAX_L3_MIN_OTHERS =
-    TickTreeUtil.bestTickFromBranch(MAX_LEVEL3_POS, MIN_LEVEL2_POS, MIN_LEVEL1_POS, MIN_LEVEL0_POS, MIN_LEAF_POS);
+    TickTreeUtil.tickFromBranch(MAX_LEVEL3_POS, MIN_LEVEL2_POS, MIN_LEVEL1_POS, MIN_LEVEL0_POS, MIN_LEAF_POS);
 
   // middle L3-0, middle leaf
   Tick immutable TICK_MIDDLE =
-    TickTreeUtil.bestTickFromBranch(MID_LEVEL3_POS, MID_LEVEL2_POS, MID_LEVEL1_POS, MID_LEVEL0_POS, MID_LEAF_POS);
+    TickTreeUtil.tickFromBranch(MID_LEVEL3_POS, MID_LEVEL2_POS, MID_LEVEL1_POS, MID_LEVEL0_POS, MID_LEAF_POS);
 
   // min tick allowed by (log)price math
   Tick immutable TICK_MIN_ALLOWED = Tick.wrap(MIN_TICK_ALLOWED);
@@ -140,7 +140,7 @@ abstract contract TickTreeTest is MangroveTest {
     Tick[] memory ticks = new Tick[](10);
     if (tick.posInLeaf() < MAX_LEAF_POS) {
       // higher leaf position
-      ticks[next++] = TickTreeUtil.bestTickFromBranch(
+      ticks[next++] = TickTreeUtil.tickFromBranch(
         tick.posInLevel3(), tick.posInLevel2(), tick.posInLevel1(), tick.posInLevel0(), tick.posInLeaf() + 1
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -149,7 +149,7 @@ abstract contract TickTreeTest is MangroveTest {
     }
     if (tick.posInLevel0() < MAX_LEVEL0_POS) {
       // higher level0 position
-      ticks[next++] = TickTreeUtil.bestTickFromBranch(
+      ticks[next++] = TickTreeUtil.tickFromBranch(
         tick.posInLevel3(), tick.posInLevel2(), tick.posInLevel1(), tick.posInLevel0() + 1, tick.posInLeaf()
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -158,7 +158,7 @@ abstract contract TickTreeTest is MangroveTest {
     }
     if (tick.posInLevel1() < MAX_LEVEL1_POS) {
       // higher level1 position
-      ticks[next++] = TickTreeUtil.bestTickFromBranch(
+      ticks[next++] = TickTreeUtil.tickFromBranch(
         tick.posInLevel3(), tick.posInLevel2(), tick.posInLevel1() + 1, tick.posInLevel0(), tick.posInLeaf()
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -167,7 +167,7 @@ abstract contract TickTreeTest is MangroveTest {
     }
     if (tick.posInLevel2() < MAX_LEVEL2_POS) {
       // higher level2 position
-      ticks[next++] = TickTreeUtil.bestTickFromBranch(
+      ticks[next++] = TickTreeUtil.tickFromBranch(
         tick.posInLevel3(), tick.posInLevel2() + 1, tick.posInLevel1(), tick.posInLevel0(), tick.posInLeaf()
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -178,7 +178,7 @@ abstract contract TickTreeTest is MangroveTest {
       // higher level3 position
       // Choosing MIN POSITION for level2, level1, level0, leaf to avoid hitting logPrice limits.
       // The important thing is to have a higher position in level3.
-      ticks[next++] = TickTreeUtil.bestTickFromBranch(tick.posInLevel3() + 1, 0, 0, 0, 0);
+      ticks[next++] = TickTreeUtil.tickFromBranch(tick.posInLevel3() + 1, 0, 0, 0, 0);
       if (!isAllowedByPriceMath(ticks[next - 1])) {
         next--;
       }
@@ -196,7 +196,7 @@ abstract contract TickTreeTest is MangroveTest {
     Tick[] memory ticks = new Tick[](10);
     if (tick.posInLeaf() > 0) {
       // lower leaf position
-      ticks[next++] = TickTreeUtil.bestTickFromBranch(
+      ticks[next++] = TickTreeUtil.tickFromBranch(
         tick.posInLevel3(), tick.posInLevel2(), tick.posInLevel1(), tick.posInLevel0(), tick.posInLeaf() - 1
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -205,7 +205,7 @@ abstract contract TickTreeTest is MangroveTest {
     }
     if (tick.posInLevel0() > 0) {
       // lower level0 position
-      ticks[next++] = TickTreeUtil.bestTickFromBranch(
+      ticks[next++] = TickTreeUtil.tickFromBranch(
         tick.posInLevel3(), tick.posInLevel2(), tick.posInLevel1(), tick.posInLevel0() - 1, tick.posInLeaf()
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -214,7 +214,7 @@ abstract contract TickTreeTest is MangroveTest {
     }
     if (tick.posInLevel1() > 0) {
       // lower level1 position
-      ticks[next++] = TickTreeUtil.bestTickFromBranch(
+      ticks[next++] = TickTreeUtil.tickFromBranch(
         tick.posInLevel3(), tick.posInLevel2(), tick.posInLevel1() - 1, tick.posInLevel0(), tick.posInLeaf()
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -223,7 +223,7 @@ abstract contract TickTreeTest is MangroveTest {
     }
     if (tick.posInLevel2() > 0) {
       // lower level2 position
-      ticks[next++] = TickTreeUtil.bestTickFromBranch(
+      ticks[next++] = TickTreeUtil.tickFromBranch(
         tick.posInLevel3(), tick.posInLevel2() - 1, tick.posInLevel1(), tick.posInLevel0(), tick.posInLeaf()
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -234,7 +234,7 @@ abstract contract TickTreeTest is MangroveTest {
       // lower level3 position
       // Choosing MAX POSITION for level2, level1, level0, leaf to avoid hitting logPrice limits.
       // The important thing is to have a lower position in level3.
-      ticks[next++] = TickTreeUtil.bestTickFromBranch(
+      ticks[next++] = TickTreeUtil.tickFromBranch(
         tick.posInLevel3() - 1, MAX_LEVEL2_POS, MAX_LEVEL1_POS, MAX_LEVEL0_POS, MAX_LEAF_POS
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {

--- a/test/core/ticktree/TickTreeTest.t.sol
+++ b/test/core/ticktree/TickTreeTest.t.sol
@@ -70,17 +70,17 @@ abstract contract TickTreeTest is MangroveTest {
   // We use this tick to test the case where the tick is at the max position in all levels except level3:
   // Max in all positions isn't supported by (log)price math.
   Tick immutable TICK_MIN_L3_MAX_OTHERS =
-    TickTreeUtil.tickFromBranch(MIN_LEVEL3_POS, MAX_LEVEL2_POS, MAX_LEVEL1_POS, MAX_LEVEL0_POS, MAX_LEAF_POS);
+    TickTreeUtil.tickFromPositions(MIN_LEVEL3_POS, MAX_LEVEL2_POS, MAX_LEVEL1_POS, MAX_LEVEL0_POS, MAX_LEAF_POS);
 
   // max L3, min L2-0, min leaf
   // We use this tick to test the case where the tick is at the min position in all levels except level3:
   // Min in all positions isn't supported by (log)price math.
   Tick immutable TICK_MAX_L3_MIN_OTHERS =
-    TickTreeUtil.tickFromBranch(MAX_LEVEL3_POS, MIN_LEVEL2_POS, MIN_LEVEL1_POS, MIN_LEVEL0_POS, MIN_LEAF_POS);
+    TickTreeUtil.tickFromPositions(MAX_LEVEL3_POS, MIN_LEVEL2_POS, MIN_LEVEL1_POS, MIN_LEVEL0_POS, MIN_LEAF_POS);
 
   // middle L3-0, middle leaf
   Tick immutable TICK_MIDDLE =
-    TickTreeUtil.tickFromBranch(MID_LEVEL3_POS, MID_LEVEL2_POS, MID_LEVEL1_POS, MID_LEVEL0_POS, MID_LEAF_POS);
+    TickTreeUtil.tickFromPositions(MID_LEVEL3_POS, MID_LEVEL2_POS, MID_LEVEL1_POS, MID_LEVEL0_POS, MID_LEAF_POS);
 
   // min tick allowed by (log)price math
   Tick immutable TICK_MIN_ALLOWED = Tick.wrap(MIN_TICK_ALLOWED);
@@ -140,7 +140,7 @@ abstract contract TickTreeTest is MangroveTest {
     Tick[] memory ticks = new Tick[](10);
     if (tick.posInLeaf() < MAX_LEAF_POS) {
       // higher leaf position
-      ticks[next++] = TickTreeUtil.tickFromBranch(
+      ticks[next++] = TickTreeUtil.tickFromPositions(
         tick.posInLevel3(), tick.posInLevel2(), tick.posInLevel1(), tick.posInLevel0(), tick.posInLeaf() + 1
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -149,7 +149,7 @@ abstract contract TickTreeTest is MangroveTest {
     }
     if (tick.posInLevel0() < MAX_LEVEL0_POS) {
       // higher level0 position
-      ticks[next++] = TickTreeUtil.tickFromBranch(
+      ticks[next++] = TickTreeUtil.tickFromPositions(
         tick.posInLevel3(), tick.posInLevel2(), tick.posInLevel1(), tick.posInLevel0() + 1, tick.posInLeaf()
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -158,7 +158,7 @@ abstract contract TickTreeTest is MangroveTest {
     }
     if (tick.posInLevel1() < MAX_LEVEL1_POS) {
       // higher level1 position
-      ticks[next++] = TickTreeUtil.tickFromBranch(
+      ticks[next++] = TickTreeUtil.tickFromPositions(
         tick.posInLevel3(), tick.posInLevel2(), tick.posInLevel1() + 1, tick.posInLevel0(), tick.posInLeaf()
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -167,7 +167,7 @@ abstract contract TickTreeTest is MangroveTest {
     }
     if (tick.posInLevel2() < MAX_LEVEL2_POS) {
       // higher level2 position
-      ticks[next++] = TickTreeUtil.tickFromBranch(
+      ticks[next++] = TickTreeUtil.tickFromPositions(
         tick.posInLevel3(), tick.posInLevel2() + 1, tick.posInLevel1(), tick.posInLevel0(), tick.posInLeaf()
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -178,7 +178,7 @@ abstract contract TickTreeTest is MangroveTest {
       // higher level3 position
       // Choosing MIN POSITION for level2, level1, level0, leaf to avoid hitting logPrice limits.
       // The important thing is to have a higher position in level3.
-      ticks[next++] = TickTreeUtil.tickFromBranch(tick.posInLevel3() + 1, 0, 0, 0, 0);
+      ticks[next++] = TickTreeUtil.tickFromPositions(tick.posInLevel3() + 1, 0, 0, 0, 0);
       if (!isAllowedByPriceMath(ticks[next - 1])) {
         next--;
       }
@@ -196,7 +196,7 @@ abstract contract TickTreeTest is MangroveTest {
     Tick[] memory ticks = new Tick[](10);
     if (tick.posInLeaf() > 0) {
       // lower leaf position
-      ticks[next++] = TickTreeUtil.tickFromBranch(
+      ticks[next++] = TickTreeUtil.tickFromPositions(
         tick.posInLevel3(), tick.posInLevel2(), tick.posInLevel1(), tick.posInLevel0(), tick.posInLeaf() - 1
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -205,7 +205,7 @@ abstract contract TickTreeTest is MangroveTest {
     }
     if (tick.posInLevel0() > 0) {
       // lower level0 position
-      ticks[next++] = TickTreeUtil.tickFromBranch(
+      ticks[next++] = TickTreeUtil.tickFromPositions(
         tick.posInLevel3(), tick.posInLevel2(), tick.posInLevel1(), tick.posInLevel0() - 1, tick.posInLeaf()
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -214,7 +214,7 @@ abstract contract TickTreeTest is MangroveTest {
     }
     if (tick.posInLevel1() > 0) {
       // lower level1 position
-      ticks[next++] = TickTreeUtil.tickFromBranch(
+      ticks[next++] = TickTreeUtil.tickFromPositions(
         tick.posInLevel3(), tick.posInLevel2(), tick.posInLevel1() - 1, tick.posInLevel0(), tick.posInLeaf()
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -223,7 +223,7 @@ abstract contract TickTreeTest is MangroveTest {
     }
     if (tick.posInLevel2() > 0) {
       // lower level2 position
-      ticks[next++] = TickTreeUtil.tickFromBranch(
+      ticks[next++] = TickTreeUtil.tickFromPositions(
         tick.posInLevel3(), tick.posInLevel2() - 1, tick.posInLevel1(), tick.posInLevel0(), tick.posInLeaf()
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {
@@ -234,7 +234,7 @@ abstract contract TickTreeTest is MangroveTest {
       // lower level3 position
       // Choosing MAX POSITION for level2, level1, level0, leaf to avoid hitting logPrice limits.
       // The important thing is to have a lower position in level3.
-      ticks[next++] = TickTreeUtil.tickFromBranch(
+      ticks[next++] = TickTreeUtil.tickFromPositions(
         tick.posInLevel3() - 1, MAX_LEVEL2_POS, MAX_LEVEL1_POS, MAX_LEVEL0_POS, MAX_LEAF_POS
       );
       if (!isAllowedByPriceMath(ticks[next - 1])) {

--- a/test/lib/TestTickTree.sol
+++ b/test/lib/TestTickTree.sol
@@ -65,11 +65,11 @@ library TickTreeUtil {
     return (level0Index << LEVEL0_SIZE_BITS) | int(pos);
   }
 
-  function tickFromLeafIndexAndPos(int leafIndex, uint pos) public pure returns (Tick) {
+  function bestTickFromLeafIndexAndPos(int leafIndex, uint pos) public pure returns (Tick) {
     return Tick.wrap((leafIndex << LEAF_SIZE_BITS) | int(pos));
   }
 
-  function tickFromBranch(uint posInLevel3, uint posInLevel2, uint posInLevel1, uint posInLevel0, uint posInLeaf)
+  function bestTickFromBranch(uint posInLevel3, uint posInLevel2, uint posInLevel1, uint posInLevel0, uint posInLeaf)
     public
     pure
     returns (Tick)
@@ -260,7 +260,7 @@ contract TestTickTree is MangroveTest {
             );
 
             for (uint leafPos = 0; leafPos <= MAX_LEAF_POS; ++leafPos) {
-              Tick tick = TickTreeUtil.tickFromLeafIndexAndPos(leafIndex, leafPos);
+              Tick tick = TickTreeUtil.bestTickFromLeafIndexAndPos(leafIndex, leafPos);
               uint offerId = leaf.firstOfIndex(leafPos);
               if (offerId == 0) {
                 assertEq(
@@ -375,7 +375,7 @@ contract TestTickTree is MangroveTest {
             Leaf leaf = mgv.leafs(olKey, leafIndex);
             for (uint leafPos = 0; leafPos <= MAX_LEAF_POS; ++leafPos) {
               {
-                Tick tick = TickTreeUtil.tickFromLeafIndexAndPos(leafIndex, leafPos);
+                Tick tick = TickTreeUtil.bestTickFromLeafIndexAndPos(leafIndex, leafPos);
                 assertEq(
                   leaf.firstOfIndex(leafPos),
                   leafs[leafIndex].firstOfIndex(leafPos),
@@ -474,7 +474,7 @@ contract TestTickTree is MangroveTest {
             int leafIndex = TickTreeUtil.leafIndexFromLevel0IndexAndPos(level0Index, levelPoss[0]);
             Leaf leaf = leafs[leafIndex];
             for (uint leafPos = 0; leafPos <= MAX_LEAF_POS; ++leafPos) {
-              Tick tick = TickTreeUtil.tickFromLeafIndexAndPos(leafIndex, leafPos);
+              Tick tick = TickTreeUtil.bestTickFromLeafIndexAndPos(leafIndex, leafPos);
               uint offerId = leaf.firstOfIndex(leafPos);
               if (offerId == 0) {
                 continue;
@@ -518,7 +518,7 @@ contract TestTickTree is MangroveTest {
 
             int leafIndex = TickTreeUtil.leafIndexFromLevel0IndexAndPos(level0Index, levelPoss[0]);
             for (uint leafPos = 0; leafPos <= MAX_LEAF_POS; ++leafPos) {
-              Tick tick = TickTreeUtil.tickFromLeafIndexAndPos(leafIndex, leafPos);
+              Tick tick = TickTreeUtil.bestTickFromLeafIndexAndPos(leafIndex, leafPos);
               uint offerId = leafs[leafIndex].firstOfIndex(leafPos);
               if (offerId == 0) {
                 continue;

--- a/test/lib/TestTickTree.sol
+++ b/test/lib/TestTickTree.sol
@@ -69,7 +69,7 @@ library TickTreeUtil {
     return Tick.wrap((leafIndex << LEAF_SIZE_BITS) | int(pos));
   }
 
-  function bestTickFromBranch(uint posInLevel3, uint posInLevel2, uint posInLevel1, uint posInLevel0, uint posInLeaf)
+  function tickFromBranch(uint posInLevel3, uint posInLevel2, uint posInLevel1, uint posInLevel0, uint posInLeaf)
     public
     pure
     returns (Tick)

--- a/test/lib/TestTickTree.sol
+++ b/test/lib/TestTickTree.sol
@@ -69,7 +69,7 @@ library TickTreeUtil {
     return Tick.wrap((leafIndex << LEAF_SIZE_BITS) | int(pos));
   }
 
-  function tickFromBranch(uint posInLevel3, uint posInLevel2, uint posInLevel1, uint posInLevel0, uint posInLeaf)
+  function bestTickFromBranch(uint posInLevel3, uint posInLevel2, uint posInLevel1, uint posInLevel0, uint posInLeaf)
     public
     pure
     returns (Tick)

--- a/test/lib/TestTickTree.sol
+++ b/test/lib/TestTickTree.sol
@@ -65,11 +65,11 @@ library TickTreeUtil {
     return (level0Index << LEVEL0_SIZE_BITS) | int(pos);
   }
 
-  function bestTickFromLeafIndexAndPos(int leafIndex, uint pos) public pure returns (Tick) {
+  function tickFromLeafIndexAndPos(int leafIndex, uint pos) public pure returns (Tick) {
     return Tick.wrap((leafIndex << LEAF_SIZE_BITS) | int(pos));
   }
 
-  function bestTickFromBranch(uint posInLevel3, uint posInLevel2, uint posInLevel1, uint posInLevel0, uint posInLeaf)
+  function tickFromBranch(uint posInLevel3, uint posInLevel2, uint posInLevel1, uint posInLevel0, uint posInLeaf)
     public
     pure
     returns (Tick)
@@ -260,7 +260,7 @@ contract TestTickTree is MangroveTest {
             );
 
             for (uint leafPos = 0; leafPos <= MAX_LEAF_POS; ++leafPos) {
-              Tick tick = TickTreeUtil.bestTickFromLeafIndexAndPos(leafIndex, leafPos);
+              Tick tick = TickTreeUtil.tickFromLeafIndexAndPos(leafIndex, leafPos);
               uint offerId = leaf.firstOfIndex(leafPos);
               if (offerId == 0) {
                 assertEq(
@@ -375,7 +375,7 @@ contract TestTickTree is MangroveTest {
             Leaf leaf = mgv.leafs(olKey, leafIndex);
             for (uint leafPos = 0; leafPos <= MAX_LEAF_POS; ++leafPos) {
               {
-                Tick tick = TickTreeUtil.bestTickFromLeafIndexAndPos(leafIndex, leafPos);
+                Tick tick = TickTreeUtil.tickFromLeafIndexAndPos(leafIndex, leafPos);
                 assertEq(
                   leaf.firstOfIndex(leafPos),
                   leafs[leafIndex].firstOfIndex(leafPos),
@@ -474,7 +474,7 @@ contract TestTickTree is MangroveTest {
             int leafIndex = TickTreeUtil.leafIndexFromLevel0IndexAndPos(level0Index, levelPoss[0]);
             Leaf leaf = leafs[leafIndex];
             for (uint leafPos = 0; leafPos <= MAX_LEAF_POS; ++leafPos) {
-              Tick tick = TickTreeUtil.bestTickFromLeafIndexAndPos(leafIndex, leafPos);
+              Tick tick = TickTreeUtil.tickFromLeafIndexAndPos(leafIndex, leafPos);
               uint offerId = leaf.firstOfIndex(leafPos);
               if (offerId == 0) {
                 continue;
@@ -518,7 +518,7 @@ contract TestTickTree is MangroveTest {
 
             int leafIndex = TickTreeUtil.leafIndexFromLevel0IndexAndPos(level0Index, levelPoss[0]);
             for (uint leafPos = 0; leafPos <= MAX_LEAF_POS; ++leafPos) {
-              Tick tick = TickTreeUtil.bestTickFromLeafIndexAndPos(leafIndex, leafPos);
+              Tick tick = TickTreeUtil.tickFromLeafIndexAndPos(leafIndex, leafPos);
               uint offerId = leafs[leafIndex].firstOfIndex(leafPos);
               if (offerId == 0) {
                 continue;

--- a/test/lib/TestTickTree.sol
+++ b/test/lib/TestTickTree.sol
@@ -69,7 +69,7 @@ library TickTreeUtil {
     return Tick.wrap((leafIndex << LEAF_SIZE_BITS) | int(pos));
   }
 
-  function tickFromBranch(uint posInLevel3, uint posInLevel2, uint posInLevel1, uint posInLevel0, uint posInLeaf)
+  function tickFromPositions(uint posInLevel3, uint posInLevel2, uint posInLevel1, uint posInLevel0, uint posInLeaf)
     public
     pure
     returns (Tick)

--- a/test/self/BitLib.t.sol
+++ b/test/self/BitLib.t.sol
@@ -6,16 +6,16 @@ import "mgv_lib/Test2.sol";
 import {BitLib} from "mgv_lib/BitLib.sol";
 
 contract BitLibTest is Test2 {
-  // from solady's LibBit.t.sol
-  function test_ctz() public {
-    assertEq(BitLib.ctz(0xff << 3), 3);
+  // adapted from solady's LibBit.t.sol
+  function test_ctz64() public {
+    assertEq(BitLib.ctz64(0xff << 3), 3);
     uint brutalizer = uint(keccak256(abi.encode(address(this), block.timestamp)));
-    for (uint i = 0; i < 256; i++) {
-      assertEq(BitLib.ctz(1 << i), i);
-      assertEq(BitLib.ctz(type(uint).max << i), i);
-      assertEq(BitLib.ctz((brutalizer | 1) << i), i);
+    for (uint i = 0; i < 64; i++) {
+      assertEq(BitLib.ctz64(1 << i), i);
+      assertEq(BitLib.ctz64(type(uint).max << i), i);
+      assertEq(BitLib.ctz64((brutalizer | 1) << i), i);
     }
-    assertEq(BitLib.ctz(0), 256);
+    assertEq(BitLib.ctz64(0), 64);
   }
 
   function test_fls() public {


### PR DESCRIPTION
- uses less gas
- specialized for 64bit uints
- easier to audit
- also renames `tickFromX` to `bestTickFromX`

In `ExternalMarketOrderOtherOfferList_WithMultipleOffersAtManyTicks`, some tests would leave the OB empty, others not. `tickFromBranch` and `tickFromLocal` must never be called when one of the levels is empty -- the result is garbage -- but that's what `ExternalMarketOrderOtherOfferList_WithMultipleOffersAtManyTicks` did. Now it checks for empty OB before reading the tick from `local`.