### PR TITLE
Feat/better offer volumes

### DIFF
--- a/lib/Constants.sol
+++ b/lib/Constants.sol
@@ -54,8 +54,8 @@ uint constant MAX_SAFE_GIVES = 33645117837968510856504196905370;
 // Without optimizer enabled it fails above 79. With optimizer and 200 runs it fails above 80. Set default a bit lower to be safe.
 uint constant INITIAL_MAX_RECURSION_DEPTH = 75;
 uint constant INITIAL_MAX_GASREQ_FOR_FAILING_OFFERS_MULTIPLIER = 3;
-// Chosen so that ratio is easy to compare to MAX_RATIO_MANTISSA << RATIO_FROM_VOLUMES_SHIFT
-uint constant RATIO_FROM_VOLUMES_SHIFT = 256-MANTISSA_BITS;
+uint constant MAX_SAFE_VOLUME = 340282366920938463463374607431768211455;
+uint constant MAX_SAFE_VOLUME_BITS = 128;
 
 // Price math limits the allowed ticks to a subset of the full range
 int constant MIN_BIN_ALLOWED = -1048575;

--- a/lib/Constants.sol
+++ b/lib/Constants.sol
@@ -48,11 +48,14 @@ uint constant MAX_RATIO_MANTISSA = 344157181422158190903584850125349735412557414
 int constant MAX_RATIO_EXP = 0;
 uint constant MANTISSA_BITS = 152;
 uint constant MANTISSA_BITS_MINUS_ONE = 151;
-// Maximum volume that can be multiplied by a ratio mantissa
-uint constant MAX_SAFE_VOLUME = 20282409603651670423947251286015;
+// Maximum volume that can be multiplied by a max ratio mantissa without overflow (MAX_SAFE_GIVES * MAX_RATIO <= type(uint).max)
+// Higher gives value can still work, at lower prices
+uint constant MAX_SAFE_GIVES = 33645117837968510856504196905370;
 // Without optimizer enabled it fails above 79. With optimizer and 200 runs it fails above 80. Set default a bit lower to be safe.
 uint constant INITIAL_MAX_RECURSION_DEPTH = 75;
 uint constant INITIAL_MAX_GASREQ_FOR_FAILING_OFFERS_MULTIPLIER = 3;
+// Chosen so that ratio is easy to compare to MAX_RATIO_MANTISSA << RATIO_FROM_VOLUMES_SHIFT
+uint constant RATIO_FROM_VOLUMES_SHIFT = 256-MANTISSA_BITS;
 
 // Price math limits the allowed ticks to a subset of the full range
 int constant MIN_BIN_ALLOWED = -1048575;

--- a/lib/FullMath.sol
+++ b/lib/FullMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Credit to Uniswap Labs under MIT license 
+// For mulDiv[roundingUp], credit to Uniswap Labs under MIT license 
 // https://github.com/Uniswap/v3-core/blob/d8b1c635c275d2a9450bd6a78f3fa2484fef73eb/contracts/libraries/FullMath.sol
 
 pragma solidity ^0.8.17;

