### PR TITLE
Tick library

### DIFF
--- a/lib/BinLib.sol
+++ b/lib/BinLib.sol
@@ -100,14 +100,14 @@ library LeafLib {
 
   function setBinFirst(Leaf leaf, Bin bin, uint id) internal pure returns (Leaf) {
     unchecked {
-      uint posInLeaf = BinLib.posInLeaf(bin);
+      uint posInLeaf = bin.posInLeaf();
       return setPosFirstOrLast(leaf, posInLeaf, id, false);
     }
   }
 
   function setBinLast(Leaf leaf, Bin bin, uint id) internal pure returns (Leaf) {
     unchecked {
-      uint posInLeaf = BinLib.posInLeaf(bin);
+      uint posInLeaf = bin.posInLeaf();
       return setPosFirstOrLast(leaf, posInLeaf, id, true);
     }
   }
@@ -130,13 +130,13 @@ library LeafLib {
 
   function firstOfBin(Leaf leaf, Bin bin) internal pure returns (uint) {
     unchecked {
-      return firstOfPos(leaf, BinLib.posInLeaf(bin));
+      return firstOfPos(leaf, bin.posInLeaf());
     }
   }
 
   function lastOfBin(Leaf leaf, Bin bin) internal pure returns (uint) {
     unchecked {
-      return lastOfPos(leaf, BinLib.posInLeaf(bin));
+      return lastOfPos(leaf, bin.posInLeaf());
     }
   }
 
@@ -183,12 +183,6 @@ library BinLib {
     unchecked {
       return Bin.unwrap(bin) >= MIN_BIN && Bin.unwrap(bin) <= MAX_BIN;
     }
-  }
-
-  // Optimized conversion for ticks that are known to map exactly to a bin at the given tickSpacing,
-  // eg for offers in the offer list which are always written with a tick-aligned tick
-  function fromBinAlignedTick(Tick tick, uint tickSpacing) internal pure returns (Bin) {
-    return Bin.wrap(Tick.unwrap(tick) / int(tickSpacing));
   }
 
   // Utility for tests&unpacked structs, less gas-optimal

--- a/lib/BinLib.sol
+++ b/lib/BinLib.sol
@@ -195,7 +195,7 @@ library BinLib {
     }
   }
 
-  function toNearestTick(Bin bin, uint tickSpacing) internal pure returns (Tick) {
+  function tick(Bin bin, uint tickSpacing) internal pure returns (Tick) {
     return Tick.wrap(Bin.unwrap(bin) * int(tickSpacing));
   }
 

--- a/lib/TickConversionLib.sol
+++ b/lib/TickConversionLib.sol
@@ -128,8 +128,8 @@ library TickConversionLib {
 
     int log_bp_ratio = log2ratio * 127869479499801913173570;
 
-    int24 tickLow = int24((log_bp_ratio - 1701479891078076505009565712080972645) >> 128);
-    int24 tickHigh = int24((log_bp_ratio + 290040965921304576580754310682015830659) >> 128);
+    int tickLow = int((log_bp_ratio - 1701479891078076505009565712080972645) >> 128);
+    int tickHigh = int((log_bp_ratio + 290040965921304576580754310682015830659) >> 128);
 
     (uint mantissaHigh, uint expHigh) = ratioFromTick(Tick.wrap(tickHigh));
 

--- a/lib/TickConversionLib.sol
+++ b/lib/TickConversionLib.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.17;
 
 import "mgv_lib/Constants.sol";
 import "mgv_lib/BitLib.sol";
+import {Tick} from "mgv_lib/TickLib.sol";
 
 library TickConversionLib {
   // returns a normalized ratio within the max/min ratio range
@@ -29,13 +30,13 @@ library TickConversionLib {
     }
   }
 
-  function tickFromVolumes(uint inboundAmt, uint outboundAmt) internal pure returns (int24 tick) {
+  function tickFromVolumes(uint inboundAmt, uint outboundAmt) internal pure returns (Tick tick) {
     (uint man, uint exp) = ratioFromVolumes(inboundAmt, outboundAmt);
     return tickFromNormalizedRatio(man,exp);
   }
 
   // expects a normalized ratio float
-  function tickFromRatio(uint mantissa, int exp) internal pure returns (int24) {
+  function tickFromRatio(uint mantissa, int exp) internal pure returns (Tick) {
     uint normalized_exp;
     (mantissa, normalized_exp) = normalizeRatio(mantissa, exp);
     return tickFromNormalizedRatio(mantissa,normalized_exp);
@@ -43,7 +44,7 @@ library TickConversionLib {
 
   // return greatest tick t such that ratio(tick) <= input ratio
   // does not expect a normalized ratio float
-  function tickFromNormalizedRatio(uint mantissa, uint exp) internal pure returns (int24 tick) {
+  function tickFromNormalizedRatio(uint mantissa, uint exp) internal pure returns (Tick tick) {
     if (floatLt(mantissa, int(exp), MIN_RATIO_MANTISSA, MIN_RATIO_EXP)) {
       revert("mgv/ratio/tooLow");
     }
@@ -130,13 +131,13 @@ library TickConversionLib {
     int24 tickLow = int24((log_bp_ratio - 1701479891078076505009565712080972645) >> 128);
     int24 tickHigh = int24((log_bp_ratio + 290040965921304576580754310682015830659) >> 128);
 
-    (uint mantissaHigh, uint expHigh) = ratioFromTick(tickHigh);
+    (uint mantissaHigh, uint expHigh) = ratioFromTick(Tick.wrap(tickHigh));
 
     bool ratioHighGt = floatLt(mantissa, int(exp), mantissaHigh, int(expHigh));
     if (tickLow == tickHigh || ratioHighGt) {
-      tick = tickLow;
+      tick = Tick.wrap(tickLow);
     } else { 
-      tick = tickHigh;
+      tick = Tick.wrap(tickHigh);
     }
   }
 
@@ -147,8 +148,8 @@ library TickConversionLib {
 
   // return ratio from tick, as a non-normalized float (meaning the leftmost set bit is not always in the  same position)
   // first return value is the mantissa, second value is the opposite of the exponent
-  function nonNormalizedRatioFromTick(int tick) internal pure returns (uint man, uint exp) {
-    uint absTick = tick < 0 ? uint(-int(tick)) : uint(tick);
+  function nonNormalizedRatioFromTick(Tick tick) internal pure returns (uint man, uint exp) {
+    uint absTick = Tick.unwrap(tick) < 0 ? uint(-int(Tick.unwrap(tick))) : uint(Tick.unwrap(tick));
     require(absTick <= uint(MAX_TICK), "absTick/outOfBounds");
 
     // each 1.0001^(2^i) below is shifted 128+(an additional shift value)
@@ -222,7 +223,7 @@ library TickConversionLib {
       man = (man * 0xa4d9a773d61316918f140bd96e8e6814) >> 128;
       extra_shift += 75;
     }
-    if (tick > 0) {
+    if (Tick.unwrap(tick) > 0) {
       man = type(uint).max / man;
       extra_shift = -extra_shift;
     }
@@ -233,14 +234,14 @@ library TickConversionLib {
 
   // return ratio from tick, as a normalized float
   // first return value is the mantissa, second value is -exp
-  function ratioFromTick(int tick) internal pure returns (uint man, uint exp) {
+  function ratioFromTick(Tick tick) internal pure returns (uint man, uint exp) {
     (man, exp) = nonNormalizedRatioFromTick(tick);
 
     uint log_bp_2X232 = 47841652135324370225811382070797757678017615758549045118126590952295589692;
     // log_1.0001(ratio) * log_2(1.0001)
-    int log2ratio = (int(tick) << 232) / int(log_bp_2X232);
+    int log2ratio = (int(Tick.unwrap(tick)) << 232) / int(log_bp_2X232);
     // floor(log) towards negative infinity
-    if (tick < 0 && int(tick) << 232 % log_bp_2X232 != 0) {
+    if (Tick.unwrap(tick) < 0 && int(Tick.unwrap(tick)) << 232 % log_bp_2X232 != 0) {
       log2ratio = log2ratio - 1;
     }
     // MANTISSA_BITS was chosen so that diff cannot be <0 

--- a/lib/TickLib.sol
+++ b/lib/TickLib.sol
@@ -33,6 +33,13 @@ library TickLib {
     }
   }
 
+
+  // Optimized conversion for ticks that are known to map exactly to a bin at the given tickSpacing,
+  // eg for offers in the offer list which are always written with a tick-aligned tick
+  function alignedToNearestBin(Tick tick, uint tickSpacing) internal pure returns (Bin) {
+    return Bin.wrap(Tick.unwrap(tick) / int(tickSpacing));
+  }
+
   // bin underestimates the ratio, so we underestimate  inbound here, i.e. the inbound/outbound ratio will again be underestimated
   // no overflow if outboundAmt is on 104 bits
   // rounds down

--- a/lib/TickLib.sol
+++ b/lib/TickLib.sol
@@ -5,26 +5,45 @@ import {Bin} from "mgv_lib/BinLib.sol";
 import "mgv_lib/Constants.sol";
 import "mgv_lib/TickConversionLib.sol";
 
+type Tick is int;
+using TickLib for Tick global;
+
 library TickLib {
 
-  function inRange(int tick) internal pure returns (bool) {
-    return tick >= MIN_TICK && tick <= MAX_TICK;
+  function inRange(Tick tick) internal pure returns (bool) {
+    return Tick.unwrap(tick) >= MIN_TICK && Tick.unwrap(tick) <= MAX_TICK;
   }
-  function fromBin(Bin bin, uint tickSpacing) internal pure returns (int) {
-    return Bin.unwrap(bin) * int(tickSpacing);
+
+  function eq(Tick tick1, Tick tick2) internal pure returns (bool) {
+    unchecked {
+      return Tick.unwrap(tick1) == Tick.unwrap(tick2);
+    }
+  }
+
+  // Returns the nearest, higher bin to the given tick at the given tickSpacing
+  function toNearestBin(Tick tick, uint tickSpacing) internal pure returns (Bin) {
+    unchecked {
+      // Do not force ticks to fit the tickSpacing (aka tick%tickSpacing==0)
+      // Round maker ratios up such that maker is always paid at least what they asked for
+      int bin = Tick.unwrap(tick) / int(tickSpacing);
+      if (Tick.unwrap(tick) > 0 && Tick.unwrap(tick) % int(tickSpacing) != 0) {
+        bin = bin + 1;
+      }
+      return Bin.wrap(bin);
+    }
   }
 
   // bin underestimates the ratio, so we underestimate  inbound here, i.e. the inbound/outbound ratio will again be underestimated
   // no overflow if outboundAmt is on 104 bits
   // rounds down
-  function inboundFromOutbound(int tick, uint outboundAmt) internal pure returns (uint) {
+  function inboundFromOutbound(Tick tick, uint outboundAmt) internal pure returns (uint) {
     (uint sig, uint exp) = TickConversionLib.nonNormalizedRatioFromTick(tick);
     return (sig * outboundAmt) >> exp;
   }
 
   // no overflow if outboundAmt is on 104 bits
   // rounds up
-  function inboundFromOutboundUp(int tick, uint outboundAmt) internal pure returns (uint) {
+  function inboundFromOutboundUp(Tick tick, uint outboundAmt) internal pure returns (uint) {
     unchecked {
       (uint sig, uint exp) = TickConversionLib.nonNormalizedRatioFromTick(tick);
       return divExpUp(sig*outboundAmt,exp);
@@ -34,14 +53,14 @@ library TickLib {
   // bin underestimates the ratio, and we underestimate outbound here, so ratio will be overestimated here
   // no overflow if inboundAmt is on 104 bits
   // rounds down
-  function outboundFromInbound(int tick, uint inboundAmt) internal pure returns (uint) {
-    (uint sig, uint exp) = TickConversionLib.nonNormalizedRatioFromTick(-tick);
+  function outboundFromInbound(Tick tick, uint inboundAmt) internal pure returns (uint) {
+    (uint sig, uint exp) = TickConversionLib.nonNormalizedRatioFromTick(Tick.wrap(-Tick.unwrap(tick)));
     return (sig * inboundAmt) >> exp;
   }
 
-  function outboundFromInboundUp(int tick, uint inboundAmt) internal pure returns (uint) {
+  function outboundFromInboundUp(Tick tick, uint inboundAmt) internal pure returns (uint) {
     unchecked {
-      (uint sig, uint exp) = TickConversionLib.nonNormalizedRatioFromTick(-tick);
+      (uint sig, uint exp) = TickConversionLib.nonNormalizedRatioFromTick(Tick.wrap(-Tick.unwrap(tick)));
       return divExpUp(sig*inboundAmt,exp);
     }
   }

--- a/lib/TickLib.sol
+++ b/lib/TickLib.sol
@@ -21,7 +21,7 @@ library TickLib {
   }
 
   // Returns the nearest, higher bin to the given tick at the given tickSpacing
-  function toNearestBin(Tick tick, uint tickSpacing) internal pure returns (Bin) {
+  function nearestBin(Tick tick, uint tickSpacing) internal pure returns (Bin) {
     unchecked {
       // Do not force ticks to fit the tickSpacing (aka tick%tickSpacing==0)
       // Round maker ratios up such that maker is always paid at least what they asked for

--- a/lib/preprocessed/ToString.post.sol
+++ b/lib/preprocessed/ToString.post.sol
@@ -26,7 +26,7 @@ function toString(OfferPacked __packed) pure returns (string memory) {
 }
 
 function toString(OfferUnpacked memory __unpacked) pure returns (string memory) {
-  return string.concat("Offer{","prev: ", vm.toString(__unpacked.prev), ", ", "next: ", vm.toString(__unpacked.next), ", ", "tick: ", vm.toString(__unpacked.tick), ", ", "gives: ", vm.toString(__unpacked.gives),"}");
+  return string.concat("Offer{","prev: ", vm.toString(__unpacked.prev), ", ", "next: ", vm.toString(__unpacked.next), ", ", "tick: ", toString(__unpacked.tick), ", ", "gives: ", vm.toString(__unpacked.gives),"}");
 }
 
 import {OfferDetailPacked, OfferDetailUnpacked} from "mgv_src/preprocessed/MgvOfferDetail.post.sol";
@@ -60,24 +60,24 @@ function binBranchToString(Bin tick) pure returns (string memory) {
   return string.concat(vm.toString(tick.posInRoot()), "->", vm.toString(tick.posInLevel1()), "[", vm.toString(tick.level1Index()), "]->", vm.toString(tick.posInLevel2()), "[", vm.toString(tick.level2Index()), "]->", vm.toString(tick.posInLevel3()), "[", vm.toString(tick.level3Index()), "]->", vm.toString(tick.posInLeaf()), "[", vm.toString(tick.leafIndex()), "]");
 }
 
-function toString(Bin tick) pure returns (string memory ret) {
+function toString(Bin bin) pure returns (string memory ret) {
   string memory suffix;
-  if (MIN_BIN > Bin.unwrap(tick) || Bin.unwrap(tick) > MAX_BIN) {
+  if (MIN_BIN > Bin.unwrap(bin) || Bin.unwrap(bin) > MAX_BIN) {
     suffix = "out of range";
-  } else if (MIN_BIN_ALLOWED > Bin.unwrap(tick) || Bin.unwrap(tick) > MAX_BIN_ALLOWED) {
-    suffix = "out of tick range";
+  } else if (MIN_BIN_ALLOWED > Bin.unwrap(bin) || Bin.unwrap(bin) > MAX_BIN_ALLOWED) {
+    suffix = "out of bin range";
   } else {
-    suffix = tickToString(TickLib.fromBin(tick,1));
+    suffix = toString(BinLib.toNearestTick(bin,1));
   }
 
-  ret = string.concat(unicode"「", vm.toString(Bin.unwrap(tick))," (default: " ,suffix, ") {tree branch: ", binBranchToString(tick), "}", unicode"」");
+  ret = string.concat(unicode"「", vm.toString(Bin.unwrap(bin))," (default: " ,suffix, ") {tree branch: ", binBranchToString(bin), "}", unicode"」");
 }
 
-function tickToString(int tick) pure returns (string memory ret) {
+function toString(Tick tick) pure returns (string memory ret) {
   (uint man, uint exp)  = TickConversionLib.ratioFromTick(tick);
   string memory str = toFixed(man,exp);
 
-  ret = string.concat(unicode"⦗ ",vm.toString(tick),"|", str,unicode":1 ⦘");
+  ret = string.concat(unicode"⦗ ",vm.toString(Tick.unwrap(tick)),"|", str,unicode":1 ⦘");
 }
 
 function toString(Leaf leaf) pure returns (string memory ret) {

--- a/lib/preprocessed/ToString.post.sol
+++ b/lib/preprocessed/ToString.post.sol
@@ -67,7 +67,7 @@ function toString(Bin bin) pure returns (string memory ret) {
   } else if (MIN_BIN_ALLOWED > Bin.unwrap(bin) || Bin.unwrap(bin) > MAX_BIN_ALLOWED) {
     suffix = "out of bin range";
   } else {
-    suffix = toString(BinLib.toNearestTick(bin,1));
+    suffix = toString(bin.tick(1));
   }
 
   ret = string.concat(unicode"「", vm.toString(Bin.unwrap(bin))," (default: " ,suffix, ") {tree branch: ", binBranchToString(bin), "}", unicode"」");

--- a/preprocessing/ToString.pre.sol.ts
+++ b/preprocessing/ToString.pre.sol.ts
@@ -47,24 +47,24 @@ function binBranchToString(Bin tick) pure returns (string memory) {
   return string.concat(vm.toString(tick.posInRoot()), "->", vm.toString(tick.posInLevel1()), "[", vm.toString(tick.level1Index()), "]->", vm.toString(tick.posInLevel2()), "[", vm.toString(tick.level2Index()), "]->", vm.toString(tick.posInLevel3()), "[", vm.toString(tick.level3Index()), "]->", vm.toString(tick.posInLeaf()), "[", vm.toString(tick.leafIndex()), "]");
 }
 
-function toString(Bin tick) pure returns (string memory ret) {
+function toString(Bin bin) pure returns (string memory ret) {
   string memory suffix;
-  if (MIN_BIN > Bin.unwrap(tick) || Bin.unwrap(tick) > MAX_BIN) {
+  if (MIN_BIN > Bin.unwrap(bin) || Bin.unwrap(bin) > MAX_BIN) {
     suffix = "out of range";
-  } else if (MIN_BIN_ALLOWED > Bin.unwrap(tick) || Bin.unwrap(tick) > MAX_BIN_ALLOWED) {
-    suffix = "out of tick range";
+  } else if (MIN_BIN_ALLOWED > Bin.unwrap(bin) || Bin.unwrap(bin) > MAX_BIN_ALLOWED) {
+    suffix = "out of bin range";
   } else {
-    suffix = tickToString(TickLib.fromBin(tick,1));
+    suffix = toString(BinLib.toNearestTick(bin,1));
   }
 
-  ret = string.concat(unicode"「", vm.toString(Bin.unwrap(tick))," (default: " ,suffix, ") {tree branch: ", binBranchToString(tick), "}", unicode"」");
+  ret = string.concat(unicode"「", vm.toString(Bin.unwrap(bin))," (default: " ,suffix, ") {tree branch: ", binBranchToString(bin), "}", unicode"」");
 }
 
-function tickToString(int tick) pure returns (string memory ret) {
+function toString(Tick tick) pure returns (string memory ret) {
   (uint man, uint exp)  = TickConversionLib.ratioFromTick(tick);
   string memory str = toFixed(man,exp);
 
-  ret = string.concat(unicode"⦗ ",vm.toString(tick),"|", str,unicode":1 ⦘");
+  ret = string.concat(unicode"⦗ ",vm.toString(Tick.unwrap(tick)),"|", str,unicode":1 ⦘");
 }
 
 function toString(Leaf leaf) pure returns (string memory ret) {

--- a/preprocessing/ToString.pre.sol.ts
+++ b/preprocessing/ToString.pre.sol.ts
@@ -54,7 +54,7 @@ function toString(Bin bin) pure returns (string memory ret) {
   } else if (MIN_BIN_ALLOWED > Bin.unwrap(bin) || Bin.unwrap(bin) > MAX_BIN_ALLOWED) {
     suffix = "out of bin range";
   } else {
-    suffix = toString(BinLib.toNearestTick(bin,1));
+    suffix = toString(bin.tick(1));
   }
 
   ret = string.concat(unicode"「", vm.toString(Bin.unwrap(bin))," (default: " ,suffix, ") {tree branch: ", binBranchToString(bin), "}", unicode"」");

--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -135,7 +135,7 @@ library OfferPackedExtra {
   }
   function bin(OfferPacked offer, uint tickSpacing) internal pure returns (Bin) {
     // Offers are always stored with a tick that corresponds exactly to a tick
-    return offer.tick().alignedToNearestBin(tickSpacing);
+    return offer.tick().nearestBin(tickSpacing);
   }
   function clearFieldsForMaker(OfferPacked offer) internal pure returns (OfferPacked) {
     unchecked {
@@ -160,7 +160,7 @@ library OfferUnpackedExtra {
   }
   function bin(OfferUnpacked memory offer, uint tickSpacing) internal pure returns (Bin) {
     // Offers are always stored with a tick that corresponds exactly to a tick
-    return offer.tick.alignedToNearestBin(tickSpacing);
+    return offer.tick.nearestBin(tickSpacing);
   }
 
 }

--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -105,7 +105,7 @@ const struct_defs = {
       id_field("prev"),
       /* * `next` points to the immediately worse offer. The worst offer's `next` is 0. _32 bits wide_. */
       id_field("next"),
-      {name:"tick",bits:24,type:"int"},
+      {name:"tick",bits:24,type:"Tick",underlyingType: "int"},
       /* * `gives` is the amount of `outbound_tkn` the offer will give if successfully executed.
       _96 bits wide_, so assuming the usual 18 decimals, amounts can only go up to
       10 billions. */

--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -124,7 +124,7 @@ uint constant HIDE_FIELDS_FROM_MAKER_MASK = ~(prev_mask_inv | next_mask_inv);
 library OfferPackedExtra {
   // Compute wants from tick and gives
   function wants(OfferPacked offer) internal pure returns (uint) {
-    return TickLib.inboundFromOutbound(offer.tick(),offer.gives());
+    return offer.tick().inboundFromOutbound(offer.gives());
   }
   // Sugar to test offer liveness
   function isLive(OfferPacked offer) internal pure returns (bool resp) {
@@ -135,7 +135,7 @@ library OfferPackedExtra {
   }
   function bin(OfferPacked offer, uint tickSpacing) internal pure returns (Bin) {
     // Offers are always stored with a tick that corresponds exactly to a tick
-    return BinLib.fromBinAlignedTick(offer.tick(), tickSpacing);
+    return offer.tick().alignedToNearestBin(tickSpacing);
   }
   function clearFieldsForMaker(OfferPacked offer) internal pure returns (OfferPacked) {
     unchecked {
@@ -149,7 +149,7 @@ library OfferPackedExtra {
 library OfferUnpackedExtra {
   // Compute wants from tick and gives
   function wants(OfferUnpacked memory offer) internal pure returns (uint) {
-    return TickLib.inboundFromOutbound(offer.tick,offer.gives);
+    return offer.tick.inboundFromOutbound(offer.gives);
   }
   // Sugar to test offer liveness
   function isLive(OfferUnpacked memory offer) internal pure returns (bool resp) {
@@ -160,7 +160,7 @@ library OfferUnpackedExtra {
   }
   function bin(OfferUnpacked memory offer, uint tickSpacing) internal pure returns (Bin) {
     // Offers are always stored with a tick that corresponds exactly to a tick
-    return BinLib.fromBinAlignedTick(offer.tick, tickSpacing);
+    return offer.tick.alignedToNearestBin(tickSpacing);
   }
 
 }

--- a/src/IMangrove.sol
+++ b/src/IMangrove.sol
@@ -8,7 +8,7 @@ pragma solidity >=0.7.0 <0.9.0;
 
 pragma experimental ABIEncoderV2;
 
-import {MgvLib, MgvStructs, IMaker, OLKey, HasMgvEvents} from "./MgvLib.sol";
+import {MgvLib, MgvStructs, IMaker, OLKey, HasMgvEvents, Tick} from "./MgvLib.sol";
 import "./MgvLib.sol" as MgvLibWrapper;
 
 interface IMangrove is HasMgvEvents {
@@ -45,7 +45,7 @@ interface IMangrove is HasMgvEvents {
     external
     returns (uint takerGot, uint takerGave, uint bounty, uint fee);
 
-  function marketOrderByTick(OLKey memory olKey, int maxTick, uint fillVolume, bool fillWants)
+  function marketOrderByTick(OLKey memory olKey, Tick maxTick, uint fillVolume, bool fillWants)
     external
     returns (uint takerGot, uint takerGave, uint bounty, uint fee);
 
@@ -53,7 +53,7 @@ interface IMangrove is HasMgvEvents {
     external
     returns (uint takerGot, uint takerGave, uint bounty, uint feePaid);
 
-  function marketOrderForByTick(OLKey memory olKey, int tick, uint fillVolume, bool fillWants, address taker)
+  function marketOrderForByTick(OLKey memory olKey, Tick tick, uint fillVolume, bool fillWants, address taker)
     external
     returns (uint takerGot, uint takerGave, uint bounty, uint feePaid);
 
@@ -80,7 +80,7 @@ interface IMangrove is HasMgvEvents {
     payable
     returns (uint offerId);
 
-  function newOfferByTick(OLKey memory olKey, int tick, uint gives, uint gasreq, uint gasprice)
+  function newOfferByTick(OLKey memory olKey, Tick tick, uint gives, uint gasreq, uint gasprice)
     external
     payable
     returns (uint offerId);
@@ -89,13 +89,13 @@ interface IMangrove is HasMgvEvents {
     external
     payable;
 
-  function updateOfferByTick(OLKey memory olKey, int tick, uint gives, uint gasreq, uint gasprice, uint offerId)
+  function updateOfferByTick(OLKey memory olKey, Tick tick, uint gives, uint gasreq, uint gasprice, uint offerId)
     external
     payable;
 
   function marketOrderByTick(
     OLKey memory olKey,
-    int maxTick,
+    Tick maxTick,
     uint fillVolume,
     bool fillWants,
     uint maxGasreqForFailingOffers
@@ -189,7 +189,7 @@ interface IMangrove is HasMgvEvents {
   function internalCleanByImpersonation(
     OLKey memory olKey,
     uint offerId,
-    int tick,
+    Tick tick,
     uint gasreq,
     uint takerWants,
     address taker

--- a/src/MgvLib.sol
+++ b/src/MgvLib.sol
@@ -36,13 +36,13 @@ library OLLib {
   }
 
   // Convert tick to bin according to olKey's tickSpacing
-  function bin(OLKey memory olKey, Tick _tick) internal pure returns (Bin) {
-    return _tick.toNearestBin(olKey.tickSpacing);
+  function nearestBin(OLKey memory olKey, Tick _tick) internal pure returns (Bin) {
+    return _tick.nearestBin(olKey.tickSpacing);
   }
 
   // Convert bin to tick according to olKey's tickSpacing
   function tick(OLKey memory olKey, Bin _bin) internal pure returns (Tick) {
-    return _bin.toNearestTick(olKey.tickSpacing);
+    return _bin.tick(olKey.tickSpacing);
   }
 }
 

--- a/src/MgvLib.sol
+++ b/src/MgvLib.sol
@@ -34,6 +34,16 @@ library OLLib {
   function flipped(OLKey memory olKey) internal pure returns (OLKey memory) {
     return OLKey(olKey.inbound, olKey.outbound, olKey.tickSpacing);
   }
+
+  // Convert tick to bin according to olKey's tickSpacing
+  function bin(OLKey memory olKey, Tick _tick) internal pure returns (Bin) {
+    return _tick.toNearestBin(olKey.tickSpacing);
+  }
+
+  // Convert bin to tick according to olKey's tickSpacing
+  function tick(OLKey memory olKey, Bin _bin) internal pure returns (Tick) {
+    return _bin.toNearestTick(olKey.tickSpacing);
+  }
 }
 
 /* # Structs
@@ -70,7 +80,7 @@ library MgvLib {
   /* `CleanTarget` holds data about an offer that should be cleaned, i.e. made to fail by executing it with the specified volume. */
   struct CleanTarget {
     uint offerId;
-    int tick;
+    Tick tick;
     uint gasreq;
     uint takerWants;
   }
@@ -279,7 +289,7 @@ interface HasMgvEvents {
 
   By emitting `maxTick`, `fillVolume` and `fillWants`, we can now also know how much of the market order was filled and if it matches the ratio given. See OrderComplete for more.
   */
-  event OrderStart(bytes32 indexed olKeyHash, address indexed taker, int maxTick, uint fillVolume, bool fillWants);
+  event OrderStart(bytes32 indexed olKeyHash, address indexed taker, Tick maxTick, uint fillVolume, bool fillWants);
 
   /*
   This event is emitted when a market order is finished.

--- a/src/MgvOfferMaking.sol
+++ b/src/MgvOfferMaking.sol
@@ -242,8 +242,8 @@ contract MgvOfferMaking is MgvHasOffers {
 
       uint tickSpacing = ofp.olKey.tickSpacing;
       // normalize tick to tickSpacing
-      Bin insertionBin = insertionTick.toNearestBin(tickSpacing);
-      insertionTick = insertionBin.toNearestTick(tickSpacing);
+      Bin insertionBin = insertionTick.nearestBin(tickSpacing);
+      insertionTick = insertionBin.tick(tickSpacing);
       require(insertionTick.inRange(), "mgv/writeOffer/tick/outOfRange");
 
       /* Log the write offer event. */

--- a/src/MgvOfferMaking.sol
+++ b/src/MgvOfferMaking.sol
@@ -242,9 +242,9 @@ contract MgvOfferMaking is MgvHasOffers {
 
       uint tickSpacing = ofp.olKey.tickSpacing;
       // normalize tick to tickSpacing
-      Bin insertionBin = TickLib.toNearestBin(insertionTick, tickSpacing);
-      insertionTick = BinLib.toNearestTick(insertionBin, tickSpacing);
-      require(TickLib.inRange(insertionTick), "mgv/writeOffer/tick/outOfRange");
+      Bin insertionBin = insertionTick.toNearestBin(tickSpacing);
+      insertionTick = insertionBin.toNearestTick(tickSpacing);
+      require(insertionTick.inRange(), "mgv/writeOffer/tick/outOfRange");
 
       /* Log the write offer event. */
       uint ofrId = ofp.id;

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -35,7 +35,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
     uint fillVolume; // used globally
     uint feePaid; // used globally
     Leaf leaf;
-    int maxTick; // maxTick is the log of the max ratio that can be reached by the market order as a limit ratio.
+    Tick maxTick; // maxTick is the log of the max ratio that can be reached by the market order as a limit ratio.
     uint maxGasreqForFailingOffers;
     uint gasreqForFailingOffers;
     uint maxRecursionDepth;
@@ -58,11 +58,11 @@ abstract contract MgvOfferTaking is MgvHasOffers {
     returns (uint takerGot, uint takerGave, uint bounty, uint fee)
   {
     uint fillVolume = fillWants ? takerWants : takerGives;
-    int maxTick = TickConversionLib.tickFromVolumes(takerGives, takerWants);
+    Tick maxTick = TickConversionLib.tickFromVolumes(takerGives, takerWants);
     return marketOrderByTick(olKey, maxTick, fillVolume, fillWants);
   }
 
-  function marketOrderByTick(OLKey memory olKey, int maxTick, uint fillVolume, bool fillWants)
+  function marketOrderByTick(OLKey memory olKey, Tick maxTick, uint fillVolume, bool fillWants)
     public
     returns (uint takerGot, uint takerGave, uint bounty, uint fee)
   {
@@ -73,7 +73,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
   function marketOrderByTick(
     OLKey memory olKey,
-    int maxTick,
+    Tick maxTick,
     uint fillVolume,
     bool fillWants,
     uint maxGasreqForFailingOffers
@@ -153,7 +153,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
   function generalMarketOrder(
     OLKey memory olKey,
-    int maxTick,
+    Tick maxTick,
     uint fillVolume,
     bool fillWants,
     address taker,
@@ -225,8 +225,8 @@ abstract contract MgvOfferTaking is MgvHasOffers {
   {
     unchecked {
       if (
-        mor.fillVolume > 0 && sor.offer.tick() <= mor.maxTick && sor.offerId > 0 && mor.maxRecursionDepth > 0
-          && mor.gasreqForFailingOffers <= mor.maxGasreqForFailingOffers
+        mor.fillVolume > 0 && Tick.unwrap(sor.offer.tick()) <= Tick.unwrap(mor.maxTick) && sor.offerId > 0
+          && mor.maxRecursionDepth > 0 && mor.gasreqForFailingOffers <= mor.maxGasreqForFailingOffers
       ) {
         mor.maxRecursionDepth--;
 
@@ -389,7 +389,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
   function internalCleanByImpersonation(
     OLKey memory olKey,
     uint offerId,
-    int tick,
+    Tick tick,
     uint gasreq,
     uint takerWants,
     address taker
@@ -429,7 +429,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
       /* We also check that `gasreq` is not worse than specified. A taker who does not care about `gasreq` can specify any amount larger than $2^{24}-1$. */
       require(sor.offerDetail.gasreq() <= gasreq, "mgv/clean/gasreqTooLow");
       /* A mismatched ratio will be detected by `execute`. */
-      require(sor.offer.tick() == tick, "mgv/clean/tickMismatch");
+      require(sor.offer.tick().eq(tick), "mgv/clean/tickMismatch");
 
       /* We start be enabling the reentrancy lock for this (`outbound_tkn`,`inbound_tkn`) pair. */
       sor.local = sor.local.lock(true);

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -162,7 +162,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
     unchecked {
       /* Checking that `takerWants` and `takerGives` fit in 104 bits prevents overflow during the main market order loop. */
       require(fillVolume <= MAX_SAFE_VOLUME, "mgv/mOrder/fillVolume/tooBig");
-      require(TickLib.inRange(maxTick), "mgv/mOrder/tick/outOfRange");
+      require(maxTick.inRange(), "mgv/mOrder/tick/outOfRange");
 
       /* `MultiOrder` (defined above) maintains information related to the entire market order. During the order, initial `wants`/`gives` values minus the accumulated amounts traded so far give the amounts that remain to be traded. */
       MultiOrder memory mor;
@@ -400,7 +400,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
       MultiOrder memory mor;
       {
-        require(TickLib.inRange(tick), "mgv/clean/tick/outOfRange");
+        require(tick.inRange(), "mgv/clean/tick/outOfRange");
         mor.maxTick = tick;
       }
       {
@@ -497,11 +497,11 @@ abstract contract MgvOfferTaking is MgvHasOffers {
           sor.takerGives = offerWants;
         } else {
           if (mor.fillWants) {
-            sor.takerGives = TickLib.inboundFromOutboundUp(sor.offer.tick(), fillVolume);
+            sor.takerGives = sor.offer.tick().inboundFromOutboundUp(fillVolume);
             sor.takerWants = fillVolume;
           } else {
             // offerWants = 0 is forbidden at offer writing
-            sor.takerWants = TickLib.outboundFromInbound(sor.offer.tick(), fillVolume);
+            sor.takerWants = sor.offer.tick().outboundFromInbound(fillVolume);
             sor.takerGives = fillVolume;
           }
         }

--- a/src/MgvOfferTakingWithPermit.sol
+++ b/src/MgvOfferTakingWithPermit.sol
@@ -78,12 +78,12 @@ abstract contract MgvOfferTakingWithPermit is MgvOfferTaking {
       require(uint160(takerWants) == takerWants, "mgv/mOrder/takerWants/160bits");
       require(uint160(takerGives) == takerGives, "mgv/mOrder/takerGives/160bits");
       uint fillVolume = fillWants ? takerWants : takerGives;
-      int tick = TickConversionLib.tickFromVolumes(takerGives, takerWants);
+      Tick tick = TickConversionLib.tickFromVolumes(takerGives, takerWants);
       return marketOrderForByTick(olKey, tick, fillVolume, fillWants, taker);
     }
   }
 
-  function marketOrderForByTick(OLKey memory olKey, int tick, uint fillVolume, bool fillWants, address taker)
+  function marketOrderForByTick(OLKey memory olKey, Tick tick, uint fillVolume, bool fillWants, address taker)
     public
     returns (uint takerGot, uint takerGave, uint bounty, uint feePaid)
   {

--- a/src/periphery/MgvReader.sol
+++ b/src/periphery/MgvReader.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.10;
 
-import {MgvLib, MgvStructs, Bin, Leaf, Field, TickLib, OLKey} from "mgv_src/MgvLib.sol";
+import {MgvLib, MgvStructs, Bin, Leaf, Field, TickLib, OLKey, Tick} from "mgv_src/MgvLib.sol";
 import {IMangrove} from "mgv_src/IMangrove.sol";
 import {TickConversionLib} from "mgv_lib/TickConversionLib.sol";
 
@@ -51,7 +51,7 @@ function toOLKey(Market memory market) pure returns (OLKey memory) {
 contract MgvReader {
   struct MarketOrder {
     OLKey olKey;
-    int maxTick;
+    Tick maxTick;
     uint initialFillVolume;
     uint totalGot;
     uint totalGave;
@@ -395,11 +395,11 @@ contract MgvReader {
     bool accumulate
   ) public view returns (VolumeData[] memory) {
     uint fillVolume = fillWants ? takerWants : takerGives;
-    int maxTick = TickConversionLib.tickFromVolumes(takerGives, takerWants);
+    Tick maxTick = TickConversionLib.tickFromVolumes(takerGives, takerWants);
     return simulateMarketOrderByTick(olKey, maxTick, fillVolume, fillWants, accumulate);
   }
 
-  function simulateMarketOrderByTick(OLKey memory olKey, int maxTick, uint fillVolume, bool fillWants)
+  function simulateMarketOrderByTick(OLKey memory olKey, Tick maxTick, uint fillVolume, bool fillWants)
     public
     view
     returns (VolumeData[] memory)
@@ -407,7 +407,7 @@ contract MgvReader {
     return simulateMarketOrderByTick(olKey, maxTick, fillVolume, fillWants, true);
   }
 
-  function simulateMarketOrderByTick(OLKey memory olKey, int maxTick, uint fillVolume, bool fillWants, bool accumulate)
+  function simulateMarketOrderByTick(OLKey memory olKey, Tick maxTick, uint fillVolume, bool fillWants, bool accumulate)
     public
     view
     returns (VolumeData[] memory)
@@ -432,7 +432,10 @@ contract MgvReader {
 
   function simulateInternalMarketOrder(MarketOrder memory mr) internal view {
     unchecked {
-      if (mr.currentFillVolume > 0 && mr.offer.tick() <= mr.maxTick && mr.offerId > 0 && mr.maxRecursionDepth > 0) {
+      if (
+        mr.currentFillVolume > 0 && Tick.unwrap(mr.offer.tick()) <= Tick.unwrap(mr.maxTick) && mr.offerId > 0
+          && mr.maxRecursionDepth > 0
+      ) {
         uint currentIndex = mr.numOffers;
 
         mr.offerDetail = MGV.offerDetails(mr.olKey, mr.offerId);

--- a/src/periphery/MgvReader.sol
+++ b/src/periphery/MgvReader.sol
@@ -483,11 +483,11 @@ contract MgvReader {
           mr.currentGives = offerWants;
         } else {
           if (mr.fillWants) {
-            mr.currentGives = TickLib.inboundFromOutboundUp(mr.offer.tick(), fillVolume);
+            mr.currentGives = mr.offer.tick().inboundFromOutboundUp(fillVolume);
             mr.currentWants = fillVolume;
           } else {
             // offerWants = 0 is forbidden at offer writing
-            mr.currentWants = TickLib.outboundFromInbound(mr.offer.tick(), fillVolume);
+            mr.currentWants = mr.offer.tick().outboundFromInbound(fillVolume);
             mr.currentGives = fillVolume;
           }
         }

--- a/src/preprocessed/MgvOffer.post.sol
+++ b/src/preprocessed/MgvOffer.post.sol
@@ -39,7 +39,7 @@ uint constant HIDE_FIELDS_FROM_MAKER_MASK = ~(prev_mask_inv | next_mask_inv);
 library OfferPackedExtra {
   // Compute wants from tick and gives
   function wants(OfferPacked offer) internal pure returns (uint) {
-    return TickLib.inboundFromOutbound(offer.tick(),offer.gives());
+    return offer.tick().inboundFromOutbound(offer.gives());
   }
   // Sugar to test offer liveness
   function isLive(OfferPacked offer) internal pure returns (bool resp) {
@@ -50,7 +50,7 @@ library OfferPackedExtra {
   }
   function bin(OfferPacked offer, uint tickSpacing) internal pure returns (Bin) {
     // Offers are always stored with a tick that corresponds exactly to a tick
-    return BinLib.fromBinAlignedTick(offer.tick(), tickSpacing);
+    return offer.tick().alignedToNearestBin(tickSpacing);
   }
   function clearFieldsForMaker(OfferPacked offer) internal pure returns (OfferPacked) {
     unchecked {
@@ -64,7 +64,7 @@ library OfferPackedExtra {
 library OfferUnpackedExtra {
   // Compute wants from tick and gives
   function wants(OfferUnpacked memory offer) internal pure returns (uint) {
-    return TickLib.inboundFromOutbound(offer.tick,offer.gives);
+    return offer.tick.inboundFromOutbound(offer.gives);
   }
   // Sugar to test offer liveness
   function isLive(OfferUnpacked memory offer) internal pure returns (bool resp) {
@@ -75,7 +75,7 @@ library OfferUnpackedExtra {
   }
   function bin(OfferUnpacked memory offer, uint tickSpacing) internal pure returns (Bin) {
     // Offers are always stored with a tick that corresponds exactly to a tick
-    return BinLib.fromBinAlignedTick(offer.tick, tickSpacing);
+    return offer.tick.alignedToNearestBin(tickSpacing);
   }
 
 }

--- a/src/preprocessed/MgvOffer.post.sol
+++ b/src/preprocessed/MgvOffer.post.sol
@@ -17,7 +17,7 @@ import "mgv_lib/Constants.sol";
 struct OfferUnpacked {
   uint prev;
   uint next;
-  int tick;
+  Tick tick;
   uint gives;
 }
 
@@ -123,7 +123,7 @@ library Library {
   function to_struct(OfferPacked __packed) internal pure returns (OfferUnpacked memory __s) { unchecked {
     __s.prev  = uint(OfferPacked.unwrap(__packed) << prev_before) >> (256 - prev_bits);
     __s.next  = uint(OfferPacked.unwrap(__packed) << next_before) >> (256 - next_bits);
-    __s.tick  = int(int(OfferPacked.unwrap(__packed) << tick_before) >> (256 - tick_bits));
+    __s.tick  = Tick.wrap(int(int(OfferPacked.unwrap(__packed) << tick_before) >> (256 - tick_bits)));
     __s.gives = uint(OfferPacked.unwrap(__packed) << gives_before) >> (256 - gives_bits);
   }}
 
@@ -133,10 +133,10 @@ library Library {
   }}
 
   // from packed to a tuple
-  function unpack(OfferPacked __packed) internal pure returns (uint __prev, uint __next, int __tick, uint __gives) { unchecked {
+  function unpack(OfferPacked __packed) internal pure returns (uint __prev, uint __next, Tick __tick, uint __gives) { unchecked {
     __prev  = uint(OfferPacked.unwrap(__packed) << prev_before) >> (256 - prev_bits);
     __next  = uint(OfferPacked.unwrap(__packed) << next_before) >> (256 - next_bits);
-    __tick  = int(int(OfferPacked.unwrap(__packed) << tick_before) >> (256 - tick_bits));
+    __tick  = Tick.wrap(int(int(OfferPacked.unwrap(__packed) << tick_before) >> (256 - tick_bits)));
     __gives = uint(OfferPacked.unwrap(__packed) << gives_before) >> (256 - gives_bits);
   }}
 
@@ -159,13 +159,13 @@ library Library {
     return OfferPacked.wrap((OfferPacked.unwrap(__packed) & next_mask) | (val << (256 - next_bits)) >> next_before);
   }}
   
-  function tick(OfferPacked __packed) internal pure returns(int) { unchecked {
-    return int(int(OfferPacked.unwrap(__packed) << tick_before) >> (256 - tick_bits));
+  function tick(OfferPacked __packed) internal pure returns(Tick) { unchecked {
+    return Tick.wrap(int(int(OfferPacked.unwrap(__packed) << tick_before) >> (256 - tick_bits)));
   }}
 
   // setters
-  function tick(OfferPacked __packed,int val) internal pure returns(OfferPacked) { unchecked {
-    return OfferPacked.wrap((OfferPacked.unwrap(__packed) & tick_mask) | (uint(val) << (256 - tick_bits)) >> tick_before);
+  function tick(OfferPacked __packed,Tick val) internal pure returns(OfferPacked) { unchecked {
+    return OfferPacked.wrap((OfferPacked.unwrap(__packed) & tick_mask) | (uint(Tick.unwrap(val)) << (256 - tick_bits)) >> tick_before);
   }}
   
   function gives(OfferPacked __packed) internal pure returns(uint) { unchecked {
@@ -185,11 +185,11 @@ function t_of_struct(OfferUnpacked memory __s) pure returns (OfferPacked) { unch
 }}
 
 // from arguments to packed
-function pack(uint __prev, uint __next, int __tick, uint __gives) pure returns (OfferPacked) { unchecked {
+function pack(uint __prev, uint __next, Tick __tick, uint __gives) pure returns (OfferPacked) { unchecked {
   uint __packed;
   __packed |= (__prev << (256 - prev_bits)) >> prev_before;
   __packed |= (__next << (256 - next_bits)) >> next_before;
-  __packed |= (uint(__tick) << (256 - tick_bits)) >> tick_before;
+  __packed |= (uint(Tick.unwrap(__tick)) << (256 - tick_bits)) >> tick_before;
   __packed |= (__gives << (256 - gives_bits)) >> gives_before;
   return OfferPacked.wrap(__packed);
 }}
@@ -201,8 +201,8 @@ function prev_check(uint __prev) pure returns (bool) { unchecked {
 function next_check(uint __next) pure returns (bool) { unchecked {
   return (__next & next_cast_mask) == __next;
 }}
-function tick_check(int __tick) pure returns (bool) { unchecked {
-  return (uint(__tick) & tick_cast_mask) == uint(__tick);
+function tick_check(Tick __tick) pure returns (bool) { unchecked {
+  return (uint(Tick.unwrap(__tick)) & tick_cast_mask) == uint(Tick.unwrap(__tick));
 }}
 function gives_check(uint __gives) pure returns (bool) { unchecked {
   return (__gives & gives_cast_mask) == __gives;

--- a/src/preprocessed/MgvOffer.post.sol
+++ b/src/preprocessed/MgvOffer.post.sol
@@ -50,7 +50,7 @@ library OfferPackedExtra {
   }
   function bin(OfferPacked offer, uint tickSpacing) internal pure returns (Bin) {
     // Offers are always stored with a tick that corresponds exactly to a tick
-    return offer.tick().alignedToNearestBin(tickSpacing);
+    return offer.tick().nearestBin(tickSpacing);
   }
   function clearFieldsForMaker(OfferPacked offer) internal pure returns (OfferPacked) {
     unchecked {
@@ -75,7 +75,7 @@ library OfferUnpackedExtra {
   }
   function bin(OfferUnpacked memory offer, uint tickSpacing) internal pure returns (Bin) {
     // Offers are always stored with a tick that corresponds exactly to a tick
-    return offer.tick.alignedToNearestBin(tickSpacing);
+    return offer.tick.nearestBin(tickSpacing);
   }
 
 }

--- a/test/core/Constant.t.sol
+++ b/test/core/Constant.t.sol
@@ -2,12 +2,12 @@
 
 pragma solidity ^0.8.10;
 
-import "mgv_lib/Test2.sol";
+import "mgv_test/lib/MangroveTest.sol";
 import "mgv_src/MgvLib.sol";
 import "mgv_lib/TickConversionLib.sol";
 
 // In these tests, the testing contract is the market maker.
-contract ConstantsTest is Test2 {
+contract ConstantsTest is MangroveTest {
   function test_constants_min_max_ratio() public {
     (uint man, uint exp) = TickConversionLib.ratioFromTick(Tick.wrap(MIN_TICK));
     assertEq(man, MIN_RATIO_MANTISSA);
@@ -15,6 +15,14 @@ contract ConstantsTest is Test2 {
     (man, exp) = TickConversionLib.ratioFromTick(Tick.wrap(MAX_TICK));
     assertEq(man, MAX_RATIO_MANTISSA);
     assertEq(int(exp), MAX_RATIO_EXP);
+  }
+
+  function test_constants_min_max_ratio2() public {
+    Tick tick;
+    tick = TickConversionLib.tickFromNormalizedRatio(MIN_RATIO_MANTISSA, uint(MIN_RATIO_EXP));
+    assertEq(tick, Tick.wrap(MIN_TICK));
+    tick = TickConversionLib.tickFromNormalizedRatio(MAX_RATIO_MANTISSA, uint(MAX_RATIO_EXP));
+    assertEq(tick, Tick.wrap(MAX_TICK));
   }
 
   // Since "Only direct number constants and references to such constants are supported by inline assembly", NOT_TOPBIT is not defined in terms of TOPBIT. Here we check that its definition is correct.

--- a/test/core/Constant.t.sol
+++ b/test/core/Constant.t.sol
@@ -9,10 +9,10 @@ import "mgv_lib/TickConversionLib.sol";
 // In these tests, the testing contract is the market maker.
 contract ConstantsTest is Test2 {
   function test_constants_min_max_ratio() public {
-    (uint man, uint exp) = TickConversionLib.ratioFromTick(MIN_TICK);
+    (uint man, uint exp) = TickConversionLib.ratioFromTick(Tick.wrap(MIN_TICK));
     assertEq(man, MIN_RATIO_MANTISSA);
     assertEq(int(exp), MIN_RATIO_EXP);
-    (man, exp) = TickConversionLib.ratioFromTick(MAX_TICK);
+    (man, exp) = TickConversionLib.ratioFromTick(Tick.wrap(MAX_TICK));
     assertEq(man, MAX_RATIO_MANTISSA);
     assertEq(int(exp), MAX_RATIO_EXP);
   }

--- a/test/core/DynamicTicks.t.sol
+++ b/test/core/DynamicTicks.t.sol
@@ -24,13 +24,13 @@ contract DynamicBinsTest is MangroveTest {
   function test_bin_to_tick(int24 _bin, uint16 tickSpacing) public {
     vm.assume(tickSpacing != 0);
     Bin bin = Bin.wrap(_bin);
-    assertEq(bin.toNearestTick(tickSpacing), Tick.wrap(int(_bin) * int(uint(tickSpacing))), "wrong bin -> tick");
+    assertEq(bin.tick(tickSpacing), Tick.wrap(int(_bin) * int(uint(tickSpacing))), "wrong bin -> tick");
   }
 
-  function test_tick_to_nearest_bin(int96 itick, uint16 _tickSpacing) public {
+  function test_tick_to_nearest_bin(int24 itick, uint16 _tickSpacing) public {
     vm.assume(_tickSpacing != 0);
-    Bin bin = Tick.wrap(itick).toNearestBin(_tickSpacing);
-    assertGe(Tick.unwrap(bin.toNearestTick(_tickSpacing)), itick, "tick -> bin -> tick must give same or lower bin");
+    Bin bin = Tick.wrap(itick).nearestBin(_tickSpacing);
+    assertGe(Tick.unwrap(bin.tick(_tickSpacing)), itick, "tick -> bin -> tick must give same or lower bin");
 
     int tickSpacing = int(uint(_tickSpacing));
     int expectedBin = itick / tickSpacing;
@@ -44,7 +44,7 @@ contract DynamicBinsTest is MangroveTest {
     vm.assume(_tickSpacing != 0);
     vm.assume(tick % int(uint(_tickSpacing)) == 0);
     Bin bin = Tick.wrap(tick).alignedToNearestBin(_tickSpacing);
-    assertEq(bin.toNearestTick(_tickSpacing), Tick.wrap(tick), "aligned tick -> bin -> tick must give same tick");
+    assertEq(bin.tick(_tickSpacing), Tick.wrap(tick), "aligned tick -> bin -> tick must give same tick");
   }
 
   // get a valid tick from a random int24
@@ -63,7 +63,7 @@ contract DynamicBinsTest is MangroveTest {
     tick = boundTick(tick);
     uint gives = 1 ether;
 
-    Tick insertionTick = Tick.wrap(tick).toNearestBin(tickSpacing).toNearestTick(tickSpacing);
+    Tick insertionTick = Tick.wrap(tick).nearestBin(tickSpacing).tick(tickSpacing);
 
     vm.assume(insertionTick.inRange());
 
@@ -83,7 +83,7 @@ contract DynamicBinsTest is MangroveTest {
     OLKey memory ol2 = OLKey(olKey.outbound, olKey.inbound, tickSpacing2);
     uint gives = 1 ether;
 
-    Tick insertionTick = Tick.wrap(tick).toNearestBin(tickSpacing).toNearestTick(tickSpacing);
+    Tick insertionTick = Tick.wrap(tick).nearestBin(tickSpacing).tick(tickSpacing);
     vm.assume(insertionTick.inRange());
 
     mgv.activate(olKey, 0, 100 << 32, 0);
@@ -118,8 +118,8 @@ contract DynamicBinsTest is MangroveTest {
     tick = boundTick(tick);
     vm.assume(tickSpacing != 0);
     uint gives = 1 ether;
-    Bin insertionBin = Tick.wrap(tick).toNearestBin(tickSpacing);
-    Tick insertionTick = insertionBin.toNearestTick(tickSpacing);
+    Bin insertionBin = Tick.wrap(tick).nearestBin(tickSpacing);
+    Tick insertionTick = insertionBin.tick(tickSpacing);
     vm.assume(insertionTick.inRange());
 
     mgv.activate(olKey, 0, 100 << 32, 0);
@@ -172,8 +172,8 @@ contract DynamicBinsTest is MangroveTest {
     vm.assume(tickSpacing != 0);
     vm.assume(int(tick) % int(uint(tickSpacing)) != 0);
     tick = boundTick(tick);
-    Bin insertionBin = Tick.wrap(tick).toNearestBin(tickSpacing);
-    Tick insertionTick = insertionBin.toNearestTick(tickSpacing);
+    Bin insertionBin = Tick.wrap(tick).nearestBin(tickSpacing);
+    Tick insertionTick = insertionBin.tick(tickSpacing);
     vm.assume(insertionTick.inRange());
     olKey.tickSpacing = tickSpacing;
 

--- a/test/core/DynamicTicks.t.sol
+++ b/test/core/DynamicTicks.t.sol
@@ -43,7 +43,7 @@ contract DynamicBinsTest is MangroveTest {
   function test_aligned_tick_to_bin(int96 tick, uint _tickSpacing) public {
     vm.assume(_tickSpacing != 0);
     vm.assume(tick % int(uint(_tickSpacing)) == 0);
-    Bin bin = Tick.wrap(tick).alignedToNearestBin(_tickSpacing);
+    Bin bin = Tick.wrap(tick).nearestBin(_tickSpacing);
     assertEq(bin.tick(_tickSpacing), Tick.wrap(tick), "aligned tick -> bin -> tick must give same tick");
   }
 

--- a/test/core/Gatekeeping.t.sol
+++ b/test/core/Gatekeeping.t.sol
@@ -592,7 +592,7 @@ contract GatekeepingTest is MangroveTest {
     uint id = mgv.newOfferByVolume(olKey, 0.05 ether, 0.05 ether, 3500_000, 0);
     MgvStructs.OfferPacked ofr = mgv.offers(olKey, id);
     Bin nextBin = Bin.wrap(Bin.unwrap(ofr.bin(olKey.tickSpacing)) + 1);
-    uint gives = TickLib.outboundFromInbound(BinLib.toNearestTick(nextBin, olKey.tickSpacing), 5 ether);
+    uint gives = olKey.tick(nextBin).outboundFromInbound(5 ether);
     uint id2 = mgv.newOfferByVolume(olKey, 5 ether, gives, 3500_000, 0);
     tkr.marketOrder(0.05 ether, 0.05 ether);
     // low-level check

--- a/test/core/InvertedTakerOperations.t.sol
+++ b/test/core/InvertedTakerOperations.t.sol
@@ -96,7 +96,7 @@ contract InvertedTakerOperationsTest is ITaker, MangroveTest {
     uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 50_000, 0);
     uint mgvQuoteBal = quote.balanceOf(address(mgv));
 
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     mgv.marketOrderByTick(olKey, tick, 1 ether, true);
     assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertEq(quote.balanceOf(address(mgv)) - mgvQuoteBal, 1 ether, "Mgv balance should have increased");
@@ -108,7 +108,7 @@ contract InvertedTakerOperationsTest is ITaker, MangroveTest {
     _takerTrade = noop;
     skipCheck = true;
     uint ofr = 2;
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     (uint totalGot, uint totalGave,,) = mgv.marketOrderByTick(olKey, tick, 0.1 ether, true);
     assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertEq(totalGot, 0.1 ether, "Incorrect totalGot");
@@ -132,7 +132,7 @@ contract InvertedTakerOperationsTest is ITaker, MangroveTest {
 
   function test_taker_pays_back_correct_amount_1() public {
     uint ofr = mkr.newOfferByVolume(0.1 ether, 0.1 ether, 100_000, 0);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     uint bal = quote.balanceOf($(this));
     _takerTrade = noop;
     mgv.marketOrderByTick(olKey, tick, 0.05 ether, true);
@@ -142,7 +142,7 @@ contract InvertedTakerOperationsTest is ITaker, MangroveTest {
 
   function test_taker_pays_back_correct_amount_2() public {
     uint ofr = mkr.newOfferByVolume(0.1 ether, 0.1 ether, 100_000, 0);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     uint bal = quote.balanceOf($(this));
     _takerTrade = noop;
     mgv.marketOrderByTick(olKey, tick, 0.02 ether, true);

--- a/test/core/Leaf.t.sol
+++ b/test/core/Leaf.t.sol
@@ -266,8 +266,8 @@ contract TickAndBinTest is MangroveTest {
 
   function showTickApprox(uint wants, uint gives) internal pure {
     Tick tick = TickConversionLib.tickFromVolumes(wants, gives);
-    uint wants2 = TickLib.inboundFromOutbound(tick, gives);
-    uint gives2 = TickLib.outboundFromInbound(tick, wants);
+    uint wants2 = tick.inboundFromOutbound(gives);
+    uint gives2 = tick.outboundFromInbound(wants);
     console.log("tick  ", toString(tick));
     console.log("wants ", wants);
     console.log("wants2", wants2);
@@ -498,11 +498,11 @@ contract FieldTest is MangroveTest {
 
     //inboundFromOutboundUp
     (sig, exp) = TickConversionLib.nonNormalizedRatioFromTick(tick);
-    assertEq(TickLib.inboundFromOutboundUp(tick, amt), divExpUp_spec(sig * amt, exp));
+    assertEq(tick.inboundFromOutboundUp(amt), divExpUp_spec(sig * amt, exp));
 
     //outboundFromInboundUp
     (sig, exp) = TickConversionLib.nonNormalizedRatioFromTick(Tick.wrap(-Tick.unwrap(tick)));
-    assertEq(TickLib.outboundFromInboundUp(tick, amt), divExpUp_spec(sig * amt, exp));
+    assertEq(tick.outboundFromInboundUp(amt), divExpUp_spec(sig * amt, exp));
   }
 
   function test_divExpUp(uint a, uint exp) public {

--- a/test/core/Leaf.t.sol
+++ b/test/core/Leaf.t.sol
@@ -5,9 +5,10 @@ pragma solidity ^0.8.10;
 import "mgv_lib/Test2.sol";
 import "mgv_src/MgvLib.sol";
 import "mgv_lib/TickConversionLib.sol";
+import "mgv_test/lib/MangroveTest.sol";
 
 // In these tests, the testing contract is the market maker.
-contract LeafTest is Test2 {
+contract LeafTest is MangroveTest {
   function assertStr(Leaf leaf, string memory str) internal {
     assertEq(toString(leaf), str);
   }
@@ -185,7 +186,7 @@ contract LeafTest is Test2 {
   }
 }
 
-contract TickAndBinTest is Test {
+contract TickAndBinTest is MangroveTest {
   function test_posInLeaf_auto(int bin) public {
     bin = bound(bin, MIN_BIN, MAX_BIN);
     int tn = NUM_BINS / 2 + bin; // normalize to positive
@@ -212,50 +213,62 @@ contract TickAndBinTest is Test {
 
   // note that tick(p) is max {t | ratio(t) <= p}
   function test_tickFromVolumes() public {
-    assertEq(TickConversionLib.tickFromVolumes(1, 1), 0);
-    assertEq(TickConversionLib.tickFromVolumes(2, 1), 6931);
-    assertEq(TickConversionLib.tickFromVolumes(1, 2), -6932);
-    assertEq(TickConversionLib.tickFromVolumes(1e18, 1), 414486);
-    assertEq(TickConversionLib.tickFromVolumes(type(uint96).max, 1), 665454);
-    assertEq(TickConversionLib.tickFromVolumes(1, type(uint96).max), -665455);
-    assertEq(TickConversionLib.tickFromVolumes(type(uint72).max, 1), 499090);
-    assertEq(TickConversionLib.tickFromVolumes(1, type(uint72).max), -499091);
-    assertEq(TickConversionLib.tickFromVolumes(999999, 1000000), -1);
-    assertEq(TickConversionLib.tickFromVolumes(1000000, 999999), 0);
-    assertEq(TickConversionLib.tickFromVolumes(1000000 * 1e18, 999999 * 1e18), 0);
+    assertEq(TickConversionLib.tickFromVolumes(1, 1), Tick.wrap(0));
+    assertEq(TickConversionLib.tickFromVolumes(2, 1), Tick.wrap(6931));
+    assertEq(TickConversionLib.tickFromVolumes(1, 2), Tick.wrap(-6932));
+    assertEq(TickConversionLib.tickFromVolumes(1e18, 1), Tick.wrap(414486));
+    assertEq(TickConversionLib.tickFromVolumes(type(uint96).max, 1), Tick.wrap(665454));
+    assertEq(TickConversionLib.tickFromVolumes(1, type(uint96).max), Tick.wrap(-665455));
+    assertEq(TickConversionLib.tickFromVolumes(type(uint72).max, 1), Tick.wrap(499090));
+    assertEq(TickConversionLib.tickFromVolumes(1, type(uint72).max), Tick.wrap(-499091));
+    assertEq(TickConversionLib.tickFromVolumes(999999, 1000000), Tick.wrap(-1));
+    assertEq(TickConversionLib.tickFromVolumes(1000000, 999999), Tick.wrap(0));
+    assertEq(TickConversionLib.tickFromVolumes(1000000 * 1e18, 999999 * 1e18), Tick.wrap(0));
   }
 
   function test_ratioFromTick() public {
     inner_test_ratioFromTick({
-      bin: 2 ** 20 - 1,
+      tick: Tick.wrap(2 ** 20 - 1),
       expected_sig: 3441571814221581909035848501253497354125574144,
       expected_exp: 0
     });
 
     inner_test_ratioFromTick({
-      bin: 138162,
+      tick: Tick.wrap(138162),
       expected_sig: 5444510673556857440102348422228887810808479744,
       expected_exp: 132
     });
 
-    inner_test_ratioFromTick({bin: -1, expected_sig: 5708419928830956428590284849313049240594808832, expected_exp: 152});
+    inner_test_ratioFromTick({
+      tick: Tick.wrap(-1),
+      expected_sig: 5708419928830956428590284849313049240594808832,
+      expected_exp: 152
+    });
 
-    inner_test_ratioFromTick({bin: 0, expected_sig: 2854495385411919762116571938898990272765493248, expected_exp: 151});
+    inner_test_ratioFromTick({
+      tick: Tick.wrap(0),
+      expected_sig: 2854495385411919762116571938898990272765493248,
+      expected_exp: 151
+    });
 
-    inner_test_ratioFromTick({bin: 1, expected_sig: 2854780834950460954092783596092880171791548416, expected_exp: 151});
+    inner_test_ratioFromTick({
+      tick: Tick.wrap(1),
+      expected_sig: 2854780834950460954092783596092880171791548416,
+      expected_exp: 151
+    });
   }
 
-  function inner_test_ratioFromTick(int bin, uint expected_sig, uint expected_exp) internal {
-    (uint sig, uint exp) = TickConversionLib.ratioFromTick(bin);
+  function inner_test_ratioFromTick(Tick tick, uint expected_sig, uint expected_exp) internal {
+    (uint sig, uint exp) = TickConversionLib.ratioFromTick(tick);
     assertEq(expected_sig, sig, "wrong sig");
     assertEq(expected_exp, exp, "wrong exp");
   }
 
   function showTickApprox(uint wants, uint gives) internal pure {
-    int tick = TickConversionLib.tickFromVolumes(wants, gives);
+    Tick tick = TickConversionLib.tickFromVolumes(wants, gives);
     uint wants2 = TickLib.inboundFromOutbound(tick, gives);
     uint gives2 = TickLib.outboundFromInbound(tick, wants);
-    console.log("tick  ", tickToString(tick));
+    console.log("tick  ", toString(tick));
     console.log("wants ", wants);
     console.log("wants2", wants2);
     console.log("--------------");
@@ -326,7 +339,7 @@ contract TickAndBinTest is Test {
   }
 }
 
-contract FieldTest is Test {
+contract FieldTest is MangroveTest {
   function test_flipBit0(uint _field, uint8 posInLevel) public {
     posInLevel = uint8(bound(posInLevel, 0, uint(LEVEL_SIZE - 1)));
     bytes32 field = bytes32(_field);
@@ -476,9 +489,9 @@ contract FieldTest is Test {
     return a / den + carry;
   }
 
-  function test_inboundFromOutboundUp_and_converse(int tick, uint amt) public {
+  function test_inboundFromOutboundUp_and_converse(Tick tick, uint amt) public {
     amt = bound(amt, 0, MAX_SAFE_VOLUME);
-    tick = bound(tick, MIN_TICK, MAX_TICK);
+    tick = Tick.wrap(bound(Tick.unwrap(tick), MIN_TICK, MAX_TICK));
 
     uint sig;
     uint exp;
@@ -488,7 +501,7 @@ contract FieldTest is Test {
     assertEq(TickLib.inboundFromOutboundUp(tick, amt), divExpUp_spec(sig * amt, exp));
 
     //outboundFromInboundUp
-    (sig, exp) = TickConversionLib.nonNormalizedRatioFromTick(-tick);
+    (sig, exp) = TickConversionLib.nonNormalizedRatioFromTick(Tick.wrap(-Tick.unwrap(tick)));
     assertEq(TickLib.outboundFromInboundUp(tick, amt), divExpUp_spec(sig * amt, exp));
   }
 

--- a/test/core/MakerOperations.t.sol
+++ b/test/core/MakerOperations.t.sol
@@ -53,7 +53,7 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     assertEq(order.offer.prev(), 0, "offer.prev should be hidden");
     assertEq(order.offer.next(), 0, "offer.next should be hidden");
     //   not hidden
-    assertEq(order.offer.tick(), 1, "offer.tick should not be hidden");
+    assertEq(order.offer.tick(), Tick.wrap(1), "offer.tick should not be hidden");
     assertEq(order.offer.gives(), 1 ether, "offer.gives should not be hidden");
 
     // OfferPackedDetail is not filtered
@@ -108,7 +108,7 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     mkr.setExecuteCallback($(this), this.assertSORFieldsFilteredCorrectly.selector);
     deal($(base), $(mkr), 1 ether);
 
-    uint ofr = mkr.newOfferByTick(1, 1 ether, 200_000);
+    uint ofr = mkr.newOfferByTick(Tick.wrap(1), 1 ether, 200_000);
     require(tkr.marketOrderWithSuccess(0.1 ether), "take must work or test is void");
     assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
   }
@@ -903,9 +903,9 @@ contract MakerOperationsTest is MangroveTest, IMaker {
   function test_update_branch_on_retract_posInLeaf() public {
     mkr.provisionMgv(10 ether);
     uint wants = 5 ether;
-    mkr.newOfferByVolume(wants, TickLib.outboundFromInbound(3, wants), 100_000, 0);
+    mkr.newOfferByVolume(wants, TickLib.outboundFromInbound(Tick.wrap(3), wants), 100_000, 0);
     uint posInLeaf = mgv.local(olKey).binPosInLeaf();
-    uint ofr = mkr.newOfferByVolume(wants, TickLib.outboundFromInbound(2, wants), 100_000, 0);
+    uint ofr = mkr.newOfferByVolume(wants, TickLib.outboundFromInbound(Tick.wrap(2), wants), 100_000, 0);
     assertGt(
       posInLeaf, mgv.local(olKey).binPosInLeaf(), "test void if posInLeaf does not change when second offer is created"
     );
@@ -963,8 +963,8 @@ contract MakerOperationsTest is MangroveTest, IMaker {
   function test_update_branch_on_insert_posInLeaf() public {
     mkr.provisionMgv(10 ether);
     Bin bin0 = Bin.wrap(0);
-    mkr.newOfferByTick(TickLib.fromBin(bin0, olKey.tickSpacing), 1 ether, 100_000, 0);
-    uint ofr = mkr.newOfferByTick(-46055, 100 ether, 100_000, 0);
+    mkr.newOfferByTick(BinLib.toNearestTick(bin0, olKey.tickSpacing), 1 ether, 100_000, 0);
+    uint ofr = mkr.newOfferByTick(Tick.wrap(-46055), 100 ether, 100_000, 0);
     MgvStructs.OfferPacked offer = mgv.offers(olKey, ofr);
     assertTrue(
       offer.bin(olKey.tickSpacing).posInLeaf() != Bin.wrap(0).posInLeaf(),
@@ -991,11 +991,12 @@ contract MakerOperationsTest is MangroveTest, IMaker {
   function test_currentBin_is_cached_no_level31_erasure() public {
     // Create a very low bin so that later the branch of lowBin will be both in storage and in cache
     Bin veryLowBin = Bin.wrap(-100000);
-    uint ofr_veryLow = mgv.newOfferByTick(olKey, Bin.unwrap(veryLowBin), 1 ether, 10_000, 0);
+    uint ofr_veryLow =
+      mgv.newOfferByTick(olKey, BinLib.toNearestTick(veryLowBin, olKey.tickSpacing), 1 ether, 10_000, 0);
 
     // Create an offer at lowTick
     Bin lowBin = Bin.wrap(10);
-    uint ofr = mgv.newOfferByTick(olKey, Bin.unwrap(lowBin), 1 ether, 10_000, 0);
+    uint ofr = mgv.newOfferByTick(olKey, BinLib.toNearestTick(lowBin, olKey.tickSpacing), 1 ether, 10_000, 0);
 
     // Make sure very low bin uses a different branch
     assertTrue(
@@ -1023,11 +1024,11 @@ contract MakerOperationsTest is MangroveTest, IMaker {
       badLocal.bestBin().level3Index() != lowBin.level3Index(), "test setup: bad bin level3Index should be different"
     );
     // Create a bin there
-    mgv.newOfferByTick(olKey, Bin.unwrap(badLocal.bestBin()), 1 ether, 10_000, 0);
+    mgv.newOfferByTick(olKey, BinLib.toNearestTick(badLocal.bestBin(), olKey.tickSpacing), 1 ether, 10_000, 0);
     // Save level3, level2
     Field highLevel3 = mgv.level3(olKey, badLocal.bestBin().level3Index());
     // Update the new bin to an even better tick
-    mgv.updateOfferByTick(olKey, Bin.unwrap(veryLowBin), 1 ether, 10_000, 0, ofr);
+    mgv.updateOfferByTick(olKey, BinLib.toNearestTick(veryLowBin, olKey.tickSpacing), 1 ether, 10_000, 0, ofr);
 
     // Make sure we the high offer's branch is still fine
     assertEq(
@@ -1040,18 +1041,18 @@ contract MakerOperationsTest is MangroveTest, IMaker {
   }
 
   function test_higher_tick() public {
-    mgv.newOfferByTick(olKey, 2, 1 ether, 100_000, 0);
+    mgv.newOfferByTick(olKey, Tick.wrap(2), 1 ether, 100_000, 0);
     (, MgvStructs.LocalPacked local) = mgv.config(olKey);
 
-    mgv.newOfferByTick(olKey, 3, 1 ether, 100_000, 0);
+    mgv.newOfferByTick(olKey, Tick.wrap(3), 1 ether, 100_000, 0);
     (, local) = mgv.config(olKey);
     assertEq(local.binPosInLeaf(), 2);
   }
 
-  function test_leaf_update_both_first_and_last(int tick) public {
-    tick = bound(tick, MIN_TICK, MAX_TICK);
+  function test_leaf_update_both_first_and_last(Tick tick) public {
+    tick = Tick.wrap(bound(Tick.unwrap(tick), MIN_TICK, MAX_TICK));
     uint ofr0 = mgv.newOfferByTick(olKey, tick, 1 ether, 0, 0);
-    Bin bin = BinLib.tickToNearestHigherBin(tick, olKey.tickSpacing);
+    Bin bin = TickLib.toNearestBin(tick, olKey.tickSpacing);
     Leaf expected = LeafLib.EMPTY;
     expected = expected.setPosFirstOrLast(bin.posInLeaf(), ofr0, true);
     expected = expected.setPosFirstOrLast(bin.posInLeaf(), ofr0, false);

--- a/test/core/MakerOperations.t.sol
+++ b/test/core/MakerOperations.t.sol
@@ -1051,7 +1051,7 @@ contract MakerOperationsTest is MangroveTest, IMaker {
   function test_leaf_update_both_first_and_last(Tick tick) public {
     tick = Tick.wrap(bound(Tick.unwrap(tick), MIN_TICK, MAX_TICK));
     uint ofr0 = mgv.newOfferByTick(olKey, tick, 1 ether, 0, 0);
-    Bin bin = olKey.bin(tick);
+    Bin bin = olKey.nearestBin(tick);
     Leaf expected = LeafLib.EMPTY;
     expected = expected.setPosFirstOrLast(bin.posInLeaf(), ofr0, true);
     expected = expected.setPosFirstOrLast(bin.posInLeaf(), ofr0, false);

--- a/test/core/MakerPosthook.t.sol
+++ b/test/core/MakerPosthook.t.sol
@@ -236,7 +236,7 @@ contract MakerPosthookTest is MangroveTest, IMaker {
 
     ofr = mgv.newOfferByVolume(olKey, 1 ether, 1 ether, gasreq, _gasprice);
 
-    int offerTick = mgv.offers(olKey, ofr).tick();
+    Tick offerTick = mgv.offers(olKey, ofr).tick();
     assertFalse(tkr.cleanByTick(ofr, offerTick, 1 ether, gasreq - 1), "clean should fail");
     assertTrue(!called, "PostHook was called");
   }
@@ -245,7 +245,7 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     executeReturnData = "NOK2";
     ofr = mgv.newOfferByVolume(olKey, 1 ether, 1 ether, gasreq, _gasprice);
 
-    int offerTick = mgv.offers(olKey, ofr).tick();
+    Tick offerTick = mgv.offers(olKey, ofr).tick();
     assertFalse(tkr.cleanByTick(ofr, offerTick, 1 ether, gasreq - 1), "clean should fail");
     // using asserts in makerPosthook here
     assertTrue(!called, "PostHook was called");
@@ -254,8 +254,8 @@ contract MakerPosthookTest is MangroveTest, IMaker {
   function test_posthook_of_skipped_offer_wrong_ratio_should_not_be_called() public {
     _posthook = failer_posthook;
     ofr = mgv.newOfferByVolume(olKey, 1 ether, 1 ether, gasreq, _gasprice);
-    int tick = mgv.offers(olKey, ofr).tick();
-    int newTick = tick - 1; // Snipe at a lower ratio
+    Tick tick = mgv.offers(olKey, ofr).tick();
+    Tick newTick = Tick.wrap(Tick.unwrap(tick) - 1); // Snipe at a lower ratio
     assertFalse(tkr.cleanByTick(ofr, newTick, 1 ether, gasreq), "clean should fail");
     assertTrue(!called, "PostHook was called");
   }

--- a/test/core/Monitor.t.sol
+++ b/test/core/Monitor.t.sol
@@ -93,7 +93,7 @@ contract MonitorTest is MangroveTest {
     uint ofrId = mkr.newOfferByVolume(0.1 ether, 0.1 ether, 100_000, 0);
     MgvStructs.OfferPacked offer = mgv.offers(olKey, ofrId);
 
-    int tick = offer.tick();
+    Tick tick = offer.tick();
 
     (MgvStructs.GlobalPacked _global, MgvStructs.LocalPacked _local) = mgv.config(olKey);
     _local = _local.lock(true);
@@ -123,7 +123,7 @@ contract MonitorTest is MangroveTest {
     MgvStructs.OfferPacked offer = mgv.offers(olKey, ofrId);
     MgvStructs.OfferDetailPacked offerDetail = mgv.offerDetails(olKey, ofrId);
 
-    int tick = offer.tick();
+    Tick tick = offer.tick();
 
     (MgvStructs.GlobalPacked _global, MgvStructs.LocalPacked _local) = mgv.config(olKey);
     // config sent during maker callback has stale best and, is locked

--- a/test/core/Permit.t.sol
+++ b/test/core/Permit.t.sol
@@ -88,7 +88,7 @@ contract PermitTest is MangroveTest, TrivialTestMaker {
   }
 
   function marketOrderFor(uint value, address who) internal returns (uint, uint, uint, uint) {
-    int tick = TickConversionLib.tickFromRatio(1, 0);
+    Tick tick = TickConversionLib.tickFromRatio(1, 0);
     return mgv.marketOrderForByTick(olKey, tick, value, true, who);
   }
 

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -64,7 +64,7 @@ contract TakerOperationsTest is MangroveTest {
   function test_execute_reverts_if_taker_is_blacklisted_for_quote() public {
     uint weiBalanceBefore = mgv.balanceOf($(this));
     uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     mkr.expect("mgv/tradeSuccess"); // trade should be OK on the maker side
     quote.approve($(mgv), 1 ether);
     quote.blacklists($(this));
@@ -77,7 +77,7 @@ contract TakerOperationsTest is MangroveTest {
   function test_execute_reverts_if_taker_is_blacklisted_for_base() public {
     uint weiBalanceBefore = mgv.balanceOf($(this));
     uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     mkr.expect("mgv/tradeSuccess"); // trade should be OK on the maker side
     quote.approve($(mgv), 1 ether);
     base.blacklists($(this));
@@ -93,20 +93,20 @@ contract TakerOperationsTest is MangroveTest {
   function test_taker_cannot_drain_maker() public {
     mgv.setDensity96X32(olKey, 0);
     quote.approve($(mgv), 1 ether);
-    int bin = -7000; // ratio slightly < 1/2
-    mkr.newOfferByTick(bin, 10, 100_000, 0);
+    Tick tick = Tick.wrap(-7000); // ratio slightly < 1/2
+    mkr.newOfferByTick(tick, 10, 100_000, 0);
     uint oldBal = quote.balanceOf($(this));
-    mgv.marketOrderByTick(olKey, MAX_TICK, 1, true);
+    mgv.marketOrderByTick(olKey, Tick.wrap(MAX_TICK), 1, true);
     uint newBal = quote.balanceOf($(this));
     assertGt(oldBal, newBal, "oldBal should be strictly higher");
   }
 
   function test_execute_fillWants() public {
     uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     mkr.expect("mgv/tradeSuccess"); // trade should be OK on the maker side
     quote.approve($(mgv), 1 ether);
-    (uint got, uint gave,,) = mgv.marketOrderByTick(olKey, tick + 1, 0.5 ether, true);
+    (uint got, uint gave,,) = mgv.marketOrderByTick(olKey, Tick.wrap(Tick.unwrap(tick) + 1), 0.5 ether, true);
     assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertEq(got, 0.5 ether, "Taker did not get correct amount");
     assertEq(gave, 0.5 ether, "Taker did not give correct amount");
@@ -121,7 +121,7 @@ contract TakerOperationsTest is MangroveTest {
     /* Setting fillWants = true means we should not receive more than `wants`.
        Here we are asking for 0.1 eth to an offer that gives 1eth for ~nothing.
        We should still only receive 0.1 eth */
-    int tick = TickConversionLib.tickFromRatio(1, 0);
+    Tick tick = TickConversionLib.tickFromRatio(1, 0);
     (uint got, uint gave,,) = mgv.marketOrderByTick(olKey, tick, 0.1 ether, true);
     assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertApproxEqRel(got, 0.1 ether, relError(10), "Wrong got value");
@@ -138,7 +138,7 @@ contract TakerOperationsTest is MangroveTest {
     /* Setting fillWants = false means we should spend as little as possible to receive
        as much as possible.
        Here despite asking for .1eth the offer gives 1eth for ~0 so we should receive 1eth. */
-    int tick = TickConversionLib.tickFromRatio(1, 0);
+    Tick tick = TickConversionLib.tickFromRatio(1, 0);
     (uint got, uint gave,,) = mgv.marketOrderByTick(olKey, tick, 0.1 ether, false);
     assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertApproxEqRel(got, 1 ether, relError(10), "Wrong got value");
@@ -151,7 +151,7 @@ contract TakerOperationsTest is MangroveTest {
     mkr.expect("mgv/tradeSuccess"); // trade should be OK on the maker side
     quote.approve($(mgv), 1 ether);
 
-    int tick = TickConversionLib.tickFromRatio(1, 0);
+    Tick tick = TickConversionLib.tickFromRatio(1, 0);
     (uint got, uint gave,,) = mgv.marketOrderByTick(olKey, tick, 1 ether, false);
     assertTrue(mkr.makerExecuteWasCalled(ofr), "ofr must be executed or test is void");
     assertEq(got, 1 ether, "Taker did not get correct amount");
@@ -165,11 +165,11 @@ contract TakerOperationsTest is MangroveTest {
   function test_mo_fillWants() public {
     uint ofr1 = mkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
     uint ofr2 = mkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
-    int offerTick1 = mgv.offers(olKey, ofr1).tick();
-    int offerTick2 = mgv.offers(olKey, ofr2).tick();
+    Tick offerTick1 = mgv.offers(olKey, ofr1).tick();
+    Tick offerTick2 = mgv.offers(olKey, ofr2).tick();
     mkr.expect("mgv/tradeSuccess"); // trade should be OK on the maker side
     quote.approve($(mgv), 2 ether);
-    int maxTick = TickConversionLib.tickFromVolumes(1.9 ether, 1.1 ether);
+    Tick maxTick = TickConversionLib.tickFromVolumes(1.9 ether, 1.1 ether);
 
     expectFrom($(mgv));
     emit OrderStart(olKey.hash(), $(this), maxTick, 1.1 ether, true);
@@ -209,7 +209,7 @@ contract TakerOperationsTest is MangroveTest {
 
   function test_mo_fillWants_zero() public {
     uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     assertTrue(mgv.offers(olKey, ofr).isLive(), "Offer should be in the book");
     quote.approve($(mgv), 1 ether);
 
@@ -249,7 +249,7 @@ contract TakerOperationsTest is MangroveTest {
 
   function test_mo_fillGives_zero() public {
     uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     assertTrue(mgv.offers(olKey, ofr).isLive(), "Offer should be in the book");
     mkr.expect("mgv/tradeSuccess"); // trade should be OK on the maker side
     quote.approve($(mgv), 1 ether);
@@ -294,7 +294,7 @@ contract TakerOperationsTest is MangroveTest {
     // uint mkr_provision = reader.getProvision(olKey, 100_000);
     quote.approve($(mgv), 1 ether);
     uint ofr = refusemkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     mkr.expect("mgv/makerTransferFail"); // status visible in the posthook
     uint beforeQuote = quote.balanceOf($(this));
     uint beforeWei = $(this).balance;
@@ -314,7 +314,7 @@ contract TakerOperationsTest is MangroveTest {
 
   function test_taker_reverts_on_penalty_triggers_revert() public {
     uint ofr = refusemkr.newOfferByVolume(1 ether, 1 ether, 50_000, 0);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     refuseReceive = true;
     quote.approve($(mgv), 1 ether);
 
@@ -326,7 +326,7 @@ contract TakerOperationsTest is MangroveTest {
     // uint mkr_provision = reader.getProvision(olKey, 100_000);
     quote.approve($(mgv), 1 ether);
     uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     mkr.expect("mgv/makerTransferFail"); // status visible in the posthook
 
     base.blacklists(address(mkr));
@@ -349,7 +349,7 @@ contract TakerOperationsTest is MangroveTest {
     // uint mkr_provision = reader.getProvision(olKey, 100_000);
     quote.approve($(mgv), 1 ether);
     uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     mkr.expect("mgv/makerReceiveFail"); // status visible in the posthook
 
     quote.blacklists(address(mkr));
@@ -371,7 +371,7 @@ contract TakerOperationsTest is MangroveTest {
   function test_taker_collects_failing_offer() public {
     quote.approve($(mgv), 1 ether);
     uint ofr = failmkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     uint beforeWei = $(this).balance;
 
     (uint takerGot, uint takerGave,,) = mgv.marketOrderByTick(olKey, tick, 1 ether, true);
@@ -384,7 +384,7 @@ contract TakerOperationsTest is MangroveTest {
     // uint mkr_provision = reader.getProvision(olKey, 50_000);
     quote.approve($(mgv), 1 ether);
     uint ofr = failmkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     uint beforeQuote = quote.balanceOf($(this));
     uint beforeWei = $(this).balance;
 
@@ -405,7 +405,7 @@ contract TakerOperationsTest is MangroveTest {
 
     uint balTaker = base.balanceOf($(this));
     uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 50_000, 0);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     quote.approve($(mgv), 1 ether);
     uint shouldGet = reader.minusFee(olKey, 1 ether);
     mgv.marketOrderByTick(olKey, tick, 1 ether, true);
@@ -416,7 +416,7 @@ contract TakerOperationsTest is MangroveTest {
   function test_taker_hasnt_approved_base_succeeds_order_wo_fee() public {
     uint balTaker = base.balanceOf($(this));
     uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 50_000, 0);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     quote.approve($(mgv), 1 ether);
     mgv.marketOrderByTick(olKey, tick, 1 ether, true);
     assertEq(base.balanceOf($(this)) - balTaker, 1 ether, "Incorrect delivered amount");
@@ -425,7 +425,7 @@ contract TakerOperationsTest is MangroveTest {
 
   function test_taker_hasnt_approved_quote_fails_order() public {
     uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 50_000, 0);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     base.approve($(mgv), 1 ether);
 
     vm.expectRevert("mgv/takerTransferFail");
@@ -478,7 +478,7 @@ contract TakerOperationsTest is MangroveTest {
   function test_fillGives_at_0_wants_works() public {
     uint wants = 0;
     uint ofr = mkr.newOfferByVolume(wants, 2 ether, 100_000, 0);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     mkr.expect("mgv/tradeSuccess");
     quote.approve($(mgv), 10 ether);
 
@@ -512,7 +512,7 @@ contract TakerOperationsTest is MangroveTest {
 
   function test_taker_has_no_quote_fails_order() public {
     uint ofr = mkr.newOfferByVolume(100 ether, 2 ether, 50_000, 0);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     mkr.expect("mgv/tradeSuccess");
 
     quote.approve($(mgv), 100 ether);
@@ -524,7 +524,7 @@ contract TakerOperationsTest is MangroveTest {
 
   function test_maker_has_not_enough_base_fails_order() public {
     uint ofr = mkr.newOfferByVolume(1 ether, 100 ether, 100_000, 0);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     mkr.expect("mgv/makerTransferFail");
     // getting rid of base tokens
     //mkr.transferToken(base,$(this),5 ether);
@@ -550,7 +550,7 @@ contract TakerOperationsTest is MangroveTest {
 
   function test_maker_revert_is_logged() public {
     uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 50_000, 0);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     mkr.expect("mgv/makerRevert");
     mkr.shouldRevert(true);
     quote.approve($(mgv), 1 ether);
@@ -562,7 +562,7 @@ contract TakerOperationsTest is MangroveTest {
 
   function test_detect_low_gas() public {
     uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 100_000, 0);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
     // Change gasbase so that gas limit checks does not prevent execution attempt
     mgv.setGasbase(olKey, 1);
     quote.approve($(mgv), 100 ether);
@@ -674,7 +674,7 @@ contract TakerOperationsTest is MangroveTest {
     quote.approve($(mgv), 1 ether);
     uint mkrBal = base.balanceOf(address(mkr));
     uint ofr = failmkr.newOfferByVolume(0.1 ether, 0.1 ether, 100_000, 0);
-    int offerTick = mgv.offers(olKey, ofr).tick();
+    Tick offerTick = mgv.offers(olKey, ofr).tick();
 
     (uint successes,) =
       mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, offerTick, 100_000, 0)), $(this));
@@ -688,7 +688,7 @@ contract TakerOperationsTest is MangroveTest {
     quote.approve($(mgv), 1 ether);
     uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 120_000, 0);
     mgv.setGasbase(olKey, 1);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
 
     vm.expectRevert("mgv/notEnoughGasForMakerTrade");
     mgv.marketOrderByTick{gas: 145_000}(olKey, tick, 1 ether, true);
@@ -698,7 +698,7 @@ contract TakerOperationsTest is MangroveTest {
     mgv.setGasbase(olKey, 1);
     quote.approve($(mgv), 1 ether);
     uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 120_000, 0);
-    int tick = mgv.offers(olKey, ofr).tick();
+    Tick tick = mgv.offers(olKey, ofr).tick();
 
     vm.expectRevert("mgv/notEnoughGasForMakerPosthook");
     mgv.marketOrderByTick{gas: 291_000}(olKey, tick, 1 ether, true);
@@ -720,7 +720,7 @@ contract TakerOperationsTest is MangroveTest {
     olKey.outbound = address(oogtt);
     mgv.activate(olKey, 0, 0, 1);
 
-    int tick = 0;
+    Tick tick = Tick.wrap(0);
     mkr.newOfferByTick(olKey, tick, 1 ether, 220_000, 0);
     vm.expectRevert("mgv/MgvFailToPayTaker");
 
@@ -796,71 +796,80 @@ contract TakerOperationsTest is MangroveTest {
   /* # Clean tests */
   /* Clean parameter validation */
   function test_gives_tick_outside_range_fails_clean() public {
-    uint ofr = failmkr.newOfferByTick(0, 1 ether, 100_000);
-    (uint successes,) = mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, 1 << 23, 0, 1)), $(this));
+    uint ofr = failmkr.newOfferByTick(Tick.wrap(0), 1 ether, 100_000);
+    (uint successes,) =
+      mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, Tick.wrap(1 << 23), 0, 1)), $(this));
     assertEq(successes, 0, "cleaning should have failed");
     assertTrue(mgv.best(olKey) == ofr, "clean must have left ofr in the book");
   }
 
   function test_gives_volume_above_96bits_fails_clean() public {
-    uint ofr = failmkr.newOfferByTick(0, 1 ether, 100_000);
-    (uint successes,) = mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, 0, 0, 1 << 96)), $(this));
+    uint ofr = failmkr.newOfferByTick(Tick.wrap(0), 1 ether, 100_000);
+    (uint successes,) =
+      mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, Tick.wrap(0), 0, 1 << 96)), $(this));
     assertEq(successes, 0, "cleaning should have failed");
     assertTrue(mgv.best(olKey) == ofr, "clean must have left ofr in the book");
   }
 
   /* Clean offer state&match validation */
   function test_clean_on_nonexistent_offer_fails() public {
-    (uint successes,) = mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(1, 0, 0, 1)), $(this));
+    (uint successes,) =
+      mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(1, Tick.wrap(0), 0, 1)), $(this));
     assertEq(successes, 0, "cleaning should have failed");
   }
 
   function test_clean_non_live_offer_fails() public {
-    uint ofr = failmkr.newOfferByTick(0, 1 ether, 100_000);
+    uint ofr = failmkr.newOfferByTick(Tick.wrap(0), 1 ether, 100_000);
     failmkr.retractOffer(ofr);
-    (uint successes,) = mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, 0, 100_000, 1)), $(this));
+    (uint successes,) =
+      mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, Tick.wrap(0), 100_000, 1)), $(this));
     assertEq(successes, 0, "cleaning should have failed");
     assertTrue(mgv.best(olKey) == 0, "clean must not have changed the book");
   }
 
   function test_cleaning_with_exact_offer_details_succeeds() public {
-    uint ofr = failmkr.newOfferByTick(0, 1 ether, 100_000);
-    (uint successes,) = mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, 0, 100_000, 0)), $(this));
+    uint ofr = failmkr.newOfferByTick(Tick.wrap(0), 1 ether, 100_000);
+    (uint successes,) =
+      mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, Tick.wrap(0), 100_000, 0)), $(this));
     assertTrue(successes > 0, "cleaning should have succeeded");
     assertTrue(mgv.best(olKey) == 0, "clean must have emptied mgv");
   }
 
   function test_giving_smaller_tick_to_clean_fails() public {
-    uint ofr = failmkr.newOfferByTick(0, 1 ether, 100_000);
-    (uint successes,) = mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, -1, 100_000, 0)), $(this));
+    uint ofr = failmkr.newOfferByTick(Tick.wrap(0), 1 ether, 100_000);
+    (uint successes,) =
+      mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, Tick.wrap(-1), 100_000, 0)), $(this));
     assertEq(successes, 0, "cleaning should have failed");
     assertTrue(mgv.best(olKey) == ofr, "clean must have left ofr in the book");
   }
 
   function test_giving_bigger_tick_to_clean_fails() public {
-    uint ofr = failmkr.newOfferByTick(0, 1 ether, 100_000);
-    (uint successes,) = mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, 1, 100_000, 0)), $(this));
+    uint ofr = failmkr.newOfferByTick(Tick.wrap(0), 1 ether, 100_000);
+    (uint successes,) =
+      mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, Tick.wrap(1), 100_000, 0)), $(this));
     assertEq(successes, 0, "cleaning should have succeeded");
     assertTrue(mgv.best(olKey) == ofr, "clean must have left ofr in the book");
   }
 
   function test_giving_smaller_gasreq_to_clean_fails() public {
-    uint ofr = failmkr.newOfferByTick(0, 1 ether, 100_000);
-    (uint successes,) = mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, 0, 99_000, 0)), $(this));
+    uint ofr = failmkr.newOfferByTick(Tick.wrap(0), 1 ether, 100_000);
+    (uint successes,) =
+      mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, Tick.wrap(0), 99_000, 0)), $(this));
     assertEq(successes, 0, "cleaning should have failed");
     assertTrue(mgv.best(olKey) == ofr, "clean must have left ofr in the book");
   }
 
   function test_giving_bigger_gasreq_to_clean_succeeds() public {
-    uint ofr = failmkr.newOfferByTick(0, 1 ether, 100_000);
-    (uint successes,) = mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, 0, 100_001, 0)), $(this));
+    uint ofr = failmkr.newOfferByTick(Tick.wrap(0), 1 ether, 100_000);
+    (uint successes,) =
+      mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, Tick.wrap(0), 100_001, 0)), $(this));
     assertTrue(successes > 0, "cleaning should have succeeded");
     assertTrue(mgv.best(olKey) == 0, "clean must have emptied mgv");
   }
 
   /* Clean - offer execution */
   function test_cleaning_non_failing_offer_fails() public {
-    int tick = 0;
+    Tick tick = Tick.wrap(0);
     uint ofr = mkr.newOfferByTick(tick, 1 ether, 100_000);
 
     expectFrom($(mgv));
@@ -873,14 +882,15 @@ contract TakerOperationsTest is MangroveTest {
     expectFrom($(base));
     emit Transfer($(mkr), $(mgv), 0 ether);
 
-    (uint successes,) = mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, 0, 100_000, 0)), $(this));
+    (uint successes,) =
+      mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, Tick.wrap(0), 100_000, 0)), $(this));
     assertEq(successes, 0, "cleaning should have failed");
     assertTrue(mgv.best(olKey) == ofr, "clean must have left ofr in the book");
   }
 
   function test_cleaning_failing_offer_transfers_bounty() public {
     uint balanceBefore = $(this).balance;
-    int tick = 0;
+    Tick tick = Tick.wrap(0);
     uint ofr = failmkr.newOfferByTick(tick, 1 ether, 100_000);
 
     expectFrom($(mgv));
@@ -898,7 +908,8 @@ contract TakerOperationsTest is MangroveTest {
     expectFrom($(mgv));
     emit CleanComplete();
 
-    (, uint bounty) = mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, 0, 100_000, 0)), $(this));
+    (, uint bounty) =
+      mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, Tick.wrap(0), 100_000, 0)), $(this));
     assertTrue(bounty > 0, "cleaning should have yielded a bounty");
     uint balanceAfter = $(this).balance;
     assertEq(balanceBefore + bounty, balanceAfter, "the bounty was not transfered to the cleaner");
@@ -906,13 +917,14 @@ contract TakerOperationsTest is MangroveTest {
   }
 
   function test_clean_multiple_failing_offers() public {
-    uint ofr = failmkr.newOfferByTick(0, 1 ether, 100_000);
-    uint ofr2 = failmkr.newOfferByTick(0, 1 ether, 100_000);
+    uint ofr = failmkr.newOfferByTick(Tick.wrap(0), 1 ether, 100_000);
+    uint ofr2 = failmkr.newOfferByTick(Tick.wrap(0), 1 ether, 100_000);
 
     uint oldBal = $(this).balance;
 
-    MgvLib.CleanTarget[] memory targets =
-      wrap_dynamic(MgvLib.CleanTarget(ofr, 0, 100_000, 0), MgvLib.CleanTarget(ofr2, 0, 100_000, 0));
+    MgvLib.CleanTarget[] memory targets = wrap_dynamic(
+      MgvLib.CleanTarget(ofr, Tick.wrap(0), 100_000, 0), MgvLib.CleanTarget(ofr2, Tick.wrap(0), 100_000, 0)
+    );
 
     expectFrom($(mgv));
     emit CleanStart(olKey.hash(), $(this), 2);
@@ -949,16 +961,16 @@ contract TakerOperationsTest is MangroveTest {
 
   function test_cleans_failing_offers_despite_one_not_failing() public {
     deal($(quote), $(this), 10 ether);
-    uint ofr = failmkr.newOfferByTick(0, 1 ether, 100_000);
-    uint ofr2 = mkr.newOfferByTick(0, 1 ether, 100_000);
-    uint ofr3 = failmkr.newOfferByTick(0, 1 ether, 100_000);
+    uint ofr = failmkr.newOfferByTick(Tick.wrap(0), 1 ether, 100_000);
+    uint ofr2 = mkr.newOfferByTick(Tick.wrap(0), 1 ether, 100_000);
+    uint ofr3 = failmkr.newOfferByTick(Tick.wrap(0), 1 ether, 100_000);
 
     uint oldBal = $(this).balance;
 
     MgvLib.CleanTarget[] memory targets = wrap_dynamic(
-      MgvLib.CleanTarget(ofr, 0, 100_000, 0),
-      MgvLib.CleanTarget(ofr2, 0, 100_000, 0),
-      MgvLib.CleanTarget(ofr3, 0, 100_000, 0)
+      MgvLib.CleanTarget(ofr, Tick.wrap(0), 100_000, 0),
+      MgvLib.CleanTarget(ofr2, Tick.wrap(0), 100_000, 0),
+      MgvLib.CleanTarget(ofr3, Tick.wrap(0), 100_000, 0)
     );
 
     expectFrom($(mgv));
@@ -1000,9 +1012,10 @@ contract TakerOperationsTest is MangroveTest {
   }
 
   function test_cleaning_by_impersonation_succeeds_and_does_not_transfer_funds() public {
-    uint ofr = failNonZeroMkr.newOfferByTick(0, 1 ether, 100_000);
+    uint ofr = failNonZeroMkr.newOfferByTick(Tick.wrap(0), 1 ether, 100_000);
     // $this cannot clean with taker because of lack of funds/approval
-    (, uint bounty) = mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, 0, 100_000, 1)), $(this));
+    (, uint bounty) =
+      mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, Tick.wrap(0), 100_000, 1)), $(this));
     assertEq(bounty, 0, "cleaning should have failed");
 
     uint balanceNativeBefore = $(this).balance;
@@ -1032,7 +1045,8 @@ contract TakerOperationsTest is MangroveTest {
     expectFrom($(mgv));
     emit CleanComplete();
 
-    (, bounty) = mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, 0, 100_000, 1)), $(otherTkr));
+    (, bounty) =
+      mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, Tick.wrap(0), 100_000, 1)), $(otherTkr));
     assertTrue(bounty > 0, "cleaning should have yielded a bounty");
     assertTrue(mgv.best(olKey) == 0, "clean must have emptied mgv");
 
@@ -1046,21 +1060,19 @@ contract TakerOperationsTest is MangroveTest {
   }
 
   function test_unconsumed_tick_leaves_correct_leaf_start_at_tick_leave_one_only(
-    int24 _bin,
+    Bin bin,
     bool crossBin,
     bool leaveOneOnly
   ) public {
     quote.approve($(mgv), 10_000 ether);
-    _bin = int24(bound(_bin, -100, 100));
-    int24 _firstPostedBin = crossBin ? _bin - 1 : _bin;
-    mkr.newOfferByTick(_firstPostedBin, 1 ether, 100_000);
-    mkr.newOfferByTick(_bin, 1 ether, 100_000);
-    uint ofr3 = mkr.newOfferByTick(_bin, 1 ether, 100_000);
-    uint ofr4 = mkr.newOfferByTick(_bin, 1 ether, 100_000);
+    bin = Bin.wrap(bound(Bin.unwrap(bin), -100, 100));
+    Bin firstPostedBin = Bin.wrap(Bin.unwrap(bin) - (crossBin ? int(1) : int(0)));
+    mkr.newOfferByTick(BinLib.toNearestTick(firstPostedBin, olKey.tickSpacing), 1 ether, 100_000);
+    mkr.newOfferByTick(BinLib.toNearestTick(bin, olKey.tickSpacing), 1 ether, 100_000);
+    uint ofr3 = mkr.newOfferByTick(BinLib.toNearestTick(bin, olKey.tickSpacing), 1 ether, 100_000);
+    uint ofr4 = mkr.newOfferByTick(BinLib.toNearestTick(bin, olKey.tickSpacing), 1 ether, 100_000);
     uint volume = leaveOneOnly ? 3 ether : 2 ether;
-    mgv.marketOrderByTick(olKey, _bin, volume, true);
-
-    Bin bin = Bin.wrap(_bin);
+    mgv.marketOrderByTick(olKey, BinLib.toNearestTick(bin, olKey.tickSpacing), volume, true);
 
     uint bestId = leaveOneOnly ? ofr4 : ofr3;
     MgvStructs.OfferPacked best = mgv.offers(olKey, bestId);
@@ -1080,7 +1092,7 @@ contract TakerOperationsTest is MangroveTest {
   This test just considers as many offers as possible that each have a maximal `wants` and makes sure the error will be about stack overflow, not uint overflow. 
   */
   function test_maximal_wants_is_ok() public {
-    uint maxOfferWants = TickLib.inboundFromOutboundUp(MAX_TICK, type(uint96).max);
+    uint maxOfferWants = TickLib.inboundFromOutboundUp(Tick.wrap(MAX_TICK), type(uint96).max);
     unchecked {
       uint recp = mgv.global().maxRecursionDepth() + 1;
       assertTrue(

--- a/test/core/TheClog.t.sol
+++ b/test/core/TheClog.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.10;
 
 import {MangroveTest} from "mgv_test/lib/MangroveTest.sol";
 import {TestTaker} from "mgv_test/lib/agents/TestTaker.sol";
-import {IMaker, MgvLib, MgvStructs, MAX_TICK} from "mgv_src/MgvLib.sol";
+import {Tick, IMaker, MgvLib, MgvStructs, MAX_TICK} from "mgv_src/MgvLib.sol";
 import {console2 as console} from "forge-std/console2.sol";
 
 contract TooDeepRecursionClogTest is MangroveTest, IMaker {
@@ -27,7 +27,7 @@ contract TooDeepRecursionClogTest is MangroveTest, IMaker {
   // Resets failure flag and reposts offer at same ratio.
   function makerPosthook(MgvLib.SingleOrder calldata order, MgvLib.OrderResult calldata) external override {
     shouldFail = false;
-    try mgv.updateOfferByTick(order.olKey, 0, minVolume, gasreq, 0, order.offerId) {
+    try mgv.updateOfferByTick(order.olKey, Tick.wrap(0), minVolume, gasreq, 0, order.offerId) {
       // we do not fail if we cannot repost since we still need to set shouldFail to false.
     } catch {}
   }
@@ -45,7 +45,7 @@ contract TooDeepRecursionClogTest is MangroveTest, IMaker {
 
     // 100 offers at same ratio at minimum volume.
     for (uint i; i < 100; ++i) {
-      mgv.newOfferByTick(olKey, 0, minVolume, gasreq, 0);
+      mgv.newOfferByTick(olKey, Tick.wrap(0), minVolume, gasreq, 0);
     }
   }
 
@@ -84,7 +84,7 @@ contract TooDeepRecursionClogTest is MangroveTest, IMaker {
     // the first offer succeeds. All other offer fails.
     vm.expectRevert();
     vm.prank($(taker));
-    mgv.marketOrderByTick(olKey, MAX_TICK, minVolume + 1, false, type(uint).max);
+    mgv.marketOrderByTick(olKey, Tick.wrap(MAX_TICK), minVolume + 1, false, type(uint).max);
   }
 
   function test_take_one_then_two_at_once_fails_for_deep_stack() public {
@@ -94,7 +94,7 @@ contract TooDeepRecursionClogTest is MangroveTest, IMaker {
     takeSome(minVolume);
     vm.expectRevert();
     vm.prank($(taker));
-    mgv.marketOrderByTick(olKey, MAX_TICK, minVolume + 1, false, type(uint).max);
+    mgv.marketOrderByTick(olKey, Tick.wrap(MAX_TICK), minVolume + 1, false, type(uint).max);
   }
 }
 
@@ -156,7 +156,7 @@ contract MaxRecursionDepthFuzzTest is MangroveTest, IMaker {
       } else if (failureMode == 2) {
         fail = uint(keccak256(abi.encodePacked(seed, i))) % 2 == 0;
       }
-      uint offerId = mgv.newOfferByTick(olKey, 0, volume, gasreq, 0);
+      uint offerId = mgv.newOfferByTick(olKey, Tick.wrap(0), volume, gasreq, 0);
       if (!fail && depth > i) {
         expectedGot += volume;
       }
@@ -177,7 +177,7 @@ contract MaxRecursionDepthFuzzTest is MangroveTest, IMaker {
     mgv.setMaxRecursionDepth(depth);
 
     vm.prank($(taker));
-    try mgv.marketOrderByTick(olKey, MAX_TICK, 200 ether, false, type(uint).max) {
+    try mgv.marketOrderByTick(olKey, Tick.wrap(MAX_TICK), 200 ether, false, type(uint).max) {
       assertLe(depth, failDepth, "should only succeed at lower depths");
     } catch {
       assertGt(depth, failDepth, "should only fail for high depth");

--- a/test/core/gas/CleanOtherOfferList.t.sol
+++ b/test/core/gas/CleanOtherOfferList.t.sol
@@ -19,18 +19,18 @@ import {
   ROOT_HIGHER_BIN
 } from "./GasTestBase.t.sol";
 import {IMangrove, TestTaker} from "mgv_test/lib/MangroveTest.sol";
-import {MgvLib, OLKey} from "mgv_src/MgvLib.sol";
+import "mgv_src/MgvLib.sol";
 import {TickTreeBoundariesGasTest} from "./TickTreeBoundariesGasTest.t.sol";
 
 // Similar to RetractOffer tests.
 
 contract ExternalCleanOfferOtherOfferList_WithNoOtherOffersGasTest is GasTestBase {
-  int internal tick;
+  Bin internal bin;
 
   function setUp() public virtual override {
     super.setUp();
-    tick = MIDDLE_BIN;
-    _offerId = mgv.newOfferByTick(olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0);
+    bin = MIDDLE_BIN;
+    _offerId = mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0);
     description = "Worst case scenario where cleaning an offer from an offer list which now becomes empty";
   }
 
@@ -38,19 +38,19 @@ contract ExternalCleanOfferOtherOfferList_WithNoOtherOffersGasTest is GasTestBas
     revert("fail"); // fail
   }
 
-  function setUpTick(int _tick) public virtual {
-    tick = _tick;
-    _offerId = mgv.newOfferByTick(olKey, _tick, 0.00001 ether, 100_000, 0);
-    description = "Cleaning an offer when another offer exists at various tick-distances to the offer's ratio";
+  function setUpBin(Bin _bin) public virtual {
+    bin = _bin;
+    _offerId = mgv.newOfferByTick(olKey, olKey.tick(_bin), 0.00001 ether, 100_000, 0);
+    description = "Cleaning an offer when another offer exists at various bin-distances to the offer's ratio";
   }
 
   function test_clean() public {
     (IMangrove mgv, TestTaker taker, OLKey memory _olKey, uint offerId) = getStored();
-    int _tick = tick;
     vm.prank($(taker));
     _gas();
-    (, uint bounty) =
-      mgv.cleanByImpersonation(_olKey, wrap_dynamic(MgvLib.CleanTarget(offerId, _tick, 100_000, 0.05 ether)), $(taker));
+    (, uint bounty) = mgv.cleanByImpersonation(
+      _olKey, wrap_dynamic(MgvLib.CleanTarget(offerId, _olKey.tick(bin), 100_000, 0.05 ether)), $(taker)
+    );
     gas_();
     require(bounty > 0);
     printDescription();
@@ -62,7 +62,7 @@ contract ExternalCleanOfferOtherOfferList_WithOtherOfferGasTest_MIDDLE_BIN is
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(MIDDLE_BIN);
+    setUpBin(MIDDLE_BIN);
     description = string.concat(description, " - Case: MIDDLE_BIN");
   }
 }
@@ -72,7 +72,7 @@ contract ExternalCleanOfferOtherOfferList_WithOtherOfferGasTest_LEAF_LOWER_BIN i
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEAF_LOWER_BIN);
+    setUpBin(LEAF_LOWER_BIN);
     description = string.concat(description, " - Case: LEAF_LOWER_BIN");
   }
 }
@@ -82,7 +82,7 @@ contract ExternalCleanOfferOtherOfferList_WithOtherOfferGasTest_LEAF_HIGHER_BIN 
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEAF_HIGHER_BIN);
+    setUpBin(LEAF_HIGHER_BIN);
     description = string.concat(description, " - Case: LEAF_HIGHER_BIN");
   }
 }
@@ -92,7 +92,7 @@ contract ExternalCleanOfferOtherOfferList_WithOtherOfferGasTest_LEVEL3_LOWER_BIN
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL3_LOWER_BIN);
+    setUpBin(LEVEL3_LOWER_BIN);
     description = string.concat(description, " - Case: LEVEL3_LOWER_BIN");
   }
 }
@@ -102,7 +102,7 @@ contract ExternalCleanOfferOtherOfferList_WithOtherOfferGasTest_LEVEL3_HIGHER_BI
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL3_HIGHER_BIN);
+    setUpBin(LEVEL3_HIGHER_BIN);
     description = string.concat(description, " - Case: LEVEL3_HIGHER_BIN");
   }
 }
@@ -112,7 +112,7 @@ contract ExternalCleanOfferOtherOfferList_WithOtherOfferGasTest_LEVEL2_LOWER_BIN
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL2_LOWER_BIN);
+    setUpBin(LEVEL2_LOWER_BIN);
     description = string.concat(description, " - Case: LEVEL2_LOWER_BIN");
   }
 }
@@ -122,7 +122,7 @@ contract ExternalCleanOfferOtherOfferList_WithOtherOfferGasTest_LEVEL2_HIGHER_BI
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL2_HIGHER_BIN);
+    setUpBin(LEVEL2_HIGHER_BIN);
     description = string.concat(description, " - Case: LEVEL2_HIGHER_BIN");
   }
 }
@@ -132,7 +132,7 @@ contract ExternalCleanOfferOtherOfferList_WithOtherOfferGasTest_LEVEL1_LOWER_BIN
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL1_LOWER_BIN);
+    setUpBin(LEVEL1_LOWER_BIN);
     description = string.concat(description, " - Case: LEVEL1_LOWER_BIN");
   }
 }
@@ -142,7 +142,7 @@ contract ExternalCleanOfferOtherOfferList_WithOtherOfferGasTest_LEVEL1_HIGHER_BI
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL1_HIGHER_BIN);
+    setUpBin(LEVEL1_HIGHER_BIN);
     description = string.concat(description, " - Case: LEVEL1_HIGHER_BIN");
   }
 }
@@ -152,7 +152,7 @@ contract ExternalCleanOfferOtherOfferList_WithOtherOfferGasTest_ROOT_LOWER_BIN i
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(ROOT_LOWER_BIN);
+    setUpBin(ROOT_LOWER_BIN);
     description = string.concat(description, " - Case: ROOT_LOWER_BIN");
   }
 }
@@ -162,7 +162,7 @@ contract ExternalCleanOfferOtherOfferList_WithOtherOfferGasTest_ROOT_HIGHER_BIN 
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(ROOT_HIGHER_BIN);
+    setUpBin(ROOT_HIGHER_BIN);
     description = string.concat(description, " - Case: ROOT_HIGHER_BIN");
   }
 }
@@ -175,10 +175,10 @@ abstract contract ExternalCleanOfferOtherOfferList_WithOtherOfferAndOfferOnSameB
     this.newOfferOnAllTestRatios();
   }
 
-  function setUpTick(int _tick) public virtual override {
-    super.setUpTick(_tick);
+  function setUpBin(Bin _bin) public virtual override {
+    super.setUpBin(_bin);
     description =
-      "Retracting an offer when another offer exists at various tick-distances to the offer ratio but also on the same tick";
+      "Retracting an offer when another offer exists at various bin-distances to the offer ratio but also on the same bin";
   }
 }
 
@@ -187,7 +187,7 @@ contract ExternalCleanOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTest
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(MIDDLE_BIN);
+    setUpBin(MIDDLE_BIN);
     description = string.concat(description, " - Case: MIDDLE_BIN");
   }
 }
@@ -197,7 +197,7 @@ contract ExternalCleanOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTest
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEAF_LOWER_BIN);
+    setUpBin(LEAF_LOWER_BIN);
     description = string.concat(description, " - Case: LEAF_LOWER_BIN");
   }
 }
@@ -207,7 +207,7 @@ contract ExternalCleanOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTest
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEAF_HIGHER_BIN);
+    setUpBin(LEAF_HIGHER_BIN);
     description = string.concat(description, " - Case: LEAF_HIGHER_BIN");
   }
 }
@@ -217,7 +217,7 @@ contract ExternalCleanOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTest
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL3_LOWER_BIN);
+    setUpBin(LEVEL3_LOWER_BIN);
     description = string.concat(description, " - Case: LEVEL3_LOWER_BIN");
   }
 }
@@ -227,7 +227,7 @@ contract ExternalCleanOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTest
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL3_HIGHER_BIN);
+    setUpBin(LEVEL3_HIGHER_BIN);
     description = string.concat(description, " - Case: LEVEL3_HIGHER_BIN");
   }
 }
@@ -237,7 +237,7 @@ contract ExternalCleanOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTest
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL2_LOWER_BIN);
+    setUpBin(LEVEL2_LOWER_BIN);
     description = string.concat(description, " - Case: LEVEL2_LOWER_BIN");
   }
 }
@@ -247,7 +247,7 @@ contract ExternalCleanOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTest
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL2_HIGHER_BIN);
+    setUpBin(LEVEL2_HIGHER_BIN);
     description = string.concat(description, " - Case: LEVEL2_HIGHER_BIN");
   }
 }
@@ -257,7 +257,7 @@ contract ExternalCleanOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTest
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL1_LOWER_BIN);
+    setUpBin(LEVEL1_LOWER_BIN);
     description = string.concat(description, " - Case: LEVEL1_LOWER_BIN");
   }
 }
@@ -267,7 +267,7 @@ contract ExternalCleanOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTest
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL1_HIGHER_BIN);
+    setUpBin(LEVEL1_HIGHER_BIN);
     description = string.concat(description, " - Case: LEVEL1_HIGHER_BIN");
   }
 }
@@ -277,7 +277,7 @@ contract ExternalCleanOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTest
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(ROOT_LOWER_BIN);
+    setUpBin(ROOT_LOWER_BIN);
     description = string.concat(description, " - Case: ROOT_LOWER_BIN");
   }
 }
@@ -287,7 +287,7 @@ contract ExternalCleanOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTest
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(ROOT_HIGHER_BIN);
+    setUpBin(ROOT_HIGHER_BIN);
     description = string.concat(description, " - Case: ROOT_HIGHER_BIN");
   }
 }
@@ -300,27 +300,27 @@ contract ExternalCleanOfferOtherOfferList_WithPriorCleanOfferAndNoOtherOffersGas
 
   function setUp() public virtual override {
     super.setUp();
-    _offerId = mgv.newOfferByTick(olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0);
-    tickOfferIds[MIDDLE_BIN] = _offerId;
+    _offerId = mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0);
+    binOfferIds[MIDDLE_BIN] = _offerId;
     this.newOfferOnAllTestRatios();
-    offerId2 = mgv.newOfferByTick(olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0);
-    description = "Cleaning a second offer at various tick-distances after cleaning an offer at MIDDLE_BIN";
+    offerId2 = mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0);
+    description = "Cleaning a second offer at various bin-distances after cleaning an offer at MIDDLE_BIN";
   }
 
   function makerExecute(MgvLib.SingleOrder calldata) external virtual override returns (bytes32) {
     revert("fail"); // fail
   }
 
-  function impl(IMangrove mgv, TestTaker taker, OLKey memory _olKey, uint, int _tick) internal override {
+  function impl(IMangrove mgv, TestTaker taker, OLKey memory _olKey, uint, Bin bin) internal override {
     vm.prank($(taker));
     mgv.cleanByImpersonation(
-      _olKey, wrap_dynamic(MgvLib.CleanTarget(offerId2, MIDDLE_BIN, 100_000, 0.05 ether)), $(taker)
+      _olKey, wrap_dynamic(MgvLib.CleanTarget(offerId2, _olKey.tick(MIDDLE_BIN), 100_000, 0.05 ether)), $(taker)
     );
 
     vm.prank($(taker));
     _gas();
     (, uint bounty) = mgv.cleanByImpersonation(
-      _olKey, wrap_dynamic(MgvLib.CleanTarget(tickOfferIds[_tick], _tick, 1_000_000, 0.05 ether)), $(taker)
+      _olKey, wrap_dynamic(MgvLib.CleanTarget(binOfferIds[bin], _olKey.tick(bin), 1_000_000, 0.05 ether)), $(taker)
     );
     gas_();
     require(bounty > 0);
@@ -338,7 +338,10 @@ abstract contract ExternalCleanOtherOfferList_WithMultipleOffersAtSameBinGasTest
     for (uint i; i < count; ++i) {
       targets.push(
         MgvLib.CleanTarget(
-          mgv.newOfferByTick(olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0), MIDDLE_BIN, 100_000, 0.05 ether
+          mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0),
+          olKey.tick(MIDDLE_BIN),
+          100_000,
+          0.05 ether
         )
       );
     }

--- a/test/core/gas/GasTestBase.t.sol
+++ b/test/core/gas/GasTestBase.t.sol
@@ -9,27 +9,29 @@ import {BinLib, Bin, LEAF_SIZE, LEVEL_SIZE} from "mgv_lib/BinLib.sol";
 
 // A bin with room for bits above and below at all bin levels, except at root which has only 2 bits.
 // forgefmt: disable-start
-int constant MIDDLE_BIN = 
+int constant IMIDDLE_BIN = 
   /* mid leaf */ LEAF_SIZE / 2 + 
   /* mid level 3 */ LEAF_SIZE * (LEVEL_SIZE / 2) +
   /* mid level 2 */ LEAF_SIZE * (LEVEL_SIZE**2)/2  +
   /* mid level 1 */ LEAF_SIZE * (LEVEL_SIZE ** 3)/4;
 // forgefmt: disable-end
 
-int constant LEAF_LOWER_BIN = MIDDLE_BIN - 1;
-int constant LEAF_HIGHER_BIN = MIDDLE_BIN + 1;
-int constant LEVEL3_LOWER_BIN = MIDDLE_BIN - LEAF_SIZE;
-int constant LEVEL3_HIGHER_BIN = MIDDLE_BIN + LEAF_SIZE;
-int constant LEVEL2_LOWER_BIN = MIDDLE_BIN - LEAF_SIZE * LEVEL_SIZE;
-int constant LEVEL2_HIGHER_BIN = MIDDLE_BIN + LEAF_SIZE * LEVEL_SIZE;
-int constant LEVEL1_LOWER_BIN = MIDDLE_BIN - LEAF_SIZE * (LEVEL_SIZE ** 2);
-int constant LEVEL1_HIGHER_BIN = MIDDLE_BIN + LEAF_SIZE * (LEVEL_SIZE ** 2);
+Bin constant MIDDLE_BIN = Bin.wrap(IMIDDLE_BIN);
+
+Bin constant LEAF_LOWER_BIN = Bin.wrap(IMIDDLE_BIN - 1);
+Bin constant LEAF_HIGHER_BIN = Bin.wrap(IMIDDLE_BIN + 1);
+Bin constant LEVEL3_LOWER_BIN = Bin.wrap(IMIDDLE_BIN - LEAF_SIZE);
+Bin constant LEVEL3_HIGHER_BIN = Bin.wrap(IMIDDLE_BIN + LEAF_SIZE);
+Bin constant LEVEL2_LOWER_BIN = Bin.wrap(IMIDDLE_BIN - LEAF_SIZE * LEVEL_SIZE);
+Bin constant LEVEL2_HIGHER_BIN = Bin.wrap(IMIDDLE_BIN + LEAF_SIZE * LEVEL_SIZE);
+Bin constant LEVEL1_LOWER_BIN = Bin.wrap(IMIDDLE_BIN - LEAF_SIZE * (LEVEL_SIZE ** 2));
+Bin constant LEVEL1_HIGHER_BIN = Bin.wrap(IMIDDLE_BIN + LEAF_SIZE * (LEVEL_SIZE ** 2));
 // Not multiplying by full LEVEL_SIZE or ROOT_HIGHER_BIN goes out of tick range
-int constant ROOT_LOWER_BIN = MIDDLE_BIN - LEAF_SIZE * (LEVEL_SIZE ** 3) / 2;
-int constant ROOT_HIGHER_BIN = MIDDLE_BIN + LEAF_SIZE * (LEVEL_SIZE ** 3) / 2;
+Bin constant ROOT_LOWER_BIN = Bin.wrap(IMIDDLE_BIN - LEAF_SIZE * (LEVEL_SIZE ** 3) / 2);
+Bin constant ROOT_HIGHER_BIN = Bin.wrap(IMIDDLE_BIN + LEAF_SIZE * (LEVEL_SIZE ** 3) / 2);
 
 abstract contract GasTestBaseStored {
-  mapping(int tick => uint offerId) internal tickOfferIds;
+  mapping(Bin bin => uint offerId) internal binOfferIds;
   string internal description = "TODO";
 
   function getStored() internal view virtual returns (IMangrove, TestTaker, OLKey memory, uint);
@@ -46,20 +48,26 @@ abstract contract GasTestBaseStored {
 
   function newOfferOnAllLowerThanMiddleTestRatios() public virtual {
     (IMangrove mgv,, OLKey memory _olKey,) = getStored();
-    tickOfferIds[LEAF_LOWER_BIN] = mgv.newOfferByTick(_olKey, LEAF_LOWER_BIN, 0.00001 ether, 1_000_000, 0);
-    tickOfferIds[LEVEL3_LOWER_BIN] = mgv.newOfferByTick(_olKey, LEVEL3_LOWER_BIN, 0.00001 ether, 1_000_000, 0);
-    tickOfferIds[LEVEL2_LOWER_BIN] = mgv.newOfferByTick(_olKey, LEVEL2_LOWER_BIN, 0.00001 ether, 1_000_000, 0);
-    tickOfferIds[LEVEL1_LOWER_BIN] = mgv.newOfferByTick(_olKey, LEVEL1_LOWER_BIN, 0.00001 ether, 1_000_000, 0);
-    tickOfferIds[ROOT_LOWER_BIN] = mgv.newOfferByTick(_olKey, ROOT_LOWER_BIN, 0.00001 ether, 1_000_000, 0);
+    binOfferIds[LEAF_LOWER_BIN] = mgv.newOfferByTick(_olKey, _olKey.tick(LEAF_LOWER_BIN), 0.00001 ether, 1_000_000, 0);
+    binOfferIds[LEVEL3_LOWER_BIN] =
+      mgv.newOfferByTick(_olKey, _olKey.tick(LEVEL3_LOWER_BIN), 0.00001 ether, 1_000_000, 0);
+    binOfferIds[LEVEL2_LOWER_BIN] =
+      mgv.newOfferByTick(_olKey, _olKey.tick(LEVEL2_LOWER_BIN), 0.00001 ether, 1_000_000, 0);
+    binOfferIds[LEVEL1_LOWER_BIN] =
+      mgv.newOfferByTick(_olKey, _olKey.tick(LEVEL1_LOWER_BIN), 0.00001 ether, 1_000_000, 0);
+    binOfferIds[ROOT_LOWER_BIN] = mgv.newOfferByTick(_olKey, _olKey.tick(ROOT_LOWER_BIN), 0.00001 ether, 1_000_000, 0);
   }
 
   function newOfferOnAllHigherThanMiddleTestRatios() public virtual {
     (IMangrove mgv,, OLKey memory _olKey,) = getStored();
-    tickOfferIds[LEAF_HIGHER_BIN] = mgv.newOfferByTick(_olKey, LEAF_HIGHER_BIN, 0.00001 ether, 1_000_000, 0);
-    tickOfferIds[LEVEL3_HIGHER_BIN] = mgv.newOfferByTick(_olKey, LEVEL3_HIGHER_BIN, 0.00001 ether, 1_000_000, 0);
-    tickOfferIds[LEVEL2_HIGHER_BIN] = mgv.newOfferByTick(_olKey, LEVEL2_HIGHER_BIN, 0.00001 ether, 1_000_000, 0);
-    tickOfferIds[LEVEL1_HIGHER_BIN] = mgv.newOfferByTick(_olKey, LEVEL1_HIGHER_BIN, 0.00001 ether, 1_000_000, 0);
-    tickOfferIds[ROOT_HIGHER_BIN] = mgv.newOfferByTick(_olKey, ROOT_HIGHER_BIN, 0.00001 ether, 1_000_000, 0);
+    binOfferIds[LEAF_HIGHER_BIN] = mgv.newOfferByTick(_olKey, _olKey.tick(LEAF_HIGHER_BIN), 0.00001 ether, 1_000_000, 0);
+    binOfferIds[LEVEL3_HIGHER_BIN] =
+      mgv.newOfferByTick(_olKey, _olKey.tick(LEVEL3_HIGHER_BIN), 0.00001 ether, 1_000_000, 0);
+    binOfferIds[LEVEL2_HIGHER_BIN] =
+      mgv.newOfferByTick(_olKey, _olKey.tick(LEVEL2_HIGHER_BIN), 0.00001 ether, 1_000_000, 0);
+    binOfferIds[LEVEL1_HIGHER_BIN] =
+      mgv.newOfferByTick(_olKey, _olKey.tick(LEVEL1_HIGHER_BIN), 0.00001 ether, 1_000_000, 0);
+    binOfferIds[ROOT_HIGHER_BIN] = mgv.newOfferByTick(_olKey, _olKey.tick(ROOT_HIGHER_BIN), 0.00001 ether, 1_000_000, 0);
   }
 }
 

--- a/test/core/gas/MarketOrderOtherOfferList.t.sol
+++ b/test/core/gas/MarketOrderOtherOfferList.t.sol
@@ -75,7 +75,7 @@ contract ExternalMarketOrderOtherOfferList_WithNoOtherOffersGasTest is GasTestBa
   function test_market_order_by_volume_full() public {
     (IMangrove mgv, TestTaker taker, OLKey memory _olKey,) = getStored();
     uint takerGives = 0.00001 ether;
-    uint takerWants = TickLib.outboundFromInbound(_olKey.tick(MIDDLE_BIN), takerGives);
+    uint takerWants = _olKey.tick(MIDDLE_BIN).outboundFromInbound(takerGives);
     vm.prank($(taker));
     _gas();
     mgv.marketOrderByVolume(_olKey, takerWants, takerGives, false);

--- a/test/core/gas/MarketOrderOtherOfferList.t.sol
+++ b/test/core/gas/MarketOrderOtherOfferList.t.sol
@@ -25,25 +25,25 @@ import {MgvStructs} from "mgv_src/MgvLib.sol";
 import "mgv_lib/Debug.sol";
 
 contract ExternalMarketOrderOtherOfferList_WithNoOtherOffersGasTest is GasTestBase {
-  int internal tick;
+  Bin internal bin;
 
   function setUp() public virtual override {
     super.setUp();
-    tick = MIDDLE_BIN;
-    _offerId = mgv.newOfferByTick(olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0);
+    bin = MIDDLE_BIN;
+    _offerId = mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0);
     description = "Worst case scenario of taking the last offer from an offer list which now becomes empty";
   }
 
-  function setUpTick(int _tick) public virtual {
-    tick = _tick;
-    _offerId = mgv.newOfferByTick(olKey, _tick, 0.00001 ether, 100_000, 0);
+  function setUpBin(Bin _bin) public virtual {
+    bin = _bin;
+    _offerId = mgv.newOfferByTick(olKey, olKey.tick(bin), 0.00001 ether, 100_000, 0);
   }
 
   function test_market_order_partial() public {
     (IMangrove mgv, TestTaker taker, OLKey memory _olKey,) = getStored();
     vm.prank($(taker));
     _gas();
-    mgv.marketOrderByTick(_olKey, MIDDLE_BIN, 1, false);
+    mgv.marketOrderByTick(_olKey, _olKey.tick(MIDDLE_BIN), 1, false);
     gas_();
     assertEq(0, mgv.best(_olKey));
     description = string.concat(description, " - Case: market order partial");
@@ -54,7 +54,7 @@ contract ExternalMarketOrderOtherOfferList_WithNoOtherOffersGasTest is GasTestBa
     (IMangrove mgv, TestTaker taker, OLKey memory _olKey,) = getStored();
     vm.prank($(taker));
     _gas();
-    mgv.marketOrderByTick(_olKey, MIDDLE_BIN, 1, true);
+    mgv.marketOrderByTick(_olKey, _olKey.tick(MIDDLE_BIN), 1, true);
     gas_();
     assertEq(0, mgv.best(_olKey));
     description = string.concat(description, " - Case: market order partial with fillwants=true");
@@ -65,7 +65,7 @@ contract ExternalMarketOrderOtherOfferList_WithNoOtherOffersGasTest is GasTestBa
     (IMangrove mgv, TestTaker taker, OLKey memory _olKey,) = getStored();
     vm.prank($(taker));
     _gas();
-    mgv.marketOrderByTick(_olKey, MIDDLE_BIN, 0.00001 ether, false);
+    mgv.marketOrderByTick(_olKey, _olKey.tick(MIDDLE_BIN), 0.00001 ether, false);
     gas_();
     assertEq(0, mgv.best(_olKey));
     description = string.concat(description, " - Case: market order by log price full fill");
@@ -75,7 +75,7 @@ contract ExternalMarketOrderOtherOfferList_WithNoOtherOffersGasTest is GasTestBa
   function test_market_order_by_volume_full() public {
     (IMangrove mgv, TestTaker taker, OLKey memory _olKey,) = getStored();
     uint takerGives = 0.00001 ether;
-    uint takerWants = TickLib.outboundFromInbound(MIDDLE_BIN, takerGives);
+    uint takerWants = TickLib.outboundFromInbound(_olKey.tick(MIDDLE_BIN), takerGives);
     vm.prank($(taker));
     _gas();
     mgv.marketOrderByVolume(_olKey, takerWants, takerGives, false);
@@ -89,7 +89,7 @@ contract ExternalMarketOrderOtherOfferList_WithNoOtherOffersGasTest is GasTestBa
     (IMangrove mgv, TestTaker taker, OLKey memory _olKey,) = getStored();
     vm.prank($(taker));
     _gas();
-    mgv.marketOrderByTick(_olKey, MIDDLE_BIN, 0.00001 ether, false);
+    mgv.marketOrderByTick(_olKey, olKey.tick(MIDDLE_BIN), 0.00001 ether, false);
     gas_();
     assertEq(0, mgv.best(_olKey));
     description = string.concat(description, " - Case: market order by ratio full fill");
@@ -98,30 +98,30 @@ contract ExternalMarketOrderOtherOfferList_WithNoOtherOffersGasTest is GasTestBa
 }
 
 abstract contract ExternalMarketOrderOtherOfferList_WithOtherOfferGasTest is GasTestBase {
-  int internal tick;
+  Bin internal bin;
 
   function setUp() public virtual override {
     super.setUp();
     // The offer to take
-    tick = MIDDLE_BIN;
-    _offerId = mgv.newOfferByTick(olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0);
-    description = "Market order taking an offer which moves the ratio up various tick-distances";
+    bin = MIDDLE_BIN;
+    _offerId = mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0);
+    description = "Market order taking an offer which moves the ratio up various bin-distances";
   }
 
-  function setUpTick(int _tick) public virtual {
+  function setUpBin(Bin _bin) public virtual {
     // The offer ratio ends up at
-    tick = _tick;
-    _offerId = mgv.newOfferByTick(olKey, _tick, 0.00001 ether, 100_000, 0);
+    bin = _bin;
+    _offerId = mgv.newOfferByTick(olKey, olKey.tick(bin), 0.00001 ether, 100_000, 0);
   }
 
   function test_market_order_partial() public {
     (IMangrove mgv, TestTaker taker, OLKey memory _olKey,) = getStored();
     vm.prank($(taker));
     _gas();
-    mgv.marketOrderByTick(_olKey, MIDDLE_BIN, 1, false);
+    mgv.marketOrderByTick(_olKey, _olKey.tick(MIDDLE_BIN), 1, false);
     gas_();
     (, MgvStructs.LocalPacked local) = mgv.config(_olKey);
-    assertEq(tick, TickLib.fromBin(local.bestBin(), _olKey.tickSpacing));
+    assertEq(bin, local.bestBin());
     printDescription();
   }
 }
@@ -131,7 +131,7 @@ contract ExternalMarketOrderOtherOfferList_WithOtherOfferGasTest_MIDDLE_BIN is
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(MIDDLE_BIN);
+    setUpBin(MIDDLE_BIN);
     description = string.concat(description, " - Case: MIDDLE_BIN");
   }
 }
@@ -141,7 +141,7 @@ contract ExternalMarketOrderOtherOfferList_WithOtherOfferGasTest_LEAF_HIGHER_BIN
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEAF_HIGHER_BIN);
+    setUpBin(LEAF_HIGHER_BIN);
     description = string.concat(description, " - Case: LEAF_HIGHER_BIN");
   }
 }
@@ -151,7 +151,7 @@ contract ExternalMarketOrderOtherOfferList_WithOtherOfferGasTest_LEVEL3_HIGHER_B
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL3_HIGHER_BIN);
+    setUpBin(LEVEL3_HIGHER_BIN);
     description = string.concat(description, " - Case: LEVEL3_HIGHER_BIN");
   }
 }
@@ -161,7 +161,7 @@ contract ExternalMarketOrderOtherOfferList_WithOtherOfferGasTest_LEVEL2_HIGHER_B
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL2_HIGHER_BIN);
+    setUpBin(LEVEL2_HIGHER_BIN);
     description = string.concat(description, " - Case: LEVEL2_HIGHER_BIN");
   }
 }
@@ -171,7 +171,7 @@ contract ExternalMarketOrderOtherOfferList_WithOtherOfferGasTest_LEVEL1_HIGHER_B
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL1_HIGHER_BIN);
+    setUpBin(LEVEL1_HIGHER_BIN);
     description = string.concat(description, " - Case: LEVEL1_HIGHER_BIN");
   }
 }
@@ -181,7 +181,7 @@ contract ExternalMarketOrderOtherOfferList_WithOtherOfferGasTest_ROOT_HIGHER_BIN
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(ROOT_HIGHER_BIN);
+    setUpBin(ROOT_HIGHER_BIN);
     description = string.concat(description, " - Case: ROOT_HIGHER_BIN");
   }
 }
@@ -189,19 +189,19 @@ contract ExternalMarketOrderOtherOfferList_WithOtherOfferGasTest_ROOT_HIGHER_BIN
 abstract contract ExternalMarketOrderOtherOfferList_WithMultipleOffersAtSameBin is SingleGasTestBase {
   function setUpOffers(uint count) internal {
     for (uint i; i < count; ++i) {
-      _offerId = mgv.newOfferByTick(olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0);
+      _offerId = mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0);
     }
-    mgv.newOfferByTick(olKey, MIDDLE_BIN + 1, 0.00001 ether, 100_000, 0);
-    description = string.concat(string.concat("Market order taking ", vm.toString(count), " offers at same tick"));
+    mgv.newOfferByTick(olKey, olKey.tick(Bin.wrap(Bin.unwrap(MIDDLE_BIN) + 1)), 0.00001 ether, 100_000, 0);
+    description = string.concat(string.concat("Market order taking ", vm.toString(count), " offers at same bin"));
   }
 
   function impl(IMangrove mgv, TestTaker taker, OLKey memory _olKey, uint) internal virtual override {
     vm.prank($(taker));
     _gas();
-    mgv.marketOrderByTick(_olKey, MIDDLE_BIN, 2 ** 96, false);
+    mgv.marketOrderByTick(_olKey, _olKey.tick(MIDDLE_BIN), 2 ** 96, false);
     gas_();
     (, MgvStructs.LocalPacked local) = mgv.config(_olKey);
-    assertEq(MIDDLE_BIN + 1, TickLib.fromBin(local.bestBin(), _olKey.tickSpacing));
+    assertEq(Bin.unwrap(MIDDLE_BIN) + 1, Bin.unwrap(local.bestBin()));
     printDescription();
   }
 }
@@ -240,17 +240,15 @@ contract ExternalMarketOrderOtherOfferList_WithMultipleOffersAtManyBins is TickT
     description = "Market order taking offers up to a bin with offers on all test ticks";
   }
 
-  function impl(IMangrove mgv, TestTaker taker, OLKey memory _olKey, uint, int _tick) internal virtual override {
+  function impl(IMangrove mgv, TestTaker taker, OLKey memory _olKey, uint, Bin _bin) internal virtual override {
     vm.prank($(taker));
     _gas();
-    mgv.marketOrderByTick(_olKey, _tick, 2 ** 104 - 1, false);
+    mgv.marketOrderByTick(_olKey, _olKey.tick(_bin), 2 ** 104 - 1, false);
     gas_();
     (, MgvStructs.LocalPacked local) = mgv.config(_olKey);
     // In some tests the market order takes all offers, in others not. `local.bestBin()` must only be called when the book is non-empty
     if (!local.root().isEmpty()) {
-      assertLt(
-        _tick, TickLib.fromBin(local.bestBin(), _olKey.tickSpacing), "tick should be strictly less than current tick"
-      );
+      assertTrue(_bin.strictlyBetter(local.bestBin()), "tick should be strictly less than current tick");
     }
   }
 }

--- a/test/core/gas/NewOfferOtherOfferList.t.sol
+++ b/test/core/gas/NewOfferOtherOfferList.t.sol
@@ -6,12 +6,12 @@ import {SingleGasTestBase, GasTestBase, MIDDLE_BIN} from "./GasTestBase.t.sol";
 import {IMangrove, TestTaker} from "mgv_test/lib/MangroveTest.sol";
 import {TickTreeBoundariesGasTest} from "./TickTreeBoundariesGasTest.t.sol";
 import {IMangrove, TestTaker} from "mgv_test/lib/MangroveTest.sol";
-import {OLKey} from "mgv_src/MgvLib.sol";
+import "mgv_src/MgvLib.sol";
 
 contract ExternalNewOfferOtherOfferList_AlwaysEmptyGasTest is SingleGasTestBase {
   function impl(IMangrove mgv, TestTaker, OLKey memory _olKey, uint) internal override {
     _gas();
-    mgv.newOfferByTick(_olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0);
+    mgv.newOfferByTick(_olKey, _olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0);
     gas_();
     description =
       "Worst case scenario if strat posts on different, as of yet always empty, list. This is unlikely to happen in practice";
@@ -21,9 +21,9 @@ contract ExternalNewOfferOtherOfferList_AlwaysEmptyGasTest is SingleGasTestBase 
 contract ExternalNewOfferOtherOfferList_WithNoOtherOffersGasTest is SingleGasTestBase {
   function setUp() public virtual override {
     super.setUp();
-    mgv.newOfferByTick(olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0);
+    mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0);
     vm.prank($(_taker));
-    mgv.marketOrderByTick(olKey, MIDDLE_BIN, 1, true);
+    mgv.marketOrderByTick(olKey, olKey.tick(MIDDLE_BIN), 1, true);
     assertEq(0, mgv.best(olKey));
     description =
       "Worst case scenario if strat posts on a different offer list which has become empty. This can happen in practice if offer list runs out of liquidity";
@@ -31,7 +31,7 @@ contract ExternalNewOfferOtherOfferList_WithNoOtherOffersGasTest is SingleGasTes
 
   function impl(IMangrove mgv, TestTaker, OLKey memory _olKey, uint) internal virtual override {
     _gas();
-    mgv.newOfferByTick(_olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0);
+    mgv.newOfferByTick(_olKey, olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0);
     gas_();
   }
 }
@@ -39,13 +39,13 @@ contract ExternalNewOfferOtherOfferList_WithNoOtherOffersGasTest is SingleGasTes
 contract ExternalNewOfferOtherOfferList_WithOtherOfferGasTest is TickTreeBoundariesGasTest, GasTestBase {
   function setUp() public virtual override {
     super.setUp();
-    _offerId = mgv.newOfferByTick(olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0);
-    description = "Posting a new offer when another offer exists at various tick-distances to the new offer";
+    _offerId = mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0);
+    description = "Posting a new offer when another offer exists at various bin-distances to the new offer";
   }
 
-  function impl(IMangrove mgv, TestTaker, OLKey memory _olKey, uint, int _tick) internal override {
+  function impl(IMangrove mgv, TestTaker, OLKey memory _olKey, uint, Bin _bin) internal override {
     _gas();
-    mgv.newOfferByTick(_olKey, _tick, 0.00001 ether, 100_000, 0);
+    mgv.newOfferByTick(_olKey, _olKey.tick(_bin), 0.00001 ether, 100_000, 0);
     gas_();
   }
 }
@@ -57,7 +57,7 @@ contract ExternalNewOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTest i
     super.setUp();
     this.newOfferOnAllTestRatios();
     description =
-      "Posting a new offer when another offer exists at various tick-distances to the new offer but also on the same tick";
+      "Posting a new offer when another offer exists at various bin-distances to the new offer but also on the same bin";
   }
 }
 
@@ -66,11 +66,11 @@ contract ExternalNewOfferOtherOfferList_WithPriorNewOfferAndNoOtherOffersGasTest
 {
   function setUp() public virtual override {
     super.setUp();
-    description = "Posting a second new offer at various tick-distances after posting an offer at MIDDLE_BIN";
+    description = "Posting a second new offer at various bin-distances after posting an offer at MIDDLE_BIN";
   }
 
   function impl(IMangrove mgv, TestTaker taker, OLKey memory _olKey, uint offerId) internal override {
-    mgv.newOfferByTick(_olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0);
+    mgv.newOfferByTick(_olKey, _olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0);
     super.impl(mgv, taker, _olKey, offerId);
   }
 }

--- a/test/core/gas/OfferGasBase.t.sol
+++ b/test/core/gas/OfferGasBase.t.sol
@@ -80,16 +80,16 @@ abstract contract OfferGasBaseBaseTest is MangroveTest, GasTestBaseStored {
     vm.prank(maker);
     TransferLib.approveToken(quote, $(mgv), type(uint).max);
     vm.prank(maker);
-    mgv.newOfferByTick(olKey, MIDDLE_BIN, offerGivesOl, 100000, 0);
+    mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), offerGivesOl, 100000, 0);
     vm.prank(maker);
-    mgv.newOfferByTick(lo, MIDDLE_BIN, offerGivesLo, 100000, 0);
+    mgv.newOfferByTick(lo, lo.tick(MIDDLE_BIN), offerGivesLo, 100000, 0);
   }
 
   function gasbase_to_empty_book(OLKey memory _olKey) internal {
     (IMangrove _mgv,,,) = getStored();
     vm.prank($(taker));
     _gas();
-    _mgv.marketOrderByTick(_olKey, MIDDLE_BIN, 1, false);
+    _mgv.marketOrderByTick(_olKey, _olKey.tick(MIDDLE_BIN), 1, false);
     gas_();
   }
 

--- a/test/core/gas/OfferPosthookFailGasDelta.t.sol
+++ b/test/core/gas/OfferPosthookFailGasDelta.t.sol
@@ -129,25 +129,25 @@ contract OfferPosthookFailGasDeltaTest is MangroveTest, IMaker {
 
     // A successful offer (both offer lists)
     vm.prank(maker);
-    mgv.newOfferByTick(olKey, MIDDLE_BIN, offerGivesOl, 10000, 0);
+    mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), offerGivesOl, 10000, 0);
     vm.prank(maker);
-    mgv.newOfferByTick(lo, MIDDLE_BIN, offerGivesLo, 10000, 0);
+    mgv.newOfferByTick(lo, lo.tick(MIDDLE_BIN), offerGivesLo, 10000, 0);
 
     // Do not approve maker - we will let offers fail since then penalty must be calculated, which costs gas.
     for (uint i; i < 19; i++) {
-      mgv.newOfferByTick(olKey, MIDDLE_BIN, offerGivesOl, 10000, 0);
-      mgv.newOfferByTick(lo, MIDDLE_BIN, offerGivesLo, 10000, 0);
+      mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), offerGivesOl, 10000, 0);
+      mgv.newOfferByTick(lo, lo.tick(MIDDLE_BIN), offerGivesLo, 10000, 0);
     }
 
     // A successful offer (both offer lists)
     vm.prank(maker);
-    mgv.newOfferByTick(olKey, MIDDLE_BIN, offerGivesOl, 10000, 0);
+    mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), offerGivesOl, 10000, 0);
     vm.prank(maker);
-    mgv.newOfferByTick(lo, MIDDLE_BIN, offerGivesLo, 10000, 0);
+    mgv.newOfferByTick(lo, lo.tick(MIDDLE_BIN), offerGivesLo, 10000, 0);
   }
 
   function posthook_delta_deep_order(OLKey memory olKey) public {
     vm.prank($(taker));
-    mgv.marketOrderByTick({olKey: olKey, maxTick: MIDDLE_BIN, fillVolume: 1 ether, fillWants: false});
+    mgv.marketOrderByTick({olKey: olKey, maxTick: olKey.tick(MIDDLE_BIN), fillVolume: 1 ether, fillWants: false});
   }
 }

--- a/test/core/gas/RetractOfferOtherOfferList.t.sol
+++ b/test/core/gas/RetractOfferOtherOfferList.t.sol
@@ -18,20 +18,20 @@ import {
   ROOT_HIGHER_BIN
 } from "./GasTestBase.t.sol";
 import {IMangrove, TestTaker} from "mgv_test/lib/MangroveTest.sol";
-import {OLKey} from "mgv_src/MgvLib.sol";
+import "mgv_src/MgvLib.sol";
 import {TickTreeBoundariesGasTest} from "./TickTreeBoundariesGasTest.t.sol";
 
 contract ExternalRetractOfferOtherOfferList_WithNoOtherOffersGasTest is GasTestBase {
   function setUp() public virtual override {
     super.setUp();
-    _offerId = mgv.newOfferByTick(olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0);
+    _offerId = mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0);
     description =
       "Worst case scenario if strat retracts an offer from an offer list which has now become empty - with and without deprovision";
   }
 
-  function setUpTick(int _tick) public virtual {
-    _offerId = mgv.newOfferByTick(olKey, _tick, 0.00001 ether, 100_000, 0);
-    description = "Retracting an offer when another offer exists at various tick-distances to the offer's ratio";
+  function setUpBin(Bin _bin) public virtual {
+    _offerId = mgv.newOfferByTick(olKey, olKey.tick(_bin), 0.00001 ether, 100_000, 0);
+    description = "Retracting an offer when another offer exists at various bin-distances to the offer's ratio";
   }
 
   function test_retract_offer_deprovision() public {
@@ -58,7 +58,7 @@ contract ExternalRetractOfferOtherOfferList_WithOtherOfferGasTest_MIDDLE_BIN is
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(MIDDLE_BIN);
+    setUpBin(MIDDLE_BIN);
     description = string.concat(description, " - Case: MIDDLE_BIN");
   }
 }
@@ -68,7 +68,7 @@ contract ExternalRetractOfferOtherOfferList_WithOtherOfferGasTest_LEAF_LOWER_BIN
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEAF_LOWER_BIN);
+    setUpBin(LEAF_LOWER_BIN);
     description = string.concat(description, " - Case: LEAF_LOWER_BIN");
   }
 }
@@ -78,7 +78,7 @@ contract ExternalRetractOfferOtherOfferList_WithOtherOfferGasTest_LEAF_HIGHER_BI
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEAF_HIGHER_BIN);
+    setUpBin(LEAF_HIGHER_BIN);
     description = string.concat(description, " - Case: LEAF_HIGHER_BIN");
   }
 }
@@ -88,7 +88,7 @@ contract ExternalRetractOfferOtherOfferList_WithOtherOfferGasTest_LEVEL3_LOWER_B
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL3_LOWER_BIN);
+    setUpBin(LEVEL3_LOWER_BIN);
     description = string.concat(description, " - Case: LEVEL3_LOWER_BIN");
   }
 }
@@ -98,7 +98,7 @@ contract ExternalRetractOfferOtherOfferList_WithOtherOfferGasTest_LEVEL3_HIGHER_
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL3_HIGHER_BIN);
+    setUpBin(LEVEL3_HIGHER_BIN);
     description = string.concat(description, " - Case: LEVEL3_HIGHER_BIN");
   }
 }
@@ -108,7 +108,7 @@ contract ExternalRetractOfferOtherOfferList_WithOtherOfferGasTest_LEVEL2_LOWER_B
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL2_LOWER_BIN);
+    setUpBin(LEVEL2_LOWER_BIN);
     description = string.concat(description, " - Case: LEVEL2_LOWER_BIN");
   }
 }
@@ -118,7 +118,7 @@ contract ExternalRetractOfferOtherOfferList_WithOtherOfferGasTest_LEVEL2_HIGHER_
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL2_HIGHER_BIN);
+    setUpBin(LEVEL2_HIGHER_BIN);
     description = string.concat(description, " - Case: LEVEL2_HIGHER_BIN");
   }
 }
@@ -128,7 +128,7 @@ contract ExternalRetractOfferOtherOfferList_WithOtherOfferGasTest_LEVEL1_LOWER_B
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL1_LOWER_BIN);
+    setUpBin(LEVEL1_LOWER_BIN);
     description = string.concat(description, " - Case: LEVEL1_LOWER_BIN");
   }
 }
@@ -138,7 +138,7 @@ contract ExternalRetractOfferOtherOfferList_WithOtherOfferGasTest_LEVEL1_HIGHER_
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL1_HIGHER_BIN);
+    setUpBin(LEVEL1_HIGHER_BIN);
     description = string.concat(description, " - Case: LEVEL1_HIGHER_BIN");
   }
 }
@@ -148,7 +148,7 @@ contract ExternalRetractOfferOtherOfferList_WithOtherOfferGasTest_ROOT_LOWER_BIN
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(ROOT_LOWER_BIN);
+    setUpBin(ROOT_LOWER_BIN);
     description = string.concat(description, " - Case: ROOT_LOWER_BIN");
   }
 }
@@ -158,7 +158,7 @@ contract ExternalRetractOfferOtherOfferList_WithOtherOfferGasTest_ROOT_HIGHER_BI
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(ROOT_HIGHER_BIN);
+    setUpBin(ROOT_HIGHER_BIN);
     description = string.concat(description, " - Case: ROOT_HIGHER_BIN");
   }
 }
@@ -172,10 +172,10 @@ abstract contract ExternalRetractOfferOtherOfferList_WithOtherOfferAndOfferOnSam
     this.newOfferOnAllTestRatios();
   }
 
-  function setUpTick(int _tick) public virtual override {
-    _tick; // silence irrelevant warning for override
+  function setUpBin(Bin _bin) public virtual override {
+    _bin; // silence irrelevant warning for override
     description =
-      "Retracting an offer when another offer exists at various tick-distances to the offer ratio but also on the same tick";
+      "Retracting an offer when another offer exists at various bin-distances to the offer ratio but also on the same bin";
   }
 }
 
@@ -184,7 +184,7 @@ contract ExternalRetractOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTe
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(MIDDLE_BIN);
+    setUpBin(MIDDLE_BIN);
     description = string.concat(description, " - Case: MIDDLE_BIN");
   }
 }
@@ -194,7 +194,7 @@ contract ExternalRetractOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTe
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEAF_LOWER_BIN);
+    setUpBin(LEAF_LOWER_BIN);
     description = string.concat(description, " - Case: LEAF_LOWER_BIN");
   }
 }
