### PR TITLE
remove test made false by asm optim

### DIFF
--- a/test/core/DynamicTicks.t.sol
+++ b/test/core/DynamicTicks.t.sol
@@ -145,17 +145,6 @@ contract DynamicBinsTest is MangroveTest {
     assertEq(mgv.root(olKey).firstOnePosition(), insertionBin.posInRoot(), "wrong pos in root");
   }
 
-  // creating offer at zero tickSpacing is impossible
-  function test_noOfferAtZeroTickSpacing(int24 tick, uint96 gives) public {
-    vm.assume(gives > 0);
-    tick = boundTick(tick);
-    olKey.tickSpacing = 0;
-    mgv.activate(olKey, 0, 0, 0);
-
-    vm.expectRevert(stdError.divisionError);
-    mgv.newOfferByTick(olKey, Tick.wrap(tick), gives, 100_00, 30);
-  }
-
   function test_id_is_correct(OLKey memory olKey) public {
     assertEq(olKey.hash(), keccak256(abi.encode(olKey)), "id() is hashing incorrect data");
   }


### PR DESCRIPTION
#572 introduce an assembly optimization that removes an implicit solidity check for `tickSpacing==0`. The test `test_noOfferAtZeroTickSpacing` should have been removed.

It is now possible to create offers with a `tickSpacing` of `0`, but governance is expected to never activate such an offerlist.