### PR TITLE
fix: properly update gas test to level3

### DIFF
--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -21,7 +21,6 @@ import {
 import {MgvHasOffers} from "./MgvHasOffers.sol";
 import {TickLib} from "mgv_lib/TickLib.sol";
 import "mgv_lib/LogPriceConversionLib.sol";
-import "mgv_lib/Debug.sol";
 
 abstract contract MgvOfferTaking is MgvHasOffers {
   /* # MultiOrder struct */

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -21,6 +21,7 @@ import {
 import {MgvHasOffers} from "./MgvHasOffers.sol";
 import {TickLib} from "mgv_lib/TickLib.sol";
 import "mgv_lib/LogPriceConversionLib.sol";
+import "mgv_lib/Debug.sol";
 
 abstract contract MgvOfferTaking is MgvHasOffers {
   /* # MultiOrder struct */

--- a/test/core/gas/CleanOtherOfferList.t.sol
+++ b/test/core/gas/CleanOtherOfferList.t.sol
@@ -30,7 +30,7 @@ contract ExternalCleanOfferOtherOfferList_WithNoOtherOffersGasTest is GasTestBas
   function setUp() public virtual override {
     super.setUp();
     logPrice = MIDDLE_LOG_PRICE;
-    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 1 ether, 100_000, 0);
+    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 100_000, 0);
     description = "Worst case scenario where cleaning an offer from an offer list which now becomes empty";
   }
 
@@ -40,7 +40,7 @@ contract ExternalCleanOfferOtherOfferList_WithNoOtherOffersGasTest is GasTestBas
 
   function setUpLogPrice(int _logPrice) public virtual {
     logPrice = _logPrice;
-    _offerId = mgv.newOfferByLogPrice(olKey, _logPrice, 1 ether, 100_000, 0);
+    _offerId = mgv.newOfferByLogPrice(olKey, _logPrice, 0.00001 ether, 100_000, 0);
     description = "Cleaning an offer when another offer exists at various tick-distances to the offer's price";
   }
 
@@ -301,10 +301,10 @@ contract ExternalCleanOfferOtherOfferList_WithPriorCleanOfferAndNoOtherOffersGas
 
   function setUp() public virtual override {
     super.setUp();
-    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 1 ether, 100_000, 0);
+    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 100_000, 0);
     logPriceOfferIds[MIDDLE_LOG_PRICE] = _offerId;
     this.newOfferOnAllTestPrices();
-    offerId2 = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 1 ether, 100_000, 0);
+    offerId2 = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 100_000, 0);
     description = "Cleaning a second offer at various tick-distances after cleaning an offer at MIDDLE_LOG_PRICE";
   }
 
@@ -339,7 +339,10 @@ abstract contract ExternalCleanOtherOfferList_WithMultipleOffersAtSameTickGasTes
     for (uint i; i < count; ++i) {
       targets.push(
         MgvLib.CleanTarget(
-          mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 1 ether, 100_000, 0), MIDDLE_LOG_PRICE, 100_000, 0.05 ether
+          mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 100_000, 0),
+          MIDDLE_LOG_PRICE,
+          100_000,
+          0.05 ether
         )
       );
     }

--- a/test/core/gas/GasTestBase.t.sol
+++ b/test/core/gas/GasTestBase.t.sol
@@ -13,7 +13,7 @@ int constant MIDDLE_LOG_PRICE =
   /* mid leaf */ LEAF_SIZE / 2 + 
   /* mid level0 */ LEAF_SIZE * (LEVEL0_SIZE / 2) +
   /* mid level 1 */ LEAF_SIZE * LEVEL0_SIZE * (LEVEL1_SIZE / 2) +
-  /* mid level 2 */ LEAF_SIZE * LEVEL0_SIZE * LEVEL1_SIZE + (LEVEL2_SIZE / 2);
+  /* mid level 2 */ LEAF_SIZE * LEVEL0_SIZE * LEVEL1_SIZE * (LEVEL2_SIZE / 3);
 // forgefmt: disable-end
 
 int constant LEAF_LOWER_LOG_PRICE = MIDDLE_LOG_PRICE - 1;