@@ -204,7 +204,7 @@ contract ExternalRetractOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTe
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEAF_HIGHER_BIN);
+    setUpBin(LEAF_HIGHER_BIN);
     description = string.concat(description, " - Case: LEAF_HIGHER_BIN");
   }
 }
@@ -214,7 +214,7 @@ contract ExternalRetractOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTe
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL3_LOWER_BIN);
+    setUpBin(LEVEL3_LOWER_BIN);
     description = string.concat(description, " - Case: LEVEL3_LOWER_BIN");
   }
 }
@@ -224,7 +224,7 @@ contract ExternalRetractOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTe
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL3_HIGHER_BIN);
+    setUpBin(LEVEL3_HIGHER_BIN);
     description = string.concat(description, " - Case: LEVEL3_HIGHER_BIN");
   }
 }
@@ -234,7 +234,7 @@ contract ExternalRetractOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTe
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL2_LOWER_BIN);
+    setUpBin(LEVEL2_LOWER_BIN);
     description = string.concat(description, " - Case: LEVEL2_LOWER_BIN");
   }
 }
@@ -244,7 +244,7 @@ contract ExternalRetractOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTe
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL2_HIGHER_BIN);
+    setUpBin(LEVEL2_HIGHER_BIN);
     description = string.concat(description, " - Case: LEVEL2_HIGHER_BIN");
   }
 }
