### PR TITLE
21 bit tick + constants tests

### DIFF
--- a/lib/BinLib.sol
+++ b/lib/BinLib.sol
@@ -278,7 +278,7 @@ library BinLib {
   }
 
   // see note posIn*
-  // note with int20 bin we only use 2 bits in root
+  // note with int21 bin we only use 2 bits in root
   //   root single node
   // <--------------------->
   //  1                  0

--- a/lib/BinLib.sol
+++ b/lib/BinLib.sol
@@ -224,7 +224,7 @@ library BinLib {
     }
   }
 
-  // ok because 2^BIN_BITS%BINS_PER_LEAF=0
+  // ok because 2^TICK_BITS%BINS_PER_LEAF=0
   // note "posIn*"
   // could instead write uint(bin) / a % b
   // but it's less explicit why it works:
@@ -278,7 +278,7 @@ library BinLib {
   }
 
   // see note posIn*
-  // note with int24 bin we only use 2 bits in root
+  // note with int20 bin we only use 2 bits in root
   //   root single node
   // <--------------------->
   //  1                  0

--- a/lib/Constants.sol
+++ b/lib/Constants.sol
@@ -12,8 +12,7 @@ int constant MIN_BIN = -1048576;
 int constant MAX_BIN = -MIN_BIN-1;
 
 // sizes must match field sizes in structs.ts where relevant
-// FIXME add tests for ^
-uint constant BIN_BITS = 24;
+uint constant TICK_BITS = 21;
 uint constant OFFER_BITS = 32;
 uint constant MAX_FIELD_SIZE = 64; // Constraint given by BitLib.ctz64
 

--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -105,7 +105,7 @@ const struct_defs = {
       id_field("prev"),
       /* * `next` points to the immediately worse offer. The worst offer's `next` is 0. _32 bits wide_. */
       id_field("next"),
-      {name:"tick",bits:24,type:"Tick",underlyingType: "int"},
+      {name:"tick",bits:21,type:"Tick",underlyingType: "int"},
       /* * `gives` is the amount of `outbound_tkn` the offer will give if successfully executed.
       _96 bits wide_, so assuming the usual 18 decimals, amounts can only go up to
       10 billions. */

--- a/src/preprocessed/MgvOffer.post.sol
+++ b/src/preprocessed/MgvOffer.post.sol
@@ -85,7 +85,7 @@ library OfferUnpackedExtra {
 // number of bits in each field
 uint constant prev_bits  = 32;
 uint constant next_bits  = 32;
-uint constant tick_bits  = 24;
+uint constant tick_bits  = 21;
 uint constant gives_bits = 96;
 
 // number of bits before each field
@@ -115,7 +115,7 @@ uint constant gives_cast_mask = ~(ONES << gives_bits);
 // size-related error message
 string constant prev_size_error  = "mgv/config/prev/32bits";
 string constant next_size_error  = "mgv/config/next/32bits";
-string constant tick_size_error  = "mgv/config/tick/24bits";
+string constant tick_size_error  = "mgv/config/tick/21bits";
 string constant gives_size_error = "mgv/config/gives/96bits";
 
 library Library {

--- a/test/core/Constant.t.sol
+++ b/test/core/Constant.t.sol
@@ -5,6 +5,8 @@ pragma solidity ^0.8.10;
 import "mgv_test/lib/MangroveTest.sol";
 import "mgv_src/MgvLib.sol";
 import "mgv_lib/TickConversionLib.sol";
+import {tick_bits} from "mgv_src/preprocessed/MgvOffer.post.sol";
+import {last_bits} from "mgv_src/preprocessed/MgvLocal.post.sol";
 
 // In these tests, the testing contract is the market maker.
 contract ConstantsTest is MangroveTest {
@@ -41,5 +43,15 @@ contract ConstantsTest is MangroveTest {
   // checks that there is no overflow
   function test_maxSafeVolumeIsSafeLowLevel() public {
     assertGt(MAX_SAFE_VOLUME * ((1 << MANTISSA_BITS) - 1), 0);
+  }
+
+  // make sure TICK_BITS in Constants.sol matches the tick bits used in offer struct
+  function test_tick_bits() public {
+    assertEq(TICK_BITS, tick_bits);
+  }
+
+  // make sure OFFER_BITS in Constants.sol matches the id fields used in structs
+  function test_offer_bits() public {
+    assertEq(OFFER_BITS, last_bits);
   }
 }

--- a/test/core/Leaf.t.sol
+++ b/test/core/Leaf.t.sol
@@ -285,7 +285,6 @@ contract TickAndBinTest is MangroveTest {
     showTickApprox(1 ether, 1 ether);
   }
 
-  // int constant min_tick_abs = int(2**(TICK_BITS-1));
   function test_leafIndex_auto(int bin) public {
     bin = bound(bin, MIN_BIN, MAX_BIN);
     int tn = NUM_BINS / 2 + bin; // normalize to positive

--- a/test/core/Leaf.t.sol
+++ b/test/core/Leaf.t.sol
@@ -285,7 +285,7 @@ contract TickAndBinTest is MangroveTest {
     showTickApprox(1 ether, 1 ether);
   }
 
-  // int constant min_tick_abs = int(2**(BIN_BITS-1));
+  // int constant min_tick_abs = int(2**(TICK_BITS-1));
   function test_leafIndex_auto(int bin) public {
     bin = bound(bin, MIN_BIN, MAX_BIN);
     int tn = NUM_BINS / 2 + bin; // normalize to positive

--- a/test/preprocessed/MgvOfferTest.post.sol
+++ b/test/preprocessed/MgvOfferTest.post.sol
@@ -22,7 +22,7 @@ contract MgvOfferTest is Test2 {
     MgvStructs.OfferPacked packed = MgvStructs.Offer.pack(prev, next, tick, gives);
     assertEq(packed.prev(),cast(prev,32),"bad prev");
     assertEq(packed.next(),cast(next,32),"bad next");
-    assertEq(Tick.unwrap(packed.tick()),cast(Tick.unwrap(tick),24),"bad tick");
+    assertEq(Tick.unwrap(packed.tick()),cast(Tick.unwrap(tick),21),"bad tick");
     assertEq(packed.gives(),cast(gives,96),"bad gives");
   }
 
@@ -62,7 +62,7 @@ contract MgvOfferTest is Test2 {
 
       MgvStructs.OfferPacked modified = packed.tick(tick);
 
-      assertEq(Tick.unwrap(modified.tick()),cast(Tick.unwrap(tick),24),"modified: bad tick");
+      assertEq(Tick.unwrap(modified.tick()),cast(Tick.unwrap(tick),21),"modified: bad tick");
 
       assertEq(modified.prev(),packed.prev(),"modified: bad prev");
       assertEq(modified.next(),packed.next(),"modified: bad next");


### PR DESCRIPTION
Depends on #572.

- Only use necessary space for tick
- Add tests to check that constants in `Constants.sol` match the sizes used in `structs.ts`.