--- a/lib/FullMath.sol
+++ b/lib/FullMath.sol
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: MIT
+// Credit to Uniswap Labs under MIT license 
+// https://github.com/Uniswap/v3-core/blob/d8b1c635c275d2a9450bd6a78f3fa2484fef73eb/contracts/libraries/FullMath.sol
+
+pragma solidity ^0.8.17;
+
+/// @title Contains 512-bit math functions
+/// @notice Facilitates multiplication and division that can have overflow of an intermediate value without any loss of precision
+/// @dev Handles "phantom overflow" i.e., allows multiplication and division where an intermediate value overflows 256 bits
+library FullMath {
+    /// @notice Calculates floor(a×b÷denominator) with full precision. Throws if result overflows a uint256 or denominator == 0
+    /// @param a The multiplicand
+    /// @param b The multiplier
+    /// @param denominator The divisor
+    /// @return result The 256-bit result
+    /// @dev Credit to Remco Bloemen under MIT license https://xn--2-umb.com/21/muldiv
+    function mulDiv(
+        uint256 a,
+        uint256 b,
+        uint256 denominator
+    ) internal pure returns (uint256 result) {
+      unchecked {
+        // 512-bit multiply [prod1 prod0] = a * b
+        // Compute the product mod 2**256 and mod 2**256 - 1
+        // then use the Chinese Remainder Theorem to reconstruct
+        // the 512 bit result. The result is stored in two 256
+        // variables such that product = prod1 * 2**256 + prod0
+        uint256 prod0; // Least significant 256 bits of the product
+        uint256 prod1; // Most significant 256 bits of the product
+        assembly {
+            let mm := mulmod(a, b, not(0))
+            prod0 := mul(a, b)
+            prod1 := sub(sub(mm, prod0), lt(mm, prod0))
+        }
+
+        // Handle non-overflow cases, 256 by 256 division
+        if (prod1 == 0) {
+            require(denominator > 0,"mgv/mulDiv/divBy0");
+            assembly {
+                result := div(prod0, denominator)
+            }
+            return result;
+        }
+
+        // Make sure the result is less than 2**256.
+        // Also prevents denominator == 0
+        require(denominator > prod1,"mgv/mulDiv/overflow");
+
+        ///////////////////////////////////////////////
+        // 512 by 256 division.
+        ///////////////////////////////////////////////
+
+        // Make division exact by subtracting the remainder from [prod1 prod0]
+        // Compute remainder using mulmod
+        uint256 remainder;
+        assembly {
+            remainder := mulmod(a, b, denominator)
+        }
+        // Subtract 256 bit number from 512 bit number
+        assembly {
+            prod1 := sub(prod1, gt(remainder, prod0))
+            prod0 := sub(prod0, remainder)
+        }
+
+        // Factor powers of two out of denominator
+        // Compute largest power of two divisor of denominator.
+        // Always >= 1.
+        uint256 twos = (0-denominator) & denominator;
+        // Divide denominator by power of two
+        assembly {
+            denominator := div(denominator, twos)
+        }
+
+        // Divide [prod1 prod0] by the factors of two
+        assembly {
+            prod0 := div(prod0, twos)
+        }
+        // Shift in bits from prod1 into prod0. For this we need
+        // to flip `twos` such that it is 2**256 / twos.
+        // If twos is zero, then it becomes one
+        assembly {
+            twos := add(div(sub(0, twos), twos), 1)
+        }
+        prod0 |= prod1 * twos;
+
+        // Invert denominator mod 2**256
+        // Now that denominator is an odd number, it has an inverse
+        // modulo 2**256 such that denominator * inv = 1 mod 2**256.
+        // Compute the inverse by starting with a seed that is correct
+        // correct for four bits. That is, denominator * inv = 1 mod 2**4
+        uint256 inv = (3 * denominator) ^ 2;
+        // Now use Newton-Raphson iteration to improve the precision.
+        // Thanks to Hensel's lifting lemma, this also works in modular
+        // arithmetic, doubling the correct bits in each step.
+        inv *= 2 - denominator * inv; // inverse mod 2**8
+        inv *= 2 - denominator * inv; // inverse mod 2**16
+        inv *= 2 - denominator * inv; // inverse mod 2**32
+        inv *= 2 - denominator * inv; // inverse mod 2**64
+        inv *= 2 - denominator * inv; // inverse mod 2**128
+        inv *= 2 - denominator * inv; // inverse mod 2**256
+
+        // Because the division is now exact we can divide by multiplying
+        // with the modular inverse of denominator. This will give us the
+        // correct result modulo 2**256. Since the precoditions guarantee
+        // that the outcome is less than 2**256, this is the final result.
+        // We don't need to compute the high bits of the result and prod1
+        // is no longer required.
+        result = prod0 * inv;
+        return result;
+      }
+    }
+
+    /// @notice Calculates ceil(a×b÷denominator) with full precision. Throws if result overflows a uint256 or denominator == 0
+    /// @param a The multiplicand
+    /// @param b The multiplier
+    /// @param denominator The divisor
+    /// @return result The 256-bit result
+    function mulDivRoundingUp(
+        uint256 a,
+        uint256 b,
+        uint256 denominator
+    ) internal pure returns (uint256 result) {
+        result = mulDiv(a, b, denominator);
+        if (mulmod(a, b, denominator) > 0) {
+
+            require(result < type(uint256).max,"mgv/mulDivUp/overflow");
+            result++;
+        }
+    }
+
+    /// @notice Calculates [floor|ceiling](a×b÷(2**expn)) with full precision. Throws if result overflows a uint.
+    /// @param a The multiplicand
+    /// @param b The multiplier
+    /// @param expn The log2 of the divisor
+    /// @param roundUp returns ceil if true, floor otherwise
+    /// @return result The 256-bit result
+    /// @dev Adapted from Remco Bloemen under MIT license https://xn--2-umb.com/21/muldiv
+    function mulDivPow2(uint a, uint b, uint expn, bool roundUp) internal pure returns (uint result) {
+      unchecked {
+        // 512-bit multiply [prod1 prod0] = a * b
+        // Compute the product mod 2**256 and mod 2**256 - 1
+        // then use the Chinese Remainder Theorem to reconstruct
+        // the 512 bit result. The result is stored in two 256
+        // variables such that product = prod1 * 2**256 + prod0
+        uint prod0; // Least significant 256 bits of the product
+        uint prod1; // Most significant 256 bits of the product
+        uint carry;
+        assembly {
+          let mm := mulmod(a, b, not(0))
+          prod0 := mul(a, b)
+          prod1 := sub(sub(mm, prod0), lt(mm, prod0))
+        }
+
+        /* 
+          carry is 1 [prod0 & (1<<e)-1 > 0]
+          cases: 
+          * if prod0 is 0, carry is 0 if e<=255 (depends on prod1 otherwise)
+          * else if e>255, carry should be 1. (1<<e)-1 is all ones, so the & is > 0.
+          * else the & is prod0%2**e
+        */
+        assembly("memory-safe") {
+          carry := gt(and(prod0,sub(shl(expn,1),1)),0)
+          carry := and(roundUp,carry)
+        }
+
+        result = prod0 >> expn;
+
+        // Handle non-overflow cases, 256 by 256 division
+        if (prod1 == 0) {
+          result = result + carry;
+          require(result >= carry,"mgv/mulDivPow2/overflowUp0");
+          return result;
+        }
+
+        // Make sure the result is less than 2**256.
+        // max value of [prod1 prod0] means expn>255 is enough to ensure < 2**256
+        // << overflow means first branch is true anyway
+        require(expn>255 || (1<<expn) > prod1,"mgv/mulDivPow2/overflow");
+
+        /* 
+          carry is carry | [prod1 & (1<<(e-256)) - 1 > 0]
+          cases:
+          * if prod0 != 0 or e<=255, carry is already correct
+          * we know prod1 != 0
+          * if e>511, carry should be 1, (1<<(e-256))-1 is all ones, so the & is > 0
+          * else the & is prod1%2**(e-256)
+         */
+        if (prod0 == 0 && expn > 255) {
+          assembly("memory-safe") {
+            carry := or(carry,gt(and(prod1,sub(shl(sub(expn,256),1),1)),0))
+            carry := and(roundUp,carry)
+          }
+         }
+
+        ///////////////////////////////////////////////
+        // 512 by 256 division.
+        ///////////////////////////////////////////////
+
+        result = (result | (prod1 << (256-expn)));
+        result = result + carry;
+        require(result >= carry,"mgv/mulDivPow2/overflowUp1");
+      }
+    }
+}