@@ -254,7 +254,7 @@ contract ExternalRetractOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTe
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL1_LOWER_BIN);
+    setUpBin(LEVEL1_LOWER_BIN);
     description = string.concat(description, " - Case: LEVEL1_LOWER_BIN");
   }
 }
@@ -264,7 +264,7 @@ contract ExternalRetractOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTe
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(LEVEL1_HIGHER_BIN);
+    setUpBin(LEVEL1_HIGHER_BIN);
     description = string.concat(description, " - Case: LEVEL1_HIGHER_BIN");
   }
 }
@@ -274,7 +274,7 @@ contract ExternalRetractOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTe
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(ROOT_LOWER_BIN);
+    setUpBin(ROOT_LOWER_BIN);
     description = string.concat(description, " - Case: ROOT_LOWER_BIN");
   }
 }
@@ -284,7 +284,7 @@ contract ExternalRetractOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTe
 {
   function setUp() public virtual override {
     super.setUp();
-    setUpTick(ROOT_HIGHER_BIN);
+    setUpBin(ROOT_HIGHER_BIN);
     description = string.concat(description, " - Case: ROOT_HIGHER_BIN");
   }
 }
@@ -297,16 +297,16 @@ contract ExternalRetractOfferOtherOfferList_WithPriorRetractOfferAndNoOtherOffer
 
   function setUp() public virtual override {
     super.setUp();
-    _offerId = mgv.newOfferByTick(olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0);
-    tickOfferIds[MIDDLE_BIN] = _offerId;
+    _offerId = mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0);
+    binOfferIds[MIDDLE_BIN] = _offerId;
     this.newOfferOnAllTestRatios();