@@ -46,29 +46,30 @@ abstract contract GasTestBaseStored {
 
   function newOfferOnAllLowerThanMiddleTestPrices() public virtual {
     (IMangrove mgv,, OLKey memory _olKey,) = getStored();
-    logPriceOfferIds[LEAF_LOWER_LOG_PRICE] = mgv.newOfferByLogPrice(_olKey, LEAF_LOWER_LOG_PRICE, 1 ether, 1_000_000, 0);
+    logPriceOfferIds[LEAF_LOWER_LOG_PRICE] =
+      mgv.newOfferByLogPrice(_olKey, LEAF_LOWER_LOG_PRICE, 0.00001 ether, 1_000_000, 0);
     logPriceOfferIds[LEVEL0_LOWER_LOG_PRICE] =
-      mgv.newOfferByLogPrice(_olKey, LEVEL0_LOWER_LOG_PRICE, 1 ether, 1_000_000, 0);
+      mgv.newOfferByLogPrice(_olKey, LEVEL0_LOWER_LOG_PRICE, 0.00001 ether, 1_000_000, 0);
     logPriceOfferIds[LEVEL1_LOWER_LOG_PRICE] =
-      mgv.newOfferByLogPrice(_olKey, LEVEL1_LOWER_LOG_PRICE, 1 ether, 1_000_000, 0);
+      mgv.newOfferByLogPrice(_olKey, LEVEL1_LOWER_LOG_PRICE, 0.00001 ether, 1_000_000, 0);
     logPriceOfferIds[LEVEL2_LOWER_LOG_PRICE] =
-      mgv.newOfferByLogPrice(_olKey, LEVEL2_LOWER_LOG_PRICE, 1 ether, 1_000_000, 0);
+      mgv.newOfferByLogPrice(_olKey, LEVEL2_LOWER_LOG_PRICE, 0.00001 ether, 1_000_000, 0);
     logPriceOfferIds[LEVEL3_LOWER_LOG_PRICE] =
-      mgv.newOfferByLogPrice(_olKey, LEVEL3_LOWER_LOG_PRICE, 1 ether, 1_000_000, 0);
+      mgv.newOfferByLogPrice(_olKey, LEVEL3_LOWER_LOG_PRICE, 0.00001 ether, 1_000_000, 0);
   }
 
   function newOfferOnAllHigherThanMiddleTestPrices() public virtual {
     (IMangrove mgv,, OLKey memory _olKey,) = getStored();
     logPriceOfferIds[LEAF_HIGHER_LOG_PRICE] =
-      mgv.newOfferByLogPrice(_olKey, LEAF_HIGHER_LOG_PRICE, 1 ether, 1_000_000, 0);
+      mgv.newOfferByLogPrice(_olKey, LEAF_HIGHER_LOG_PRICE, 0.00001 ether, 1_000_000, 0);
     logPriceOfferIds[LEVEL0_HIGHER_LOG_PRICE] =
-      mgv.newOfferByLogPrice(_olKey, LEVEL0_HIGHER_LOG_PRICE, 1 ether, 1_000_000, 0);
+      mgv.newOfferByLogPrice(_olKey, LEVEL0_HIGHER_LOG_PRICE, 0.00001 ether, 1_000_000, 0);
     logPriceOfferIds[LEVEL1_HIGHER_LOG_PRICE] =
-      mgv.newOfferByLogPrice(_olKey, LEVEL1_HIGHER_LOG_PRICE, 1 ether, 1_000_000, 0);
+      mgv.newOfferByLogPrice(_olKey, LEVEL1_HIGHER_LOG_PRICE, 0.00001 ether, 1_000_000, 0);
     logPriceOfferIds[LEVEL2_HIGHER_LOG_PRICE] =
-      mgv.newOfferByLogPrice(_olKey, LEVEL2_HIGHER_LOG_PRICE, 1 ether, 1_000_000, 0);
+      mgv.newOfferByLogPrice(_olKey, LEVEL2_HIGHER_LOG_PRICE, 0.00001 ether, 1_000_000, 0);
     logPriceOfferIds[LEVEL3_HIGHER_LOG_PRICE] =
-      mgv.newOfferByLogPrice(_olKey, LEVEL3_HIGHER_LOG_PRICE, 1 ether, 1_000_000, 0);
+      mgv.newOfferByLogPrice(_olKey, LEVEL3_HIGHER_LOG_PRICE, 0.00001 ether, 1_000_000, 0);
   }
 }
 

