### PR TITLE
optimize leaf.firstOfferPosition (changes spec for invalid leaves)

### DIFF
--- a/lib/TickLib.sol
+++ b/lib/TickLib.sol
@@ -131,8 +131,8 @@ library LeafLib {
   // Will check for the first position (0,1,2 or 3) that has a nonzero first-of-tick or a nonzero last-of-tick offer. Leafs where only one of those is nonzero are invalid anyway.
   function firstOfferPosition(Leaf leaf) internal pure returns (uint ret) {
     assembly("memory-safe") {
-      ret := shl(1,gt(0xffffffffffffffffffffffffffffffff,leaf))
-      ret := or(ret,gt(0xffffffffffffffff,shr(shl(7,iszero(ret)),leaf)))
+      ret := gt(leaf,0xffffffffffffffffffffffffffffffff)
+      ret := or(shl(1,iszero(ret)),gt(0xffffffffffffffff,shr(shl(7,ret),leaf)))
     }
   }
 

--- a/lib/TickLib.sol
+++ b/lib/TickLib.sol
@@ -128,45 +128,16 @@ library LeafLib {
     return uint(raw << (OFFER_BITS * ((index * 2) + 1)) >> (256 - OFFER_BITS));
   }
 
-  // TODO optimize with a hashmap, or:
-  // if > half: +=1; if += quarter: +=1, or:
-  // or nested if dichotomy
+  // Will check for the first position (0,1,2 or 3) that has a nonzero first-of-tick or a nonzero last-of-tick offer. Leafs where only one of those is nonzero are invalid anyway.
   function firstOfferPosition(Leaf leaf) internal pure returns (uint ret) {
-    uint offerId = Leaf.unwrap(leaf) >> (OFFER_BITS * 7);
-    if (offerId != 0) {
-      ret = 0;
-    } else {
-      offerId = Leaf.unwrap(leaf) << (OFFER_BITS * 2) >> (OFFER_BITS * 7);
-      if (offerId != 0) {
-        ret = 1;
-      } else {
-        offerId = Leaf.unwrap(leaf) << (OFFER_BITS * 4) >> (OFFER_BITS * 7);
-        if (offerId != 0) {
-          ret = 2;
-        } else {
-          offerId = Leaf.unwrap(leaf) << (OFFER_BITS * 6) >> (OFFER_BITS * 7);
-          if (offerId != 0) {
-            ret = 3;
-          }
-        }
-      }
+    assembly("memory-safe") {
+      ret := shl(1,gt(0xffffffffffffffffffffffffffffffff,leaf))
+      ret := or(ret,gt(0xffffffffffffffff,shr(shl(7,iszero(ret)),leaf)))
     }
   }
 
-  // TODO: a debruijn hashtable would be less gasexpensive?
-  // returns the 0 offer if empty
-  // FIXME find a version with way fewer jumps
   function getNextOfferId(Leaf leaf) internal pure returns (uint offerId) {
-    offerId = Leaf.unwrap(leaf) >> (OFFER_BITS * 7);
-    if (offerId == 0) {
-      offerId = Leaf.unwrap(leaf) << (OFFER_BITS * 2) >> (OFFER_BITS * 7);
-      if (offerId == 0) {
-        offerId = Leaf.unwrap(leaf) << (OFFER_BITS * 4) >> (OFFER_BITS * 7);
-        if (offerId == 0) {
-          offerId = Leaf.unwrap(leaf) << (OFFER_BITS * 6) >> (OFFER_BITS * 7);
-        }
-      }
-    }
+    return firstOfIndex(leaf,firstOfferPosition(leaf));
   }
 }
 

--- a/lib/TickLib.sol
+++ b/lib/TickLib.sol
@@ -132,7 +132,7 @@ library LeafLib {
   function firstOfferPosition(Leaf leaf) internal pure returns (uint ret) {
     assembly("memory-safe") {
       ret := gt(leaf,0xffffffffffffffffffffffffffffffff)
-      ret := or(shl(1,iszero(ret)),gt(0xffffffffffffffff,shr(shl(7,ret),leaf)))
+      ret := or(shl(1,iszero(ret)),iszero(gt(shr(shl(7,ret),leaf),0xffffffffffffffff)))
     }
   }
 

--- a/test/core/Leaf.t.sol
+++ b/test/core/Leaf.t.sol
@@ -66,6 +66,13 @@ contract LeafTest is Test2 {
     assertEq(leaf.lastOfIndex(index), lastId, "last id");
   }
 
+  function test_firstOfferPosition_on_invalid_leaf() public {
+    Leaf leaf = LeafLib.EMPTY;
+    leaf = leaf.setIndexFirstOrLast(0, 1, true);
+    leaf = leaf.setIndexFirstOrLast(1, 2, false);
+    assertEq(leaf.firstOfferPosition(), 0, "first offer position should be 0 (despite leaf being invalid)");
+  }
+
   function test_next_offer_id() public {
     Leaf leaf = LeafLib.EMPTY;
     assertEq(leaf.getNextOfferId(), 0);
@@ -75,9 +82,9 @@ contract LeafTest is Test2 {
     checkFirstOffer(leaf2, 0);
     leaf2 = leaf.setIndexFirstOrLast(1, 27, false);
     checkFirstOffer(leaf2, 27);
-    leaf = leaf.setIndexFirstOrLast(0, 13, true);
     leaf2 = leaf.setIndexFirstOrLast(1, 823, false);
-    checkFirstOffer(leaf2, 823);
+    leaf2 = leaf.setIndexFirstOrLast(0, 13, true);
+    checkFirstOffer(leaf2, 0);
     leaf = leaf.setIndexFirstOrLast(3, 2113, false);
     checkFirstOffer(leaf, 2113);
     leaf = leaf.setIndexFirstOrLast(3, 2, false);

--- a/test/core/Leaf.t.sol
+++ b/test/core/Leaf.t.sol
@@ -46,6 +46,21 @@ contract LeafTest is Test2 {
     assertEq(leaf.firstOfferPosition(), 2);
   }
 
+  function test_firstOfferPosition_leaf_quarter_1s_lsb() public {
+    Leaf leaf;
+    leaf = Leaf.wrap((1 << 64) - 1);
+    assertEq(leaf.firstOfferPosition(), 3);
+
+    leaf = Leaf.wrap(((1 << 64) - 1) << 64);
+    assertEq(leaf.firstOfferPosition(), 2);
+
+    leaf = Leaf.wrap(((1 << 64) - 1) << 128);
+    assertEq(leaf.firstOfferPosition(), 1);
+
+    leaf = Leaf.wrap(((1 << 64) - 1) << 192);
+    assertEq(leaf.firstOfferPosition(), 0);
+  }
+
   function test_firstOfferPosition() public {
     Leaf leaf = LeafLib.EMPTY;
     leaf = leaf.setTickFirst(Tick.wrap(1), 31);

--- a/test/core/Leaf.t.sol
+++ b/test/core/Leaf.t.sol
@@ -41,6 +41,11 @@ contract LeafTest is Test2 {
     assertStr(leaf, "[32,0][19992,711][4,1][0,1208]");
   }
 
+  function test_firstOfferPosition_invalid_leaf_half_1s_lsb() public {
+    Leaf leaf = Leaf.wrap((1 << 128) - 1);
+    assertEq(leaf.firstOfferPosition(), 2);
+  }
+
   function test_firstOfferPosition() public {
     Leaf leaf = LeafLib.EMPTY;
     leaf = leaf.setTickFirst(Tick.wrap(1), 31);


### PR DESCRIPTION
Uses simple assembly instead of nested if-then-else.