-    offerId2 = mgv.newOfferByTick(olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0);
-    description = "Retracting a second offer at various tick-distances after retracting an offer at MIDDLE_BIN";
+    offerId2 = mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0);
+    description = "Retracting a second offer at various bin-distances after retracting an offer at MIDDLE_BIN";
   }
 
-  function impl(IMangrove mgv, TestTaker, OLKey memory _olKey, uint, int _tick) internal override {
+  function impl(IMangrove mgv, TestTaker, OLKey memory _olKey, uint, Bin _bin) internal override {
     mgv.retractOffer(_olKey, offerId2, false);
-    uint offerId = tickOfferIds[_tick];
+    uint offerId = binOfferIds[_bin];
     _gas();
     mgv.retractOffer(_olKey, offerId, false);
     gas_();

--- a/test/core/gas/RetractOfferSameOfferList.t.sol
+++ b/test/core/gas/RetractOfferSameOfferList.t.sol
@@ -2,14 +2,14 @@
 
 pragma solidity ^0.8.18;
 
-import {SingleGasTestBase, GasTestBase, MIDDLE_BIN} from "./GasTestBase.t.sol";
+import {SingleGasTestBase, GasTestBase, IMIDDLE_BIN, MIDDLE_BIN} from "./GasTestBase.t.sol";
 import {IMangrove, TestTaker} from "mgv_test/lib/MangroveTest.sol";
 import {TickTreeBoundariesGasTest} from "./TickTreeBoundariesGasTest.t.sol";
 import {MgvLib, OLKey} from "mgv_src/MgvLib.sol";
 import {LEAF_SIZE, LEVEL_SIZE} from "mgv_lib/BinLib.sol";
 import "mgv_lib/Debug.sol";
 
-int constant LOW_BIN = MIDDLE_BIN - LEAF_SIZE * 2 * (LEVEL_SIZE ** 3) / 3;
+Bin constant LOW_BIN = Bin.wrap(IMIDDLE_BIN - LEAF_SIZE * 2 * (LEVEL_SIZE ** 3) / 3);
 
 contract PosthookSuccessRetractOfferSameList_WithOtherOfferGasTest is TickTreeBoundariesGasTest, GasTestBase {
   uint internal offerId2;
@@ -17,26 +17,26 @@ contract PosthookSuccessRetractOfferSameList_WithOtherOfferGasTest is TickTreeBo
   function setUp() public virtual override {
     super.setUp();
     this.newOfferOnAllTestRatios();
-    _offerId = mgv.newOfferByTick(olKey, MIDDLE_BIN, 1000 ether, 1_000_000, 0);
-    tickOfferIds[MIDDLE_BIN] = _offerId;
+    _offerId = mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), 1000 ether, 1_000_000, 0);
+    binOfferIds[MIDDLE_BIN] = _offerId;
     // Offer to take at very low ratio
-    mgv.newOfferByTick(olKey, LOW_BIN, 2 ** 96 - 1, 1_000_000, 0);
-    offerId2 = mgv.newOfferByTick(olKey, LOW_BIN, 2 ** 96 - 1, 1_000_000, 0);
+    mgv.newOfferByTick(olKey, olKey.tick(LOW_BIN), 2 ** 96 - 1, 1_000_000, 0);
+    offerId2 = mgv.newOfferByTick(olKey, olKey.tick(LOW_BIN), 2 ** 96 - 1, 1_000_000, 0);
     description =
       "Retracting an offer in posthook for now empty offer list but where new offer has varying closeness to taken offer";
   }
 
   function makerPosthook(MgvLib.SingleOrder calldata, MgvLib.OrderResult calldata) public virtual override {
     (IMangrove mgv,, OLKey memory _olKey,) = getStored();
-    uint offerId = tickOfferIds[tick];
+    uint offerId = binOfferIds[bin];
     _gas();
     mgv.retractOffer(_olKey, offerId, true);
     gas_();
   }
 
-  function impl(IMangrove mgv, TestTaker taker, OLKey memory _olKey, uint, int) internal override {
+  function impl(IMangrove mgv, TestTaker taker, OLKey memory _olKey, uint, Bin) internal override {
     vm.prank($(taker));
-    mgv.marketOrderByTick(_olKey, LOW_BIN, 1, true);
+    mgv.marketOrderByTick(_olKey, olKey.tick(LOW_BIN), 1, true);
   }
 }
 
@@ -46,12 +46,12 @@ contract PosthookSuccessRetractOfferSameList_WithPriorRetractOfferAndOtherOffers
   function setUp() public virtual override {
     super.setUp();
     description =
-      "Retracting a second offer at various tick-distances in posthook after retracting an offer at MIDDLE_BIN";
+      "Retracting a second offer at various bin-distances in posthook after retracting an offer at MIDDLE_BIN";
   }
 
   function makerPosthook(MgvLib.SingleOrder calldata sor, MgvLib.OrderResult calldata result) public virtual override {
     (IMangrove mgv,, OLKey memory _olKey,) = getStored();
-    // Retract near taken - the measured one is at various tick-distances.
+    // Retract near taken - the measured one is at various bin-distances.
     mgv.retractOffer(_olKey, offerId2, true);
     super.makerPosthook(sor, result);
   }

--- a/test/core/gas/TickTreeBoundariesGasTest.t.sol
+++ b/test/core/gas/TickTreeBoundariesGasTest.t.sol
@@ -22,81 +22,81 @@ import "mgv_lib/Debug.sol";
 
 /// Implements tests for all boundaries of bin values. Starting from a MIDDLE_BIN it goes above and below creating new branches for all levels.
 abstract contract TickTreeBoundariesGasTest is GasTestBaseStored {
-  int internal tick;
+  Bin internal bin;
 
-  function testTick(int _tick) internal virtual {
-    tick = _tick;
+  function testBin(Bin _bin) internal virtual {
+    bin = _bin;
     (IMangrove mgv, TestTaker taker, OLKey memory _olKey, uint offerId) = getStored();
 
-    impl(mgv, taker, _olKey, offerId, _tick);
+    impl(mgv, taker, _olKey, offerId, _bin);
   }
 
-  function impl(IMangrove mgv, TestTaker taker, OLKey memory _olKey, uint offerId, int _tick) internal virtual;
+  function impl(IMangrove mgv, TestTaker taker, OLKey memory _olKey, uint offerId, Bin _bin) internal virtual;
 
   function test_ExistingBin() public {
-    testTick(MIDDLE_BIN);
-    description = string.concat(description, " - Case: Existing tick");
+    testBin(MIDDLE_BIN);
+    description = string.concat(description, " - Case: Existing bin");
     printDescription();
   }
 
   function test_ExistingLeafLowerBin() public {
-    testTick(LEAF_LOWER_BIN);
+    testBin(LEAF_LOWER_BIN);
     description = string.concat(description, " - Case: Existing leaf lower bin");
     printDescription();
   }
 
   function test_ExistingLeafHigherBin() public {
-    console.log("MIDDLE", MIDDLE_BIN);
-    console.log("LEAF HIGHER", LEAF_HIGHER_BIN);
-    testTick(LEAF_HIGHER_BIN);
+    console.log("MIDDLE", toString(MIDDLE_BIN));
+    console.log("LEAF HIGHER", toString(LEAF_HIGHER_BIN));
+    testBin(LEAF_HIGHER_BIN);
     description = string.concat(description, " - Case: Existing leaf higher bin");
     printDescription();
   }
 
   function test_NewLevel3HigherBin() public {
-    testTick(LEVEL3_HIGHER_BIN);
+    testBin(LEVEL3_HIGHER_BIN);
     description = string.concat(description, " - Case: New level3 higher bin");
     printDescription();
   }
 
   function test_NewLevel3LowerBin() public {
-    testTick(LEVEL3_LOWER_BIN);
+    testBin(LEVEL3_LOWER_BIN);
     description = string.concat(description, " - Case: New level3 lower bin");
     printDescription();
   }
 
   function test_NewLevel2HigherBin() public {
-    testTick(LEVEL2_HIGHER_BIN);
+    testBin(LEVEL2_HIGHER_BIN);
     description = string.concat(description, " - Case: New level 2 higher bin");
     printDescription();
   }
 
   function test_NewLevel2LowerBin() public {
-    testTick(LEVEL2_LOWER_BIN);
+    testBin(LEVEL2_LOWER_BIN);
     description = string.concat(description, " - Case: New level 2 lower bin");
     printDescription();
   }
 
   function test_NewLevel1HigherBin() public {
-    testTick(LEVEL1_HIGHER_BIN);
+    testBin(LEVEL1_HIGHER_BIN);
     description = string.concat(description, " - Case: New level 1 higher bin");
     printDescription();
   }
 
   function test_NewLevel1LowerBin() public {
-    testTick(LEVEL1_LOWER_BIN);
+    testBin(LEVEL1_LOWER_BIN);
     description = string.concat(description, " - Case: New level 1 lower bin");
     printDescription();
   }
 
   function test_NewRootHigherBin() public {
-    testTick(ROOT_HIGHER_BIN);
+    testBin(ROOT_HIGHER_BIN);
     description = string.concat(description, " - Case: New root higher bin");
     printDescription();
   }
 
   function test_NewRootLowerBin() public {
-    testTick(ROOT_LOWER_BIN);
+    testBin(ROOT_LOWER_BIN);
     description = string.concat(description, " - Case: New root lower bin");
     printDescription();
   }

--- a/test/core/gas/UpdateOfferOtherOfferList.t.sol
+++ b/test/core/gas/UpdateOfferOtherOfferList.t.sol
@@ -5,14 +5,14 @@ pragma solidity ^0.8.18;
 import {SingleGasTestBase, GasTestBase, MIDDLE_BIN} from "./GasTestBase.t.sol";
 import {IMangrove, TestTaker} from "mgv_test/lib/MangroveTest.sol";
 import {TickTreeBoundariesGasTest} from "./TickTreeBoundariesGasTest.t.sol";
-import {OLKey} from "mgv_src/MgvLib.sol";
+import "mgv_src/MgvLib.sol";
 
 contract ExternalUpdateOfferOtherOfferList_WithNoOtherOffersGasTest is SingleGasTestBase {
   function setUp() public virtual override {
     super.setUp();
-    _offerId = mgv.newOfferByTick(olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0);
+    _offerId = mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0);
     vm.prank($(_taker));
-    mgv.marketOrderByTick(olKey, MIDDLE_BIN, 1, true);
+    mgv.marketOrderByTick(olKey, olKey.tick(MIDDLE_BIN), 1, true);
     assertEq(0, mgv.best(olKey));
     description =
       "Worst case scenario if strat updates an offer on a different offer list which has become empty. This can happen in practice if offer list runs out of liquidity";
@@ -20,7 +20,7 @@ contract ExternalUpdateOfferOtherOfferList_WithNoOtherOffersGasTest is SingleGas
 
   function impl(IMangrove mgv, TestTaker, OLKey memory _olKey, uint offerId) internal virtual override {
     _gas();
-    mgv.updateOfferByTick(_olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0, offerId);
+    mgv.updateOfferByTick(_olKey, _olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0, offerId);
     gas_();
   }
 }
@@ -28,15 +28,15 @@ contract ExternalUpdateOfferOtherOfferList_WithNoOtherOffersGasTest is SingleGas
 contract ExternalUpdateOfferOtherOfferList_WithOtherOfferGasTest is TickTreeBoundariesGasTest, GasTestBase {
   function setUp() public virtual override {
     super.setUp();
-    _offerId = mgv.newOfferByTick(olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0);
-    mgv.newOfferByTick(olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0);
+    _offerId = mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0);
+    mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0);
     description =
       "Updating an offer when another offer exists at various tick-distances to the offer's new ratio (initial same ratio)";
   }
 
-  function impl(IMangrove mgv, TestTaker, OLKey memory _olKey, uint offerId, int _tick) internal override {
+  function impl(IMangrove mgv, TestTaker, OLKey memory _olKey, uint offerId, Bin _bin) internal override {
     _gas();
-    mgv.updateOfferByTick(_olKey, _tick, 0.00001 ether, 100_000, 0, offerId);
+    mgv.updateOfferByTick(_olKey, _olKey.tick(_bin), 0.00001 ether, 100_000, 0, offerId);
     gas_();
   }
 }
@@ -48,7 +48,7 @@ contract ExternalUpdateOfferOtherOfferList_WithOtherOfferAndOfferOnSameBinGasTes
     super.setUp();
     this.newOfferOnAllTestRatios();
     description =
-      "Updating an offer when another offer exists at various tick-distances to the new offer ratio but also on the same tick";
+      "Updating an offer when another offer exists at various bin-distances to the new offer ratio but also on the same bin";
   }
 }
 