--- a/test/core/gas/NewOfferOtherOfferList.t.sol
+++ b/test/core/gas/NewOfferOtherOfferList.t.sol
@@ -11,7 +11,7 @@ import {OLKey} from "mgv_src/MgvLib.sol";
 contract ExternalNewOfferOtherOfferList_AlwaysEmptyGasTest is SingleGasTestBase {
   function impl(IMangrove mgv, TestTaker, OLKey memory _olKey, uint) internal override {
     _gas();
-    mgv.newOfferByLogPrice(_olKey, MIDDLE_LOG_PRICE, 0.1 ether, 100_000, 0);
+    mgv.newOfferByLogPrice(_olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 100_000, 0);
     gas_();
     description =
       "Worst case scenario if strat posts on different, as of yet always empty, list. This is unlikely to happen in practice";
@@ -21,7 +21,7 @@ contract ExternalNewOfferOtherOfferList_AlwaysEmptyGasTest is SingleGasTestBase 
 contract ExternalNewOfferOtherOfferList_WithNoOtherOffersGasTest is SingleGasTestBase {
   function setUp() public virtual override {
     super.setUp();
-    mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 1 ether, 100_000, 0);
+    mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 100_000, 0);
     vm.prank($(_taker));
     mgv.marketOrderByLogPrice(olKey, MIDDLE_LOG_PRICE, 1, true);
     assertEq(0, mgv.best(olKey));
@@ -31,7 +31,7 @@ contract ExternalNewOfferOtherOfferList_WithNoOtherOffersGasTest is SingleGasTes
 
   function impl(IMangrove mgv, TestTaker, OLKey memory _olKey, uint) internal virtual override {
     _gas();
-    mgv.newOfferByLogPrice(_olKey, MIDDLE_LOG_PRICE, 0.1 ether, 100_000, 0);
+    mgv.newOfferByLogPrice(_olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 100_000, 0);
     gas_();
   }
 }
@@ -39,13 +39,13 @@ contract ExternalNewOfferOtherOfferList_WithNoOtherOffersGasTest is SingleGasTes
 contract ExternalNewOfferOtherOfferList_WithOtherOfferGasTest is TickBoundariesGasTest, GasTestBase {
   function setUp() public virtual override {
     super.setUp();
-    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 1 ether, 100_000, 0);
+    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 100_000, 0);
     description = "Posting a new offer when another offer exists at various tick-distances to the new offer";
   }
 
   function impl(IMangrove mgv, TestTaker, OLKey memory _olKey, uint, int _logPrice) internal override {
     _gas();
-    mgv.newOfferByLogPrice(_olKey, _logPrice, 1 ether, 100_000, 0);
+    mgv.newOfferByLogPrice(_olKey, _logPrice, 0.00001 ether, 100_000, 0);
     gas_();
   }
 }
@@ -70,7 +70,7 @@ contract ExternalNewOfferOtherOfferList_WithPriorNewOfferAndNoOtherOffersGasTest
   }
 
   function impl(IMangrove mgv, TestTaker taker, OLKey memory _olKey, uint offerId) internal override {
-    mgv.newOfferByLogPrice(_olKey, MIDDLE_LOG_PRICE, 1 ether, 100_000, 0);
+    mgv.newOfferByLogPrice(_olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 100_000, 0);
     super.impl(mgv, taker, _olKey, offerId);
   }
 }

--- a/test/core/gas/NewOfferSameOfferList.t.sol
+++ b/test/core/gas/NewOfferSameOfferList.t.sol
@@ -13,7 +13,7 @@ contract PosthookSuccessNewOfferSameList_WithNoOtherOffersGasTest is TickBoundar
   function setUp() public virtual override {
     super.setUp();
     // At price MIDDLE_LOG_PRICE so we can post a better or worse offer in same leaf.
-    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 1 ether, 1_000_000, 0);
+    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 1_000_000, 0);
     description =
       "Posting a new offer in posthook for now empty offer list but where new offer has varying closeness to taken offer";
   }