--- a/lib/TickLib.sol
+++ b/lib/TickLib.sol
@@ -5,7 +5,6 @@ import {Bin} from "mgv_lib/BinLib.sol";
 import "mgv_lib/BitLib.sol";
 import "mgv_lib/Constants.sol";
 import "mgv_lib/FullMath.sol";
-import {console2 as csf} from "forge-std/console2.sol";
 
 type Tick is int;
 using TickLib for Tick global;

--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -80,7 +80,7 @@ uni.hospitable(true);
 /* Struct fields that are common to multiple structs are factored here. Multiple field names refer to offer identifiers, so the `id` field is a function that takes a name as argument. */
 
 const fields = {
-  gives: { name: "gives", bits: 96, type: "uint" },
+  gives: { name: "gives", bits: 160, type: "uint" },
   gasprice: { name: "gasprice", bits: 16, type: "uint" },
   gasreq: { name: "gasreq", bits: 24, type: "uint" },
   kilo_offer_gasbase: { name: "kilo_offer_gasbase", bits: 9, type: "uint" },
@@ -105,9 +105,7 @@ const struct_defs = {
       /* * `next` points to the immediately worse offer. The worst offer's `next` is 0. _32 bits wide_. */
       id_field("next"),
       {name:"tick",bits:21,type:"Tick",underlyingType: "int"},
-      /* * `gives` is the amount of `outbound_tkn` the offer will give if successfully executed.
-      _96 bits wide_, so assuming the usual 18 decimals, amounts can only go up to
-      10 billions. */
+      /* * `gives` is the amount of `outbound_tkn` the offer will give if successfully executed. _160 bits wide_.  */
       fields.gives,
     ],
     additionalDefinitions: `import "mgv_lib/BinLib.sol";

--- a/src/preprocessed/MgvOffer.post.sol
+++ b/src/preprocessed/MgvOffer.post.sol
@@ -87,7 +87,7 @@ library OfferLib {
   uint constant prev_bits  = 32;
   uint constant next_bits  = 32;
   uint constant tick_bits  = 21;
-  uint constant gives_bits = 96;
+  uint constant gives_bits = 160;
 
   // number of bits before each field
   uint constant prev_before  = 0           + 0;
@@ -117,7 +117,7 @@ library OfferLib {
   string constant prev_size_error  = "mgv/config/prev/32bits";
   string constant next_size_error  = "mgv/config/next/32bits";
   string constant tick_size_error  = "mgv/config/tick/21bits";
-  string constant gives_size_error = "mgv/config/gives/96bits";
+  string constant gives_size_error = "mgv/config/gives/160bits";
 
   // from packed to in-memory struct
   function to_struct(Offer __packed) internal pure returns (OfferUnpacked memory __s) { unchecked {

--- a/test/core/Constant.t.sol
+++ b/test/core/Constant.t.sol
@@ -76,5 +76,19 @@ contract ConstantsTest is MangroveTest {
     assertEq(MAX_SAFE_GIVES, type(uint).max / MAX_RATIO_MANTISSA, "MAX_SAFE_GIVES");
     assertEq(MIN_BIN_ALLOWED, MIN_TICK, "MIN_BIN_ALLOWED");
     assertEq(MAX_BIN_ALLOWED, MAX_TICK, "MAX_BIN_ALLOWED");
+    assertEq(MAX_SAFE_VOLUME, (1 << MAX_SAFE_VOLUME_BITS) - 1);
+  }
+
+  // For the ratio computed in TickLib.tickFromVolumes to be valid, it must represent a number less than the maximum ratio. Since it is computed by (inbound << MAX_SAFE_VOLUME_BITS) / outbound and inbound <= MAX_SAFE_VOLUME,
+  function test_tickFromVolumes_is_maxRatio_safe() public {
+    assertTrue(MAX_SAFE_VOLUME <= MAX_RATIO_MANTISSA, "MAX_SAFE_VOLUME is too big");
+    // The check above only holds because it can ignore MAX_RATIO_EXP;
+    assertTrue(MAX_RATIO_EXP == 0, "max ratio exp must be 0 for the check above to hold");
+  }
+
+  // In TickLib.tickFromVolumes, the (uint) exp of a normalized float is computed by MAX_SAFE_VOLUME_BITS - log2(number) + MANTISSA_BITS_MINUS_ONE
+  // Lack of underflow is only guaranteed if the maximum possible log2 does not yield a < 0 exp.
+  function test_tickFromVolumes_underflow_safe() public {
+    assertTrue(255 - MANTISSA_BITS_MINUS_ONE < MAX_SAFE_VOLUME_BITS, "risk of underflow in TickLib.tickFromVolumes");
   }
 }

--- a/test/core/Constant.t.sol
+++ b/test/core/Constant.t.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.10;
 
 import "mgv_test/lib/MangroveTest.sol";
 import "mgv_src/MgvLib.sol";
-import "forge-std/stdError.sol";
 
 // In these tests, the testing contract is the market maker.
 contract ConstantsTest is MangroveTest {

--- a/test/core/Constant.t.sol
+++ b/test/core/Constant.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.10;
 
 import "mgv_test/lib/MangroveTest.sol";
 import "mgv_src/MgvLib.sol";
+import "forge-std/stdError.sol";
 
 // In these tests, the testing contract is the market maker.
 contract ConstantsTest is MangroveTest {
@@ -24,6 +25,13 @@ contract ConstantsTest is MangroveTest {
     assertEq(tick, Tick.wrap(MAX_TICK));
   }
 
+  function test_max_safe_gives() public {
+    // check no revert
+    TickLib.inboundFromOutboundUp(Tick.wrap(MAX_TICK), MAX_SAFE_GIVES);
+    vm.expectRevert("mgv/mulDivPow2/overflow");
+    TickLib.inboundFromOutbound(Tick.wrap(MAX_TICK), MAX_SAFE_GIVES + 1);
+  }
+
   // Since "Only direct number constants and references to such constants are supported by inline assembly", NOT_TOPBIT is not defined in terms of TOPBIT. Here we check that its definition is correct.
   function test_not_topbit_is_negation_of_topbit() public {
     assertEq(TOPBIT, ~NOT_TOPBIT, "TOPBIT != ~NOT_TOPBIT");
@@ -35,11 +43,6 @@ contract ConstantsTest is MangroveTest {
     assertGt(ROOT_SIZE, 0, "root size too small");
     assertLe(LEVEL_SIZE, int(MAX_FIELD_SIZE), "level size too big");
     assertGt(LEVEL_SIZE, 0, "level size too small");
-  }
-
-  // checks that there is no overflow
-  function test_maxSafeVolumeIsSafeLowLevel() public {
-    assertGt(MAX_SAFE_VOLUME * ((1 << MANTISSA_BITS) - 1), 0);
   }
 
   // make sure TICK_BITS in Constants.sol matches the tick bits used in offer struct
@@ -70,7 +73,7 @@ contract ConstantsTest is MangroveTest {
     assertEq(MIN_TICK, -((1 << 20) - 1), "MIN_TICK");
     assertEq(MAX_TICK, -MIN_TICK, "MAX_TICK");
     assertEq(MANTISSA_BITS_MINUS_ONE, MANTISSA_BITS - 1, "MANTISSA_BITS_MINUS_ONE");
-    assertEq(MAX_SAFE_VOLUME, (1 << (256 - MANTISSA_BITS)) - 1, "MAX_SAFE_VOLUME");
+    assertEq(MAX_SAFE_GIVES, type(uint).max / MAX_RATIO_MANTISSA, "MAX_SAFE_GIVES");
     assertEq(MIN_BIN_ALLOWED, MIN_TICK, "MIN_BIN_ALLOWED");
     assertEq(MAX_BIN_ALLOWED, MAX_TICK, "MAX_BIN_ALLOWED");
   }

--- a/test/core/Field.t.sol
+++ b/test/core/Field.t.sol
@@ -132,33 +132,4 @@ contract FieldTest is MangroveTest {
   function field_isDirty(DirtyField field) public {
     assertEq(field.isDirty(), DirtyField.unwrap(field) & TOPBIT == TOPBIT);
   }
-
-  // non-optimized divExpUp
-  function divExpUp_spec(uint a, uint exp) internal pure returns (uint) {
-    if (a == 0) return 0;
-    if (exp > 255) return 1;
-    uint den = 2 ** exp;
-    uint carry = a % den == 0 ? 0 : 1;
-    return a / den + carry;
-  }
-
-  function test_inboundFromOutboundUp_and_converse(Tick tick, uint amt) public {
-    amt = bound(amt, 0, MAX_SAFE_VOLUME);
-    tick = Tick.wrap(bound(Tick.unwrap(tick), MIN_TICK, MAX_TICK));
-
-    uint sig;
-    uint exp;
-
-    //inboundFromOutboundUp
-    (sig, exp) = TickLib.nonNormalizedRatioFromTick(tick);
-    assertEq(tick.inboundFromOutboundUp(amt), divExpUp_spec(sig * amt, exp));
-
-    //outboundFromInboundUp
-    (sig, exp) = TickLib.nonNormalizedRatioFromTick(Tick.wrap(-Tick.unwrap(tick)));
-    assertEq(tick.outboundFromInboundUp(amt), divExpUp_spec(sig * amt, exp));
-  }
-
-  function test_divExpUp(uint a, uint exp) public {
-    assertEq(TickLib.divExpUp(a, exp), divExpUp_spec(a, exp));
-  }
 }

--- a/test/core/FullMath.t.sol
+++ b/test/core/FullMath.t.sol
@@ -41,9 +41,42 @@ contract FullMathTest is Test2 {
     }
   }
 
+  function test_above_uint_max_den() public {
+    bool floor = false;
+    bool ceil = true;
+
+    // forgefmt: disable-start
+    mEq(             1,      1, 256, floor,          0);
+    mEq(             1,      1, 256,  ceil,          1);
+    mEq(type(uint).max,      1, 256, floor,          0);
+    mEq(type(uint).max,      1, 256,  ceil,          1);
+    mEq(type(uint).max,      2, 256, floor,          1);
+    mEq(type(uint).max,      2, 256,  ceil,          2);
+    mEq(type(uint).max, 1<<255, 256, floor, (1<<255)-1);
+    mEq(type(uint).max, 1<<255, 256,  ceil,     1<<255);
+    mEq(type(uint).max, 1<<255, 512, floor,          0);
+    mEq(type(uint).max, 1<<255, 512,  ceil,          1);
+    // forgefmt: disable-end
+  }
+
   /* ************
     Utility
   ************* */
+
+  function mEq(uint a, uint b, uint e, bool roundUp, uint expected) internal {
+    uint actual = FullMath.mulDivPow2(a, b, e, roundUp);
+
+    if (expected != actual) {
+      string memory roundUpStr = roundUp ? "ceil" : "floor";
+      emit log(string.concat("Error: wrong mulDiv(", roundUpStr, ")"));
+      emit log_named_string("       a", vm.toString(a));
+      emit log_named_string("       b", vm.toString(b));
+      emit log_named_string("    expn", vm.toString(e));
+      emit log_named_string("expected", vm.toString(expected));
+      emit log_named_string("  actual", vm.toString(actual));
+      fail();
+    }
+  }
 
   function assertMul(uint a, uint b, uint e, bool roundUp, string memory err) internal {
     require(e <= 255, "e>255 not valid for FullMath.mulDiv[roundingUp]");
@@ -82,6 +115,7 @@ contract FullMathTest is Test2 {
         emit log_named_string("    mulDiv", vm.toString(expected));
         emit log_named_string("mulDivPow2", vm.toString(actual));
       }
+      fail();
     }
   }
 

--- a/test/core/FullMath.t.sol
+++ b/test/core/FullMath.t.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier:	AGPL-3.0
+
+pragma solidity ^0.8.10;
+
+import "mgv_lib/Test2.sol";
+import "mgv_src/MgvLib.sol";
+import "mgv_test/lib/MangroveTest.sol";
+// import {Fullmath as F} from "mgv_lib/FullMath.sol";
+
+// Only mulDivPow2 needs testing
+contract FullMathTest is Test2 {
+  FullMathProxy fmp;
+
+  function setUp() public virtual {
+    fmp = new FullMathProxy();
+  }
+
+  function test_fuzz_ceil(uint a, uint b, uint e) public {
+    e = bound(e, 0, 255);
+    assertMulUp(a, b, e, "fuzz_ceil");
+  }
+
+  function test_fuzz_floor(uint a, uint b, uint e) public {
+    e = bound(e, 0, 255);
+    assertMul(a, b, e, "fuzz_ceil");
+  }
+
+  function test_manual1() public {
+    for (uint e = 0; e < 256; e++) {
+      assertMul(type(uint).max, type(uint).max, e, "floor");
+      assertMulUp(type(uint).max, type(uint).max, e, "ceil");
+    }
+  }
+
+  function test_manual_up() public {
+    for (uint e = 0; e < 256; e++) {
+      assertMulUp(1, (1 << e) + 1, e, "up1");
+      assertMulUp(1, (1 << e) - 1, e, "up2");
+      assertMulUp(1 << (256 - e) + 1, (1 << e) + 1, e, "up3");
+      assertMulUp(1 << (256 - e) + 1, (1 << e) - 1, e, "up4");
+    }
+  }
+
+  /* ************
+    Utility
+  ************* */
+
+  function assertMul(uint a, uint b, uint e, bool roundUp, string memory err) internal {
+    require(e <= 255, "e>255 not valid for FullMath.mulDiv[roundingUp]");
+
+    uint expected;
+    bool expected_success = false;
+    if (roundUp) {
+      try fmp.mulDivRoundingUp(a, b, 1 << e) returns (uint got) {
+        expected = got;
+        expected_success = true;
+      } catch {}
+    } else {
+      try fmp.mulDiv(a, b, 1 << e) returns (uint got) {
+        expected = got;
+        expected_success = true;
+      } catch {}
+    }
+
+    uint actual;
+    bool actual_success = false;
+    try fmp.mulDivPow2(a, b, e, roundUp) returns (uint got) {
+      actual = got;
+      actual_success = true;
+    } catch {}
+
+    if (expected != actual || expected_success != actual_success) {
+      emit log(string.concat("Error: mulDiv != mulDivPow2(", roundUp ? "ceil" : "floor", ")"));
+      emit log(err);
+      emit log_named_string("         a", vm.toString(a));
+      emit log_named_string("         b", vm.toString(b));
+      emit log_named_string("      expn", vm.toString(e));
+      if (expected_success != actual_success) {
+        emit log_named_string("    mulDiv", vm.toString(expected_success));
+        emit log_named_string("mulDivPow2", vm.toString(actual_success));
+      } else {
+        emit log_named_string("    mulDiv", vm.toString(expected));
+        emit log_named_string("mulDivPow2", vm.toString(actual));
+      }
+    }
+  }
+
+  function assertMul(uint a, uint b, uint e, string memory err) internal {
+    assertMul(a, b, e, false, err);
+  }
+
+  function assertMulUp(uint a, uint b, uint e, string memory err) internal {
+    assertMul(a, b, e, true, err);
+  }
+}
+
+contract FullMathProxy {
+  function mulDivRoundingUp(uint a, uint b, uint e) external pure returns (uint) {
+    return FullMath.mulDivRoundingUp(a, b, e);
+  }
+
+  function mulDiv(uint a, uint b, uint e) external pure returns (uint) {
+    return FullMath.mulDiv(a, b, e);
+  }
+
+  function mulDivPow2(uint a, uint b, uint e, bool roundUp) external pure returns (uint) {
+    return FullMath.mulDivPow2(a, b, e, roundUp);
+  }
+}

--- a/test/core/Gatekeeping.t.sol
+++ b/test/core/Gatekeeping.t.sol
@@ -185,14 +185,24 @@ contract GatekeepingTest is MangroveTest {
     mgv.setGasmax(uint(type(uint24).max) + 1);
   }
 
-  function test_makerWants_too_big_fails_newOfferByVolume() public {
-    vm.expectRevert("ratioFromVolumes/inbound/tooBig");
-    mkr.newOfferByVolume(MAX_SAFE_VOLUME + 1, 1 ether, 10_000, 0);
+  function test_makerGives_too_big_fails_newOfferByVolume() public {
+    vm.expectRevert("mgv/writeOffer/gives/tooBig");
+    mkr.newOfferByVolume(1 << 159, 1 << 160, 10_000);
   }
 
-  function test_makerGives_too_big_fails_newOfferByVolume() public {
-    vm.expectRevert("ratioFromVolumes/outbound/tooBig");
-    mkr.newOfferByVolume(1 ether, MAX_SAFE_VOLUME + 1, 10_000, 0);
+  function test_makerWants_too_big_fails_newOfferByVolume() public {
+    vm.expectRevert("mgv/mulDiv/overflow");
+    mkr.newOfferByVolume(1 << 160, 1, 100_000, 0);
+  }
+
+  function test_ratio_too_big_fails_newOfferByVolume() public {
+    vm.expectRevert("mgv/ratioFromVol/ratioTooHigh");
+    mkr.newOfferByVolume(MAX_RATIO_MANTISSA + 1, 1, 100_000, 0);
+  }
+
+  function test_ratio_too_small_fails_newOfferByVolume() public {
+    vm.expectRevert("mgv/ratioFromVol/ratioTooLow");
+    mkr.newOfferByVolume(1, MAX_RATIO_MANTISSA + 1, 100_000, 0);
   }
 
   function test_newOfferByTick_extrema_tick() public {
@@ -247,11 +257,6 @@ contract GatekeepingTest is MangroveTest {
     // try new offer now that we set the last id to uint32.max
     vm.expectRevert("mgv/offerIdOverflow");
     mgv.newOfferByVolume(olKey, 1 ether, 1 ether, 0, 0);
-  }
-
-  function test_makerGives_wider_than_96_bits_fails_newOfferByVolume() public {
-    vm.expectRevert("mgv/writeOffer/gives/96bits");
-    mkr.newOfferByVolume(1, 1 << 96, 10_000);
   }
 
   function test_makerGasreq_wider_than_24_bits_fails_newOfferByVolume() public {

--- a/test/core/Gatekeeping.t.sol
+++ b/test/core/Gatekeeping.t.sol
@@ -185,24 +185,19 @@ contract GatekeepingTest is MangroveTest {
     mgv.setGasmax(uint(type(uint24).max) + 1);
   }
 
-  function test_makerGives_too_big_fails_newOfferByVolume() public {
-    vm.expectRevert("mgv/writeOffer/gives/tooBig");
-    mkr.newOfferByVolume(1 << 159, 1 << 160, 10_000);
-  }
-
   function test_makerWants_too_big_fails_newOfferByVolume() public {
-    vm.expectRevert("mgv/mulDiv/overflow");
-    mkr.newOfferByVolume(1 << 160, 1, 100_000, 0);
+    mgv.setDensity96X32(olKey, 0);
+    // check no revert
+    mkr.newOfferByVolume(MAX_SAFE_VOLUME, 1, 100_000, 0);
+    vm.expectRevert("mgv/tickFromVol/inbound/tooBig");
+    mkr.newOfferByVolume(MAX_SAFE_VOLUME + 1, 1, 100_000, 0);
   }
 
-  function test_ratio_too_big_fails_newOfferByVolume() public {
-    vm.expectRevert("mgv/ratioFromVol/ratioTooHigh");
-    mkr.newOfferByVolume(MAX_RATIO_MANTISSA + 1, 1, 100_000, 0);
-  }
-
-  function test_ratio_too_small_fails_newOfferByVolume() public {
-    vm.expectRevert("mgv/ratioFromVol/ratioTooLow");
-    mkr.newOfferByVolume(1, MAX_RATIO_MANTISSA + 1, 100_000, 0);
+  function test_makerGives_too_small_fails_newOfferByVolume() public {
+    // check no revert
+    mkr.newOfferByVolume(1, MAX_SAFE_VOLUME, 100_000, 0);
+    vm.expectRevert("mgv/tickFromVol/outbound/tooBig");
+    mkr.newOfferByVolume(1, MAX_SAFE_VOLUME + 1, 100_000, 0);
   }
 
   function test_newOfferByTick_extrema_tick() public {

--- a/test/core/MakerOperations.t.sol
+++ b/test/core/MakerOperations.t.sol
@@ -1059,4 +1059,9 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     mgv.retractOffer(olKey, ofr0, true);
     assertEq(mgv.leafs(olKey, bin.leafIndex()), LeafLib.EMPTY, "leaf should be empty");
   }
+
+  function test_bad_gives_tick_combo() public {
+    vm.expectRevert("mgv/mulDivPow2/overflow");
+    mkr.newOfferByTick(Tick.wrap(MAX_TICK), MAX_SAFE_GIVES + 1, 100_000, 0);
+  }
 }

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -659,8 +659,6 @@ contract TakerOperationsTest is MangroveTest {
   }
 
   // none should revert
-  // max price using volumes: 1<<MAX_RATIO_MANTISSA
-  // min price using volumes: 1/(1<<RATIO_FROM_VOLUMES_SHIFT)
   function test_marketOrderByVolume_takerGives_extrema_ok() public {
     mgv.marketOrderByVolume(olKey, MAX_SAFE_VOLUME, 1, true);
     mgv.marketOrderByVolume(olKey, MAX_SAFE_VOLUME, 1, false);

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -662,35 +662,24 @@ contract TakerOperationsTest is MangroveTest {
   // max price using volumes: 1<<MAX_RATIO_MANTISSA
   // min price using volumes: 1/(1<<RATIO_FROM_VOLUMES_SHIFT)
   function test_marketOrderByVolume_takerGives_extrema_ok() public {
-    uint GB = OfferLib.gives_bits;
-    mgv.marketOrderByVolume(olKey, 1, MAX_RATIO_MANTISSA, true);
-    mgv.marketOrderByVolume(olKey, 1, MAX_RATIO_MANTISSA, false);
-    mgv.marketOrderByVolume(olKey, 1 << RATIO_FROM_VOLUMES_SHIFT, 1, true);
-    mgv.marketOrderByVolume(olKey, 1 << MAX_RATIO_MANTISSA, 1, false);
-    mgv.marketOrderByVolume(olKey, 1 << GB, 1 << (GB - 1), false);
-    mgv.marketOrderByVolume(olKey, 1 << (GB - 1), 1 << GB, true);
+    mgv.marketOrderByVolume(olKey, MAX_SAFE_VOLUME, 1, true);
+    mgv.marketOrderByVolume(olKey, MAX_SAFE_VOLUME, 1, false);
+    mgv.marketOrderByVolume(olKey, 1, MAX_SAFE_VOLUME, true);
+    mgv.marketOrderByVolume(olKey, 1, MAX_SAFE_VOLUME, false);
   }
 
   function test_marketOrderByVolume_takerGives_extrema_ko() public {
-    uint GB = OfferLib.gives_bits;
+    vm.expectRevert("mgv/tickFromVol/inbound/tooBig");
+    mgv.marketOrderByVolume(olKey, 1, MAX_SAFE_VOLUME + 1, true);
 
-    vm.expectRevert("mgv/ratioFromVol/ratioTooHigh");
-    mgv.marketOrderByVolume(olKey, 1, MAX_RATIO_MANTISSA + 1, true);
+    vm.expectRevert("mgv/tickFromVol/outbound/tooBig");
+    mgv.marketOrderByVolume(olKey, MAX_SAFE_VOLUME + 1, 1, true);
 
-    vm.expectRevert("mgv/ratioFromVol/ratioTooLow");
-    mgv.marketOrderByVolume(olKey, (1 << RATIO_FROM_VOLUMES_SHIFT) + 1, 1, true);
+    vm.expectRevert("mgv/tickFromVol/inbound/tooBig");
+    mgv.marketOrderByVolume(olKey, 1, MAX_SAFE_VOLUME + 1, false);
 
-    vm.expectRevert("mgv/ratioFromVol/ratioTooHigh");
-    mgv.marketOrderByVolume(olKey, 1, MAX_RATIO_MANTISSA + 1, false);
-
-    vm.expectRevert("mgv/ratioFromVol/ratioTooLow");
-    mgv.marketOrderByVolume(olKey, (1 << RATIO_FROM_VOLUMES_SHIFT) + 1, 1, false);
-
-    vm.expectRevert("mgv/mOrder/fillVolume/tooBig");
-    mgv.marketOrderByVolume(olKey, 1 << GB, 1 << (GB - 1), true);
-
-    vm.expectRevert("mgv/mOrder/fillVolume/tooBig");
-    mgv.marketOrderByVolume(olKey, 1 << (GB - 1), 1 << GB, false);
+    vm.expectRevert("mgv/tickFromVol/outbound/tooBig");
+    mgv.marketOrderByVolume(olKey, MAX_SAFE_VOLUME + 1, 1, false);
   }
 
   function test_clean_with_0_wants_ejects_offer() public {

--- a/test/preprocessed/MgvOfferTest.post.sol
+++ b/test/preprocessed/MgvOfferTest.post.sol
@@ -23,7 +23,7 @@ contract MgvOfferTest is Test2 {
     assertEq(packed.prev(),cast(prev,32),"bad prev");
     assertEq(packed.next(),cast(next,32),"bad next");
     assertEq(Tick.unwrap(packed.tick()),cast(Tick.unwrap(tick),21),"bad tick");
-    assertEq(packed.gives(),cast(gives,96),"bad gives");
+    assertEq(packed.gives(),cast(gives,160),"bad gives");
   }
 
   /* test_set_x tests:
@@ -74,7 +74,7 @@ contract MgvOfferTest is Test2 {
 
       Offer modified = packed.gives(gives);
 
-      assertEq(modified.gives(),cast(gives,96),"modified: bad gives");
+      assertEq(modified.gives(),cast(gives,160),"modified: bad gives");
 
       assertEq(modified.prev(),packed.prev(),"modified: bad prev");
       assertEq(modified.next(),packed.next(),"modified: bad next");


### PR DESCRIPTION
tldr:
* `offer.gives` goes up to 160 bits
* marketOrder's `fillVolume` as well
* volume-based marketOrder & offer creation/updated are limited to 128 `[maker|taker][Wants|Gives]` (nontrivial & no time to allow the full price range with the API, which I'd say is fine since it exists mostly for convenience)

For `ratioFromVolumes`, use Remco Bloemen's [muldiv](https://xn--2-umb.com/21/muldiv/). For `inboundFromOutbound` and similar functions, use a new `mulDivPow2` that should be carefully reviewed.

**Why `mulDivPow2`**: `mulDiv(a,b,d)` (and `mulDivRoundUp`) return `a*b/d`. It throws if the result does not fit in 256 bits or if `d=0`. This is useful to compute a ratio from `gives` and `wants`. 

But to compute a `wants` from `gives` and `tick`, you start by converting a tick to a ratio represented as a `mantissa,exponent` pair, and `wants = gives*mantissa / 2^exponent`. The exponent may be > 255, so we can't use `mulDiv`. `mulDivPow2(a,b,e)` returns `a*b/(2<<e)`. It throws if the result does not fit in 256 bits. It also takes an extra `roundUp` argument.

In reviewing `mulDivPow2` you can assume that the first assembly block correctly returns the full `a*b` product, split into two words `prod1` and `prod0`.