@@ -59,15 +59,15 @@ contract ExternalUpdateOfferOtherOfferList_WithPriorUpdateOfferAndNoOtherOffersG
 
   function setUp() public virtual override {
     super.setUp();
-    offerId2 = mgv.newOfferByTick(olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0);
+    offerId2 = mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0);
     vm.prank($(_taker));
-    mgv.marketOrderByTick(olKey, MIDDLE_BIN, 1, true);
+    mgv.marketOrderByTick(olKey, olKey.tick(MIDDLE_BIN), 1, true);
     assertEq(0, mgv.best(olKey));
-    description = "Updating a second offer at various tick-distances after updating an offer at MIDDLE_BIN";
+    description = "Updating a second offer at various bin-distances after updating an offer at MIDDLE_BIN";
   }
 
   function impl(IMangrove mgv, TestTaker taker, OLKey memory _olKey, uint offerId) internal override {
-    mgv.updateOfferByTick(_olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0, offerId2);
+    mgv.updateOfferByTick(_olKey, _olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0, offerId2);
     super.impl(mgv, taker, _olKey, offerId);
   }
 }

--- a/test/core/gas/UpdateOfferOtherOfferListDetails.t.sol
+++ b/test/core/gas/UpdateOfferOtherOfferListDetails.t.sol
@@ -10,14 +10,14 @@ import {OLKey} from "mgv_src/MgvLib.sol";
 contract ExternalUpdateOfferOtherOfferList_DeadDeprovisioned is SingleGasTestBase {
   function setUp() public virtual override {
     super.setUp();
-    _offerId = mgv.newOfferByTick(olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0);
+    _offerId = mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0);
     mgv.retractOffer(olKey, _offerId, true);
     description = "Update dead deprovisioned offer";
   }
 
   function impl(IMangrove mgv, TestTaker, OLKey memory _olKey, uint offerId) internal virtual override {
     _gas();
-    mgv.updateOfferByTick(_olKey, LEVEL2_HIGHER_BIN, 0.00001 ether, 100_000, 0, offerId);
+    mgv.updateOfferByTick(_olKey, olKey.tick(LEVEL2_HIGHER_BIN), 0.00001 ether, 100_000, 0, offerId);
     gas_();
   }
 }