@@ -31,7 +31,7 @@ contract PosthookSuccessNewOfferSameList_WithNoOtherOffersGasTest is TickBoundar
     if (sor.offerId == offerId) {
       int _logPrice = logPrice;
       _gas();
-      mgv.newOfferByLogPrice(_olKey, _logPrice, 1 ether, 1_000_000, 0);
+      mgv.newOfferByLogPrice(_olKey, _logPrice, 0.00001 ether, 1_000_000, 0);
       gas_();
     }
   }
@@ -48,8 +48,8 @@ contract PosthookSuccessNewOfferSameList_WithOtherOfferGasTest is
   function setUp() public virtual override {
     super.setUp();
     // We insert two others so PosthookFailure will still have the second offer on the book when executing posthook as the first is taken to do the fill.
-    mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 1 ether, 1_000_000, 0);
-    mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 1 ether, 1_000_000, 0);
+    mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 1_000_000, 0);
+    mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 1_000_000, 0);
     description =
       "Posting a new offer in posthook for offer list with other offer at same tick as taken but where new offer has varying closeness to taken offer";
   }
@@ -87,7 +87,7 @@ contract PosthookSuccessNewOfferSameList_WithPriorNewOfferAndNoOtherOffersGasTes
     (IMangrove mgv,, OLKey memory _olKey, uint offerId) = getStored();
     if (sor.offerId == offerId) {
       // Insert at middle price - the measured one is at various tick-distances.
-      mgv.newOfferByLogPrice(_olKey, MIDDLE_LOG_PRICE, 1 ether, 1_000_000, 0);
+      mgv.newOfferByLogPrice(_olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 1_000_000, 0);
     }
     super.makerPosthook(sor, result);
   }

--- a/test/core/gas/RetractOfferOtherOfferList.t.sol
+++ b/test/core/gas/RetractOfferOtherOfferList.t.sol
@@ -24,13 +24,13 @@ import {TickBoundariesGasTest} from "./TickBoundariesGasTest.t.sol";
 contract ExternalRetractOfferOtherOfferList_WithNoOtherOffersGasTest is GasTestBase {
   function setUp() public virtual override {
     super.setUp();
-    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 1 ether, 100_000, 0);
+    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 100_000, 0);
     description =
       "Worst case scenario if strat retracts an offer from an offer list which has now become empty - with and without deprovision";
   }
 
   function setUpLogPrice(int _logPrice) public virtual {
-    _offerId = mgv.newOfferByLogPrice(olKey, _logPrice, 1 ether, 100_000, 0);
+    _offerId = mgv.newOfferByLogPrice(olKey, _logPrice, 0.00001 ether, 100_000, 0);
     description = "Retracting an offer when another offer exists at various tick-distances to the offer's price";
   }
 
@@ -297,10 +297,10 @@ contract ExternalRetractOfferOtherOfferList_WithPriorRetractOfferAndNoOtherOffer
 
   function setUp() public virtual override {
     super.setUp();
-    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 1 ether, 100_000, 0);
+    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 100_000, 0);
     logPriceOfferIds[MIDDLE_LOG_PRICE] = _offerId;
     this.newOfferOnAllTestPrices();
-    offerId2 = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 1 ether, 100_000, 0);
+    offerId2 = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 100_000, 0);
     description = "Retracting a second offer at various tick-distances after retracting an offer at MIDDLE_LOG_PRICE";
   }
 

--- a/test/core/gas/TickBoundariesGasTest.t.sol
+++ b/test/core/gas/TickBoundariesGasTest.t.sol
@@ -17,7 +17,8 @@ import {
   LEVEL3_HIGHER_LOG_PRICE
 } from "./GasTestBase.t.sol";
 
-import {IMangrove, TestTaker, OLKey} from "mgv_test/lib/MangroveTest.sol";
+import {IMangrove, TestTaker, OLKey, MgvStructs} from "mgv_test/lib/MangroveTest.sol";
+import "mgv_lib/Debug.sol";
 
 /// Implements tests for all boundaries of tick values. Starting from a MIDDLE_LOG_PRICE it goes above and below creating new branches for all levels.
 abstract contract TickBoundariesGasTest is GasTestBaseStored {
@@ -26,6 +27,7 @@ abstract contract TickBoundariesGasTest is GasTestBaseStored {
   function testLogPrice(int _logPrice) internal virtual {
     logPrice = _logPrice;
     (IMangrove mgv, TestTaker taker, OLKey memory _olKey, uint offerId) = getStored();
+
     impl(mgv, taker, _olKey, offerId, _logPrice);
   }
 
@@ -44,6 +46,8 @@ abstract contract TickBoundariesGasTest is GasTestBaseStored {
   }
 
   function test_ExistingLeafHigherTick() public {
+    console.log("MIDDLE", MIDDLE_LOG_PRICE);
+    console.log("LEAF HIGHER", LEAF_HIGHER_LOG_PRICE);
     testLogPrice(LEAF_HIGHER_LOG_PRICE);
     description = string.concat(description, " - Case: Existing leaf higher tick");
     printDescription();

--- a/test/core/gas/UpdateOfferOtherOfferList.t.sol
+++ b/test/core/gas/UpdateOfferOtherOfferList.t.sol
@@ -10,7 +10,7 @@ import {OLKey} from "mgv_src/MgvLib.sol";
 contract ExternalUpdateOfferOtherOfferList_WithNoOtherOffersGasTest is SingleGasTestBase {
   function setUp() public virtual override {
     super.setUp();
-    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 1 ether, 100_000, 0);
+    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 100_000, 0);
     vm.prank($(_taker));
     mgv.marketOrderByLogPrice(olKey, MIDDLE_LOG_PRICE, 1, true);
     assertEq(0, mgv.best(olKey));
@@ -20,7 +20,7 @@ contract ExternalUpdateOfferOtherOfferList_WithNoOtherOffersGasTest is SingleGas
 
   function impl(IMangrove mgv, TestTaker, OLKey memory _olKey, uint offerId) internal virtual override {
     _gas();
-    mgv.updateOfferByLogPrice(_olKey, MIDDLE_LOG_PRICE, 0.1 ether, 100_000, 0, offerId);
+    mgv.updateOfferByLogPrice(_olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 100_000, 0, offerId);
     gas_();
   }
 }
@@ -28,15 +28,15 @@ contract ExternalUpdateOfferOtherOfferList_WithNoOtherOffersGasTest is SingleGas
 contract ExternalUpdateOfferOtherOfferList_WithOtherOfferGasTest is TickBoundariesGasTest, GasTestBase {
   function setUp() public virtual override {
     super.setUp();
-    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 1 ether, 100_000, 0);
-    mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 1 ether, 100_000, 0);
+    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 100_000, 0);
+    mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 100_000, 0);
     description =
       "Updating an offer when another offer exists at various tick-distances to the offer's new price (initial same price)";
   }
 
   function impl(IMangrove mgv, TestTaker, OLKey memory _olKey, uint offerId, int _logPrice) internal override {
     _gas();
-    mgv.updateOfferByLogPrice(_olKey, _logPrice, 1 ether, 100_000, 0, offerId);
+    mgv.updateOfferByLogPrice(_olKey, _logPrice, 0.00001 ether, 100_000, 0, offerId);
     gas_();
   }
 }
@@ -59,7 +59,7 @@ contract ExternalUpdateOfferOtherOfferList_WithPriorUpdateOfferAndNoOtherOffersG
 
   function setUp() public virtual override {
     super.setUp();
-    offerId2 = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 1 ether, 100_000, 0);
+    offerId2 = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 100_000, 0);
     vm.prank($(_taker));
     mgv.marketOrderByLogPrice(olKey, MIDDLE_LOG_PRICE, 1, true);
     assertEq(0, mgv.best(olKey));