@@ -25,14 +25,14 @@ contract ExternalUpdateOfferOtherOfferList_DeadDeprovisioned is SingleGasTestBas
 contract ExternalUpdateOfferOtherOfferList_DeadProvisioned is SingleGasTestBase {
   function setUp() public virtual override {
     super.setUp();
-    _offerId = mgv.newOfferByTick(olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0);
+    _offerId = mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0);
     mgv.retractOffer(olKey, _offerId, false);
     description = "Update dead provisioned offer";
   }
 
   function impl(IMangrove mgv, TestTaker, OLKey memory _olKey, uint offerId) internal virtual override {
     _gas();
-    mgv.updateOfferByTick(_olKey, LEVEL2_HIGHER_BIN, 0.00001 ether, 100_000, 0, offerId);
+    mgv.updateOfferByTick(_olKey, olKey.tick(LEVEL2_HIGHER_BIN), 0.00001 ether, 100_000, 0, offerId);
     gas_();
   }
 }
@@ -40,14 +40,14 @@ contract ExternalUpdateOfferOtherOfferList_DeadProvisioned is SingleGasTestBase 
 contract ExternalUpdateOfferOtherOfferList_Gasreq is GasTestBase {
   function setUp() public virtual override {
     super.setUp();
-    _offerId = mgv.newOfferByTick(olKey, MIDDLE_BIN, 0.00001 ether, 100_000, 0);
+    _offerId = mgv.newOfferByTick(olKey, olKey.tick(MIDDLE_BIN), 0.00001 ether, 100_000, 0);
     description = "Update live offer with different gasreq values.";
   }
 
   function test_live_far_away_same_gasreq() public {
     (IMangrove mgv,, OLKey memory _olKey, uint offerId) = getStored();
     _gas();
-    mgv.updateOfferByTick(_olKey, LEVEL2_HIGHER_BIN, 0.00001 ether, 100_000, 0, offerId);
+    mgv.updateOfferByTick(_olKey, olKey.tick(LEVEL2_HIGHER_BIN), 0.00001 ether, 100_000, 0, offerId);
     gas_();
     description = string.concat(description, " - Case: same gasreq");
     printDescription();
@@ -56,7 +56,7 @@ contract ExternalUpdateOfferOtherOfferList_Gasreq is GasTestBase {
   function test_live_far_away_higher_gasreq() public {
     (IMangrove mgv,, OLKey memory _olKey, uint offerId) = getStored();
     _gas();
-    mgv.updateOfferByTick(_olKey, LEVEL2_HIGHER_BIN, 0.00001 ether, 1_000_000, 0, offerId);
+    mgv.updateOfferByTick(_olKey, olKey.tick(LEVEL2_HIGHER_BIN), 0.00001 ether, 1_000_000, 0, offerId);
     gas_();
     description = string.concat(description, " - Case: higher gasreq");
     printDescription();
@@ -65,7 +65,7 @@ contract ExternalUpdateOfferOtherOfferList_Gasreq is GasTestBase {
   function test_live_far_away_lower_gasreq() public {
     (IMangrove mgv,, OLKey memory _olKey, uint offerId) = getStored();
     _gas();
-    mgv.updateOfferByTick(_olKey, LEVEL2_HIGHER_BIN, 0.00001 ether, 10_000, 0, offerId);
+    mgv.updateOfferByTick(_olKey, olKey.tick(LEVEL2_HIGHER_BIN), 0.00001 ether, 10_000, 0, offerId);
     gas_();
     description = string.concat(description, " - Case: lower gasreq");
     printDescription();

--- a/test/core/ticktree/TickTreeMarketOrder.t.sol
+++ b/test/core/ticktree/TickTreeMarketOrder.t.sol
@@ -256,7 +256,7 @@ contract TickTreeMarketOrderTest is TickTreeTest {
     removeTakenOffers(scenario.lowerBin, lowerOfferIds);
     removeTakenOffers(scenario.middleBin, middleOfferIds);
     removeTakenOffers(scenario.higherBin, higherOfferIds);
-    mgv.marketOrderByTick(olKey, MAX_TICK, fillVolume, true);
+    mgv.marketOrderByTick(olKey, Tick.wrap(MAX_TICK), fillVolume, true);
     assertTrue(lastTakenOfferId == 0 || lastTakenOfferPosthookCalled, "last taken offer posthook not called");
 
     // assertMgvTickTreeIsConsistent();

--- a/test/core/ticktree/TickTreeNewOffer.t.sol
+++ b/test/core/ticktree/TickTreeNewOffer.t.sol
@@ -142,7 +142,7 @@ contract TickTreeNewOfferTest is TickTreeTest {
 
     // 4. Create new offer and add it to tick tree
     Bin insertionBin = scenario.binScenario.bin;
-    Tick tick = insertionBin.toNearestTick(olKey.tickSpacing);
+    Tick tick = insertionBin.tick(olKey.tickSpacing);
     uint gives = getAcceptableGivesForBin(insertionBin, 50_000);
     mkr.newOfferByTick(tick, gives, 50_000, 50);
     tickTree.addOffer(insertionBin, gives, 50_000, 50, $(mkr));

--- a/test/core/ticktree/TickTreeNewOffer.t.sol
+++ b/test/core/ticktree/TickTreeNewOffer.t.sol
@@ -142,7 +142,7 @@ contract TickTreeNewOfferTest is TickTreeTest {
 
     // 4. Create new offer and add it to tick tree
     Bin insertionBin = scenario.binScenario.bin;
-    int tick = TickLib.fromBin(insertionBin, olKey.tickSpacing);
+    Tick tick = BinLib.toNearestTick(insertionBin, olKey.tickSpacing);
     uint gives = getAcceptableGivesForBin(insertionBin, 50_000);
     mkr.newOfferByTick(tick, gives, 50_000, 50);
     tickTree.addOffer(insertionBin, gives, 50_000, 50, $(mkr));

--- a/test/core/ticktree/TickTreeNewOffer.t.sol
+++ b/test/core/ticktree/TickTreeNewOffer.t.sol
@@ -142,7 +142,7 @@ contract TickTreeNewOfferTest is TickTreeTest {
 
     // 4. Create new offer and add it to tick tree
     Bin insertionBin = scenario.binScenario.bin;
-    Tick tick = BinLib.toNearestTick(insertionBin, olKey.tickSpacing);
+    Tick tick = insertionBin.toNearestTick(olKey.tickSpacing);
     uint gives = getAcceptableGivesForBin(insertionBin, 50_000);
     mkr.newOfferByTick(tick, gives, 50_000, 50);
     tickTree.addOffer(insertionBin, gives, 50_000, 50, $(mkr));

--- a/test/core/ticktree/TickTreeTest.t.sol
+++ b/test/core/ticktree/TickTreeTest.t.sol
@@ -310,7 +310,7 @@ abstract contract TickTreeTest is MangroveTest {
   }
 
   function add_n_offers_to_bin(Bin bin, uint n, bool offersFail) internal returns (uint[] memory offerIds, uint gives) {
-    Tick tick = bin.toNearestTick(olKey.tickSpacing);
+    Tick tick = bin.tick(olKey.tickSpacing);
     uint gasreq = 10_000_000;
     gives = getAcceptableGivesForBin(bin, gasreq);
     offerIds = new uint[](n);

--- a/test/core/ticktree/TickTreeTest.t.sol
+++ b/test/core/ticktree/TickTreeTest.t.sol
@@ -310,7 +310,7 @@ abstract contract TickTreeTest is MangroveTest {
   }
 
   function add_n_offers_to_bin(Bin bin, uint n, bool offersFail) internal returns (uint[] memory offerIds, uint gives) {
-    int tick = TickLib.fromBin(bin, olKey.tickSpacing);
+    Tick tick = BinLib.toNearestTick(bin, olKey.tickSpacing);
     uint gasreq = 10_000_000;
     gives = getAcceptableGivesForBin(bin, gasreq);
     offerIds = new uint[](n);

--- a/test/core/ticktree/TickTreeTest.t.sol
+++ b/test/core/ticktree/TickTreeTest.t.sol
@@ -310,7 +310,7 @@ abstract contract TickTreeTest is MangroveTest {
   }
 
   function add_n_offers_to_bin(Bin bin, uint n, bool offersFail) internal returns (uint[] memory offerIds, uint gives) {
-    Tick tick = BinLib.toNearestTick(bin, olKey.tickSpacing);
+    Tick tick = bin.toNearestTick(olKey.tickSpacing);
     uint gasreq = 10_000_000;
     gives = getAcceptableGivesForBin(bin, gasreq);
     offerIds = new uint[](n);

--- a/test/core/ticktree/TickTreeUpdateOffer.t.sol
+++ b/test/core/ticktree/TickTreeUpdateOffer.t.sol
@@ -284,7 +284,7 @@ contract TickTreeUpdateOfferTest is TickTreeTest {
     Bin newBin = scenario.newBin;
     uint newGives = getAcceptableGivesForBin(newBin, offerDetail.gasreq());
     mkr.updateOfferByTick(
-      BinLib.toNearestTick(newBin, olKey.tickSpacing), newGives, offerDetail.gasreq(), offerDetail.gasprice(), offerId
+      newBin.toNearestTick(olKey.tickSpacing), newGives, offerDetail.gasreq(), offerDetail.gasprice(), offerId
     );
     tickTree.updateOffer(offerId, newBin, newGives, offerDetail.gasreq(), offerDetail.gasprice(), $(mkr));
     if (printToConsole) {

--- a/test/core/ticktree/TickTreeUpdateOffer.t.sol
+++ b/test/core/ticktree/TickTreeUpdateOffer.t.sol
@@ -284,7 +284,7 @@ contract TickTreeUpdateOfferTest is TickTreeTest {
     Bin newBin = scenario.newBin;
     uint newGives = getAcceptableGivesForBin(newBin, offerDetail.gasreq());
     mkr.updateOfferByTick(
-      TickLib.fromBin(newBin, olKey.tickSpacing), newGives, offerDetail.gasreq(), offerDetail.gasprice(), offerId
+      BinLib.toNearestTick(newBin, olKey.tickSpacing), newGives, offerDetail.gasreq(), offerDetail.gasprice(), offerId
     );
     tickTree.updateOffer(offerId, newBin, newGives, offerDetail.gasreq(), offerDetail.gasprice(), $(mkr));
     if (printToConsole) {

--- a/test/core/ticktree/TickTreeUpdateOffer.t.sol
+++ b/test/core/ticktree/TickTreeUpdateOffer.t.sol
@@ -284,7 +284,7 @@ contract TickTreeUpdateOfferTest is TickTreeTest {
     Bin newBin = scenario.newBin;
     uint newGives = getAcceptableGivesForBin(newBin, offerDetail.gasreq());
     mkr.updateOfferByTick(
-      newBin.toNearestTick(olKey.tickSpacing), newGives, offerDetail.gasreq(), offerDetail.gasprice(), offerId
+      newBin.tick(olKey.tickSpacing), newGives, offerDetail.gasreq(), offerDetail.gasprice(), offerId
     );
     tickTree.updateOffer(offerId, newBin, newGives, offerDetail.gasreq(), offerDetail.gasprice(), $(mkr));
     if (printToConsole) {

--- a/test/lib/MangroveTest.sol
+++ b/test/lib/MangroveTest.sol
@@ -20,6 +20,7 @@ import {IMangrove} from "mgv_src/IMangrove.sol";
 import {
   IERC20,
   MgvLib,
+  Tick,
   HasMgvEvents,
   IMaker,
   ITaker,
@@ -177,7 +178,7 @@ contract MangroveTest is Test2, HasMgvEvents {
           string.concat(toFixed(ofr.wants(), req_tk.decimals()), " ", req_tk.symbol()),
           "  /  ",
           string.concat(toFixed(ofr.gives, ofr_tk.decimals()), " ", ofr_tk.symbol()),
-          string.concat(" (", vm.toString(ofr.tick), ") "),
+          string.concat(" (", toString(ofr.tick), ") "),
           vm.toString(detail.maker)
         )
       );
@@ -285,7 +286,7 @@ contract MangroveTest is Test2, HasMgvEvents {
     return tt;
   }
 
-  function mockCompleteFillBuyOrder(uint takerWants, int tick) public view returns (MgvLib.SingleOrder memory sor) {
+  function mockCompleteFillBuyOrder(uint takerWants, Tick tick) public view returns (MgvLib.SingleOrder memory sor) {
     sor.olKey = olKey;
     // complete fill (prev and next are bogus)
     sor.offer = MgvStructs.Offer.pack({__prev: 0, __next: 0, __tick: tick, __gives: takerWants});
@@ -295,7 +296,7 @@ contract MangroveTest is Test2, HasMgvEvents {
 
   function mockPartialFillBuyOrder(
     uint takerWants,
-    int tick,
+    Tick tick,
     uint partialFill,
     OLKey memory _olBaseQuote,
     bytes32 makerData
@@ -308,7 +309,7 @@ contract MangroveTest is Test2, HasMgvEvents {
     result.mgvData = "mgv/tradeSuccess";
   }
 
-  function mockCompleteFillSellOrder(uint takerWants, int tick) public view returns (MgvLib.SingleOrder memory sor) {
+  function mockCompleteFillSellOrder(uint takerWants, Tick tick) public view returns (MgvLib.SingleOrder memory sor) {
     sor.olKey = lo;
     // complete fill (prev and next are bogus)
     sor.offer = MgvStructs.Offer.pack({__prev: 0, __next: 0, __tick: tick, __gives: takerWants});
@@ -318,7 +319,7 @@ contract MangroveTest is Test2, HasMgvEvents {
 
   function mockPartialFillSellOrder(
     uint takerWants,
-    int tick,
+    Tick tick,
     uint partialFill,
     OLKey memory _olBaseQuote,
     bytes32 makerData
@@ -420,7 +421,7 @@ contract MangroveTest is Test2, HasMgvEvents {
   }
 
   /// creates `fold` offers in the (outbound, inbound) market with the same `tick`, `gives` and `gasreq` and with `caller` as maker
-  function densify(OLKey memory _ol, int tick, uint gives, uint gasreq, uint fold, address caller) internal {
+  function densify(OLKey memory _ol, Tick tick, uint gives, uint gasreq, uint fold, address caller) internal {
     if (gives == 0) {
       return;
     }
@@ -440,6 +441,22 @@ contract MangroveTest is Test2, HasMgvEvents {
       densify(_ol, offer.tick(), offer.gives(), detail.gasreq(), fold, caller);
       length--;
       fromId = reader.nextOfferId(_ol, offer);
+    }
+  }
+
+  function assertEq(Tick a, Tick b) internal {
+    if (!a.eq(b)) {
+      emit log("Error: a == b not satisfied [TIck]");
+      emit log_named_string("      Left", toString(a));
+      emit log_named_string("     Right", toString(b));
+      fail();
+    }
+  }
+
+  function assertEq(Tick a, Tick b, string memory err) internal {
+    if (!a.eq(b)) {
+      emit log_named_string("Error", err);
+      assertEq(a, b);
     }
   }
 

--- a/test/lib/MangroveTest.sol
+++ b/test/lib/MangroveTest.sol
@@ -304,7 +304,7 @@ contract MangroveTest is Test2, HasMgvEvents {
     sor.olKey = _olBaseQuote;
     sor.offer = MgvStructs.Offer.pack({__prev: 0, __next: 0, __tick: tick, __gives: takerWants * partialFill});
     sor.takerWants = takerWants;
-    sor.takerGives = TickLib.inboundFromOutboundUp(tick, takerWants);
+    sor.takerGives = tick.inboundFromOutboundUp(takerWants);
     result.makerData = makerData;
     result.mgvData = "mgv/tradeSuccess";
   }
@@ -327,7 +327,7 @@ contract MangroveTest is Test2, HasMgvEvents {
     sor.olKey = _olBaseQuote.flipped();
     sor.offer = MgvStructs.Offer.pack({__prev: 0, __next: 0, __tick: tick, __gives: takerWants * partialFill});
     sor.takerWants = takerWants;
-    sor.takerGives = TickLib.inboundFromOutboundUp(tick, takerWants);
+    sor.takerGives = tick.inboundFromOutboundUp(takerWants);
     result.makerData = makerData;
     result.mgvData = "mgv/tradeSuccess";
   }

--- a/test/lib/TestTickTree.sol
+++ b/test/lib/TestTickTree.sol
@@ -545,7 +545,7 @@ contract TestTickTree is MangroveTest {
     // console.log("leaf after: %s", toString(leafs[bin.leafIndex()]));
 
     // Create offer
-    int tick = TickLib.fromBin(bin, olKey.tickSpacing);
+    Tick tick = BinLib.toNearestTick(bin, olKey.tickSpacing);
     offers[offerId].offer = MgvStructs.Offer.pack({__prev: lastId, __next: 0, __tick: tick, __gives: gives});
     offers[offerId].detail = MgvStructs.OfferDetail.pack({
       __maker: maker,

--- a/test/lib/TestTickTree.sol
+++ b/test/lib/TestTickTree.sol
@@ -545,7 +545,7 @@ contract TestTickTree is MangroveTest {
     // console.log("leaf after: %s", toString(leafs[bin.leafIndex()]));
 
     // Create offer
-    Tick tick = bin.toNearestTick(olKey.tickSpacing);
+    Tick tick = bin.tick(olKey.tickSpacing);
     offers[offerId].offer = MgvStructs.Offer.pack({__prev: lastId, __next: 0, __tick: tick, __gives: gives});
     offers[offerId].detail = MgvStructs.OfferDetail.pack({
       __maker: maker,

--- a/test/lib/TestTickTree.sol
+++ b/test/lib/TestTickTree.sol
@@ -545,7 +545,7 @@ contract TestTickTree is MangroveTest {
     // console.log("leaf after: %s", toString(leafs[bin.leafIndex()]));
 
     // Create offer
-    Tick tick = BinLib.toNearestTick(bin, olKey.tickSpacing);
+    Tick tick = bin.toNearestTick(olKey.tickSpacing);
     offers[offerId].offer = MgvStructs.Offer.pack({__prev: lastId, __next: 0, __tick: tick, __gives: gives});
     offers[offerId].detail = MgvStructs.OfferDetail.pack({
       __maker: maker,

--- a/test/lib/agents/TestMaker.sol
+++ b/test/lib/agents/TestMaker.sol
@@ -290,29 +290,29 @@ contract SimpleTestMaker is TrivialTestMaker {
     return offerId;
   }
 
-  function newOfferByTick(int tick, uint gives, uint gasreq) public returns (uint) {
+  function newOfferByTick(Tick tick, uint gives, uint gasreq) public returns (uint) {
     return newOfferByTick(tick, gives, gasreq, 0);
   }
 
-  function newFailingOfferByTick(int tick, uint gives, uint gasreq) public returns (uint) {
+  function newFailingOfferByTick(Tick tick, uint gives, uint gasreq) public returns (uint) {
     return newOfferByTickWithFunding(
       olKey, tick, gives, gasreq, 0, 0, OfferData({shouldRevert: true, executeData: "someData"})
     );
   }
 
-  function newOfferByTick(int tick, uint gives, uint gasreq, uint gasprice) public returns (uint) {
+  function newOfferByTick(Tick tick, uint gives, uint gasreq, uint gasprice) public returns (uint) {
     return newOfferByTick(olKey, tick, gives, gasreq, gasprice);
   }
 
-  function newOfferByTick(OLKey memory _olKey, int tick, uint gives, uint gasreq) public returns (uint) {
+  function newOfferByTick(OLKey memory _olKey, Tick tick, uint gives, uint gasreq) public returns (uint) {
     return newOfferByTick(_olKey, tick, gives, gasreq, 0);
   }
 
-  function newOfferByTick(OLKey memory _olKey, int tick, uint gives, uint gasreq, uint gasprice) public returns (uint) {
+  function newOfferByTick(OLKey memory _olKey, Tick tick, uint gives, uint gasreq, uint gasprice) public returns (uint) {
     return newOfferByTickWithFunding(_olKey, tick, gives, gasreq, gasprice, 0);
   }
 
-  function newOfferByTickWithFunding(OLKey memory _ol, int tick, uint gives, uint gasreq, uint gasprice, uint amount)
+  function newOfferByTickWithFunding(OLKey memory _ol, Tick tick, uint gives, uint gasreq, uint gasprice, uint amount)
     public
     returns (uint)
   {
@@ -322,7 +322,7 @@ contract SimpleTestMaker is TrivialTestMaker {
 
   function newOfferByTickWithFunding(
     OLKey memory _ol,
-    int tick,
+    Tick tick,
     uint gives,
     uint gasreq,
     uint gasprice,
@@ -334,18 +334,18 @@ contract SimpleTestMaker is TrivialTestMaker {
     return offerId;
   }
 
-  function updateOfferByTick(int tick, uint gives, uint gasreq, uint offerId) public {
+  function updateOfferByTick(Tick tick, uint gives, uint gasreq, uint offerId) public {
     updateOfferByTick(tick, gives, gasreq, 0, offerId);
   }
 
-  function updateOfferByTick(int tick, uint gives, uint gasreq, uint gasprice, uint offerId) public {
+  function updateOfferByTick(Tick tick, uint gives, uint gasreq, uint gasprice, uint offerId) public {
     OfferData memory offerData;
     updateOfferByTickWithFunding(olKey, tick, gives, gasreq, gasprice, offerId, 0, offerData);
   }
 
   function updateOfferByTickWithFunding(
     OLKey memory _olKey,
-    int tick,
+    Tick tick,
     uint gives,
     uint gasreq,
     uint gasprice,
@@ -437,20 +437,20 @@ contract SimpleTestMaker is TrivialTestMaker {
   }
 
   function clean(uint offerId, uint takerWants) public returns (bool success) {
-    int tick = mgv.offers(olKey, offerId).tick();
+    Tick tick = mgv.offers(olKey, offerId).tick();
     return clean(olKey, offerId, tick, takerWants);
   }
 
-  function clean(uint offerId, int tick, uint takerWants) public returns (bool success) {
+  function clean(uint offerId, Tick tick, uint takerWants) public returns (bool success) {
     return clean(olKey, offerId, tick, takerWants);
   }
 
   function clean(OLKey memory _olKey, uint offerId, uint takerWants) public returns (bool success) {
-    int tick = mgv.offers(olKey, offerId).tick();
+    Tick tick = mgv.offers(olKey, offerId).tick();
     return clean(_olKey, offerId, tick, takerWants);
   }
 
-  function clean(OLKey memory _olKey, uint offerId, int tick, uint takerWants) public returns (bool success) {
+  function clean(OLKey memory _olKey, uint offerId, Tick tick, uint takerWants) public returns (bool success) {
     MgvLib.CleanTarget[] memory targets = new MgvLib.CleanTarget[](1);
     targets[0] = MgvLib.CleanTarget(offerId, tick, type(uint48).max, takerWants);
     (uint successes,) = mgv.cleanByImpersonation(_olKey, targets, address(this));

--- a/test/lib/agents/TestTaker.sol
+++ b/test/lib/agents/TestTaker.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.10;
 
 import {IMangrove} from "mgv_src/IMangrove.sol";
-import {IERC20, ITaker, MgvLib, OLKey} from "mgv_src/MgvLib.sol";
+import "mgv_src/MgvLib.sol";
 import {Script2} from "mgv_lib/Script2.sol";
 import {TransferLib} from "mgv_lib/TransferLib.sol";
 
@@ -55,15 +55,15 @@ contract TestTaker is ITaker, Script2 {
     public
     returns (uint bounty)
   {
-    int tick = _mgv.offers(_olKey, offerId).tick();
+    Tick tick = _mgv.offers(_olKey, offerId).tick();
     return cleanByTickWithInfo(_mgv, _olKey, offerId, tick, takerWants, gasreq);
   }
 
-  function cleanByTick(uint offerId, int tick, uint takerWants, uint gasreq) public returns (bool success) {
+  function cleanByTick(uint offerId, Tick tick, uint takerWants, uint gasreq) public returns (bool success) {
     return this.cleanByTick(mgv, olKey, offerId, tick, takerWants, gasreq);
   }
 
-  function cleanByTick(IMangrove _mgv, OLKey memory _olKey, uint offerId, int tick, uint takerWants, uint gasreq)
+  function cleanByTick(IMangrove _mgv, OLKey memory _olKey, uint offerId, Tick tick, uint takerWants, uint gasreq)
     public
     returns (bool success)
   {
@@ -75,7 +75,7 @@ contract TestTaker is ITaker, Script2 {
     IMangrove _mgv,
     OLKey memory _olKey,
     uint offerId,
-    int tick,
+    Tick tick,
     uint takerWants,
     uint gasreq
   ) public returns (uint bounty) {

--- a/test/preprocessed/MgvOfferTest.post.sol
+++ b/test/preprocessed/MgvOfferTest.post.sol
@@ -18,11 +18,11 @@ contract MgvOfferTest is Test2 {
     return u << (256-to) >> (256-to);
   }
 
-  function test_pack(uint prev, uint next, int tick, uint gives) public {
+  function test_pack(uint prev, uint next, Tick tick, uint gives) public {
     MgvStructs.OfferPacked packed = MgvStructs.Offer.pack(prev, next, tick, gives);
     assertEq(packed.prev(),cast(prev,32),"bad prev");
     assertEq(packed.next(),cast(next,32),"bad next");
-    assertEq(packed.tick(),cast(tick,24),"bad tick");
+    assertEq(Tick.unwrap(packed.tick()),cast(Tick.unwrap(tick),24),"bad tick");
     assertEq(packed.gives(),cast(gives,96),"bad gives");
   }
 
@@ -41,7 +41,7 @@ contract MgvOfferTest is Test2 {
       assertEq(modified.prev(),cast(prev,32),"modified: bad prev");
 
       assertEq(modified.next(),packed.next(),"modified: bad next");
-      assertEq(modified.tick(),packed.tick(),"modified: bad tick");
+      assertEq(Tick.unwrap(modified.tick()),Tick.unwrap(packed.tick()),"modified: bad tick");
       assertEq(modified.gives(),packed.gives(),"modified: bad gives");
     }
   function test_set_next(MgvStructs.OfferPacked packed,uint next) public {
@@ -53,16 +53,16 @@ contract MgvOfferTest is Test2 {
       assertEq(modified.next(),cast(next,32),"modified: bad next");
 
       assertEq(modified.prev(),packed.prev(),"modified: bad prev");
-      assertEq(modified.tick(),packed.tick(),"modified: bad tick");
+      assertEq(Tick.unwrap(modified.tick()),Tick.unwrap(packed.tick()),"modified: bad tick");
       assertEq(modified.gives(),packed.gives(),"modified: bad gives");
     }
-  function test_set_tick(MgvStructs.OfferPacked packed,int tick) public {
+  function test_set_tick(MgvStructs.OfferPacked packed,Tick tick) public {
       MgvStructs.OfferPacked original = packed.tick(packed.tick());
-      assertEq(original.tick(),packed.tick(), "original: bad tick");
+      assertEq(Tick.unwrap(original.tick()),Tick.unwrap(packed.tick()), "original: bad tick");
 
       MgvStructs.OfferPacked modified = packed.tick(tick);
 
-      assertEq(modified.tick(),cast(tick,24),"modified: bad tick");
+      assertEq(Tick.unwrap(modified.tick()),cast(Tick.unwrap(tick),24),"modified: bad tick");
 
       assertEq(modified.prev(),packed.prev(),"modified: bad prev");
       assertEq(modified.next(),packed.next(),"modified: bad next");
@@ -78,15 +78,15 @@ contract MgvOfferTest is Test2 {
 
       assertEq(modified.prev(),packed.prev(),"modified: bad prev");
       assertEq(modified.next(),packed.next(),"modified: bad next");
-      assertEq(modified.tick(),packed.tick(),"modified: bad tick");
+      assertEq(Tick.unwrap(modified.tick()),Tick.unwrap(packed.tick()),"modified: bad tick");
     }
 
   function test_unpack(MgvStructs.OfferPacked packed) public {
-    (uint prev, uint next, int tick, uint gives) = packed.unpack();
+    (uint prev, uint next, Tick tick, uint gives) = packed.unpack();
 
     assertEq(packed.prev(),prev,"bad prev");
     assertEq(packed.next(),next,"bad next");
-    assertEq(packed.tick(),tick,"bad tick");
+    assertEq(Tick.unwrap(packed.tick()),Tick.unwrap(tick),"bad tick");
     assertEq(packed.gives(),gives,"bad gives");
   }
 
@@ -101,7 +101,7 @@ contract MgvOfferTest is Test2 {
     MgvStructs.OfferUnpacked memory unpacked = packed.to_struct();
     assertEq(unpacked.prev,packed.prev(),"bad prev");
     assertEq(unpacked.next,packed.next(),"bad next");
-    assertEq(unpacked.tick,packed.tick(),"bad tick");
+    assertEq(Tick.unwrap(unpacked.tick),Tick.unwrap(packed.tick()),"bad tick");
     assertEq(unpacked.gives,packed.gives(),"bad gives");
   }
 
@@ -114,7 +114,7 @@ contract MgvOfferTest is Test2 {
     packed2 = packed2.gives(unpacked.gives);
     assertEq(packed.prev(),packed2.prev(),"bad prev");
     assertEq(packed.next(),packed2.next(),"bad next");
-    assertEq(packed.tick(),packed2.tick(),"bad tick");
+    assertEq(Tick.unwrap(packed.tick()),Tick.unwrap(packed2.tick()),"bad tick");
     assertEq(packed.gives(),packed2.gives(),"bad gives");
   }
 }


### PR DESCRIPTION
- TickTree tests use bin instead of tick
- Make a Tick type
- Use library dot syntax (`firstArg.fn(...)`) where possible
- External APIs expose `Tick` arguments instead of `int` arguments
- Utility `olKey.tick(bin)` and `olKey.bin(tick)` to make tests more readable