@@ -67,7 +67,7 @@ contract ExternalUpdateOfferOtherOfferList_WithPriorUpdateOfferAndNoOtherOffersG
   }
 
   function impl(IMangrove mgv, TestTaker taker, OLKey memory _olKey, uint offerId) internal override {
-    mgv.updateOfferByLogPrice(_olKey, MIDDLE_LOG_PRICE, 1 ether, 100_000, 0, offerId2);
+    mgv.updateOfferByLogPrice(_olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 100_000, 0, offerId2);
     super.impl(mgv, taker, _olKey, offerId);
   }
 }

--- a/test/core/gas/UpdateOfferOtherOfferListDetails.t.sol
+++ b/test/core/gas/UpdateOfferOtherOfferListDetails.t.sol
@@ -10,14 +10,14 @@ import {OLKey} from "mgv_src/MgvLib.sol";
 contract ExternalUpdateOfferOtherOfferList_DeadDeprovisioned is SingleGasTestBase {
   function setUp() public virtual override {
     super.setUp();
-    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 1 ether, 100_000, 0);
+    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 100_000, 0);
     mgv.retractOffer(olKey, _offerId, true);
     description = "Update dead deprovisioned offer";
   }
 
   function impl(IMangrove mgv, TestTaker, OLKey memory _olKey, uint offerId) internal virtual override {
     _gas();
-    mgv.updateOfferByLogPrice(_olKey, LEVEL1_HIGHER_LOG_PRICE, 0.1 ether, 100_000, 0, offerId);
+    mgv.updateOfferByLogPrice(_olKey, LEVEL1_HIGHER_LOG_PRICE, 0.00001 ether, 100_000, 0, offerId);
     gas_();
   }
 }
@@ -25,14 +25,14 @@ contract ExternalUpdateOfferOtherOfferList_DeadDeprovisioned is SingleGasTestBas
 contract ExternalUpdateOfferOtherOfferList_DeadProvisioned is SingleGasTestBase {
   function setUp() public virtual override {
     super.setUp();
-    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 1 ether, 100_000, 0);
+    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 100_000, 0);
     mgv.retractOffer(olKey, _offerId, false);
     description = "Update dead provisioned offer";
   }
 
   function impl(IMangrove mgv, TestTaker, OLKey memory _olKey, uint offerId) internal virtual override {
     _gas();
-    mgv.updateOfferByLogPrice(_olKey, LEVEL1_HIGHER_LOG_PRICE, 0.1 ether, 100_000, 0, offerId);
+    mgv.updateOfferByLogPrice(_olKey, LEVEL1_HIGHER_LOG_PRICE, 0.00001 ether, 100_000, 0, offerId);
     gas_();
   }
 }
@@ -40,14 +40,14 @@ contract ExternalUpdateOfferOtherOfferList_DeadProvisioned is SingleGasTestBase 
 contract ExternalUpdateOfferOtherOfferList_Gasreq is GasTestBase {
   function setUp() public virtual override {
     super.setUp();
-    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 1 ether, 100_000, 0);
+    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 100_000, 0);
     description = "Update live offer with different gasreq values.";
   }
 
   function test_live_far_away_same_gasreq() public {
     (IMangrove mgv,, OLKey memory _olKey, uint offerId) = getStored();
     _gas();
-    mgv.updateOfferByLogPrice(_olKey, LEVEL1_HIGHER_LOG_PRICE, 0.1 ether, 100_000, 0, offerId);
+    mgv.updateOfferByLogPrice(_olKey, LEVEL1_HIGHER_LOG_PRICE, 0.00001 ether, 100_000, 0, offerId);
     gas_();
     description = string.concat(description, " - Case: same gasreq");
     printDescription();
@@ -56,7 +56,7 @@ contract ExternalUpdateOfferOtherOfferList_Gasreq is GasTestBase {
   function test_live_far_away_higher_gasreq() public {
     (IMangrove mgv,, OLKey memory _olKey, uint offerId) = getStored();
     _gas();
-    mgv.updateOfferByLogPrice(_olKey, LEVEL1_HIGHER_LOG_PRICE, 0.1 ether, 1_000_000, 0, offerId);
+    mgv.updateOfferByLogPrice(_olKey, LEVEL1_HIGHER_LOG_PRICE, 0.00001 ether, 1_000_000, 0, offerId);
     gas_();
     description = string.concat(description, " - Case: higher gasreq");
     printDescription();
@@ -65,7 +65,7 @@ contract ExternalUpdateOfferOtherOfferList_Gasreq is GasTestBase {
   function test_live_far_away_lower_gasreq() public {
     (IMangrove mgv,, OLKey memory _olKey, uint offerId) = getStored();
     _gas();
-    mgv.updateOfferByLogPrice(_olKey, LEVEL1_HIGHER_LOG_PRICE, 0.1 ether, 10_000, 0, offerId);
+    mgv.updateOfferByLogPrice(_olKey, LEVEL1_HIGHER_LOG_PRICE, 0.00001 ether, 10_000, 0, offerId);
     gas_();
     description = string.concat(description, " - Case: lower gasreq");
     printDescription();

--- a/test/core/gas/UpdateOfferSameOfferList.t.sol
+++ b/test/core/gas/UpdateOfferSameOfferList.t.sol
@@ -14,7 +14,7 @@ contract PosthookSuccessUpdateOfferSameList_WithNoOtherOffersGasTest is TickBoun
 
   function setUp() public virtual override {
     super.setUp();
-    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 1 ether, 1_000_000, 0);
+    _offerId = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 1_000_000, 0);
     description =
       "Updating an offer in posthook for now empty offer list but where new offer has varying closeness to taken offer";
   }
@@ -33,7 +33,7 @@ contract PosthookSuccessUpdateOfferSameList_WithNoOtherOffersGasTest is TickBoun
       int _logPrice = logPrice;
       _gas();
       // Same gasreq, not deprovisioned, gasprice unchanged.
-      mgv.updateOfferByLogPrice(_olKey, _logPrice, 1 ether, 1_000_000, 0, offerId);
+      mgv.updateOfferByLogPrice(_olKey, _logPrice, 0.00001 ether, 1_000_000, 0, offerId);
       gas_();
     }
   }
@@ -52,8 +52,8 @@ contract PosthookSuccessUpdateOfferSameList_WithOtherOfferGasTest is
   function setUp() public virtual override {
     super.setUp();
     // We insert two others so PosthookFailure will still have the second offer on the book when executing posthook as the first is taken to do the fill.
-    offerId2 = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 1 ether, 1_000_000, 0);
-    mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 1 ether, 1_000_000, 0);
+    offerId2 = mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 1_000_000, 0);
+    mgv.newOfferByLogPrice(olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 1_000_000, 0);
     description =
       "Updating an offer in posthook for offer list with other offer at same tick as taken but where new offer has varying closeness to taken offer";
   }
@@ -91,7 +91,7 @@ contract PosthookSuccessUpdateOfferSameList_WithPriorUpdateOfferAndNoOtherOffers
     (IMangrove mgv,, OLKey memory _olKey, uint offerId) = getStored();
     if (sor.offerId == offerId) {
       // Insert at middle price - the measured one is at various tick-distances.
-      mgv.updateOfferByLogPrice(_olKey, MIDDLE_LOG_PRICE, 1 ether, 1_000_000, 0, offerId2);
+      mgv.updateOfferByLogPrice(_olKey, MIDDLE_LOG_PRICE, 0.00001 ether, 1_000_000, 0, offerId2);
     }
     super.makerPosthook(sor, result);
   }


### PR DESCRIPTION
In #564 I wrote as the last component of the sum defining `MIDDLE_LOG_PRICE` in gas tests:

```
LEAF_SIZE * LEVEL0_SIZE * LEVEL1_SIZE + (LEVEL2_SIZE / 2);
```

it should have been

```
LEAF_SIZE * LEVEL0_SIZE * LEVEL1_SIZE * (LEVEL2_SIZE / 2);
```

but this makes other ticks go beyond the limit, so I use

```
LEAF_SIZE * LEVEL0_SIZE * LEVEL1_SIZE * (LEVEL2_SIZE / 3);
```

The rest of the commit is adapting volumes to these high ticks: due to the max market order volume, with very high prices it becomes impossible to consume many offers, unless each offer has a negligible volume.
