### PR TITLE
Gasprice in mwei

### DIFF
--- a/lib/DensityLib.sol
+++ b/lib/DensityLib.sol
@@ -116,32 +116,33 @@ library DensityLib {
   }}
 
   // Convenience function: get a fixed-point density from the given parameters. Computes the price of gas in outbound base tokens, then multiplies by cover_factor.
-  // Warning: multiply input prices by 100
+  // Warning: you must multiply input usd prices by 100
   // not supposed to be gas optimized
   function paramsTo96X32(
     uint outbound_decimals, 
-    uint gasprice_in_gwei, 
-    uint eth_in_usdx100, 
-    uint outbound_display_in_usdx100, 
+    uint gasprice_in_mwei, 
+    uint eth_in_centiusd, 
+    uint outbound_display_in_centiusd, 
     uint cover_factor
   ) internal pure returns (uint) {
     // Do not use unchecked here
     require(uint8(outbound_decimals) == outbound_decimals,"DensityLib/fixedFromParams1/decimals/wrong");
-    uint num = cover_factor * gasprice_in_gwei * (10**outbound_decimals) * eth_in_usdx100;
+    uint num = cover_factor * gasprice_in_mwei * (10**outbound_decimals) * eth_in_centiusd;
     // use * instead of << to trigger overflow check
-    return (num * (1 << 32)) / (outbound_display_in_usdx100 * 1e9);
+    return (num * (1 << 32)) / (outbound_display_in_centiusd * 1e12);
   }
 
+  // Version with token in mwei instead of usd
   function paramsTo96X32(
     uint outbound_decimals, 
-    uint gasprice_in_gwei, 
-    uint outbound_display_in_gwei, 
+    uint gasprice_in_mwei, 
+    uint outbound_display_in_mwei, 
     uint cover_factor
   ) internal pure returns (uint) {
     // Do not use unchecked here
     require(uint8(outbound_decimals) == outbound_decimals,"DensityLib/fixedFromParams2/decimals/wrong");
-    uint num = cover_factor * gasprice_in_gwei * (10**outbound_decimals);
+    uint num = cover_factor * gasprice_in_mwei * (10**outbound_decimals);
     // use * instead of << to trigger overflow check
-    return (num * (1 << 32)) / outbound_display_in_gwei;
+    return (num * (1 << 32)) / outbound_display_in_mwei;
   }
 }

--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -81,7 +81,7 @@ uni.hospitable(true);
 
 const fields = {
   gives: { name: "gives", bits: 96, type: "uint" },
-  gasprice: { name: "gasprice", bits: 16, type: "uint" },
+  gasprice: { name: "gasprice", bits: 26, type: "uint" },
   gasreq: { name: "gasreq", bits: 24, type: "uint" },
   kilo_offer_gasbase: { name: "kilo_offer_gasbase", bits: 9, type: "uint" },
 };
@@ -186,7 +186,7 @@ They have the following fields: */
       
     (There is an inefficiency here. The overhead could be split into an "offer-local overhead" and a "general overhead". That general overhead gas penalty could be spread between all offers executed during an order, or all failing offers. It would still be possible for a cleaner to execute a failing offer alone and make them pay the entire general gas overhead. For the sake of simplicity we keep only one "offer overhead" value.)
 
-    If an offer fails, `gasprice` wei is taken from the
+    If an offer fails, `gasprice` mwei is taken from the
     provision per unit of gas used. `gasprice` should approximate the average gas
     ratio at offer creation time.
 
@@ -198,7 +198,7 @@ They have the following fields: */
     So, when an offer is created, the maker is asked to provision the
     following amount of wei:
     ```
-    (gasreq + offer_gasbase) * gasprice
+    (gasreq + offer_gasbase) * gasprice * 1e6
     ```
 
       where `offer_gasbase` and `gasprice` are Mangrove's current configuration values (or a higher value for `gasprice` if specified by the maker).
@@ -206,14 +206,14 @@ They have the following fields: */
 
       When an offer fails, the following amount is given to the taker as compensation:
     ```
-    (gasused + offer_gasbase) * gasprice
+    (gasused + offer_gasbase) * gasprice * 1e6
     ```
 
     where `offer_gasbase` and `gasprice` are Mangrove's current configuration values.  The rest is given back to the maker.
 
       */
       fields.kilo_offer_gasbase,
-      /* * `gasprice` is in gwei/gas and _16 bits wide_, which accomodates 1 to ~65k gwei / gas.  `gasprice` is also the name of a global Mangrove parameter. When an offer is created, the offer's `gasprice` is set to the max of the user-specified `gasprice` and Mangrove's global `gasprice`. */
+      /* * `gasprice` is in mwei/gas and _26 bits wide_, which accomodates 0.001 to ~67k gwei / gas.  `gasprice` is also the name of a global Mangrove parameter. When an offer is created, the offer's `gasprice` is set to the max of the user-specified `gasprice` and Mangrove's global `gasprice`. */
       fields.gasprice,
     ],
     additionalDefinitions: (struct) => `
@@ -252,7 +252,7 @@ library OfferDetailUnpackedExtra {
       { name: "useOracle", bits: 1, type: "bool" },
       /* * If `notify` is true, the dex will notify the monitor address after every offer execution. */
       { name: "notify", bits: 1, type: "bool" },
-      /* * The `gasprice` is the amount of penalty paid by failed offers, in gwei per gas used. `gasprice` should approximate the average gas price and will be subject to regular updates. */
+      /* * The `gasprice` is the amount of penalty paid by failed offers, in mwei per gas used. `gasprice` should approximate the average gas price and will be subject to regular updates. */
       fields.gasprice,
       /* * `gasmax` specifies how much gas an offer may ask for at execution time. An offer which asks for more gas than the block limit would live forever on the book. Nobody could take it or remove it, except its creator (who could cancel it). In practice, we will set this parameter to a reasonable limit taking into account both practical transaction sizes and the complexity of maker contracts.
       */

--- a/script/core/ActivateMarket.s.sol
+++ b/script/core/ActivateMarket.s.sol
@@ -12,8 +12,8 @@ import {ActivateSemibook} from "./ActivateSemibook.s.sol";
  TKN1=USDC \
  TKN2=WETH \
  TICK_SPACING=1 \
- TKN1_IN_GWEI=$(cast --to-wei $(bc -l <<< 1/$NATIVE_IN_USDC) gwei) \
- TKN2_IN_GWEI=$(cast --to-wei $(bc -l <<< 1/$NATIVE_IN_ETH) gwei) \
+ TKN1_IN_MWEI=$(cast --to-wei $(bc -l <<< 1/$NATIVE_IN_USDC) mwei) \
+ TKN2_IN_MWEI=$(cast --to-wei $(bc -l <<< 1/$NATIVE_IN_ETH) mwei) \
  FEE=30 \
  forge script --fork-url mumbai ActivateMarket*/
 
@@ -27,8 +27,8 @@ contract ActivateMarket is Deployer {
         tkn1: envAddressOrName("TKN2"),
         tickSpacing: vm.envUint("TICK_SPACING")
       }),
-      tkn1_in_gwei: vm.envUint("TKN1_IN_GWEI"),
-      tkn2_in_gwei: vm.envUint("TKN2_IN_GWEI"),
+      tkn1_in_mwei: vm.envUint("TKN1_IN_MWEI"),
+      tkn2_in_mwei: vm.envUint("TKN2_IN_MWEI"),
       fee: vm.envUint("FEE")
     });
   }
@@ -39,16 +39,16 @@ contract ActivateMarket is Deployer {
     tkn1: first tokens
     tkn2: second tokens,
     tickSpacing: tick spacing,
-    tkn1_in_gwei: price of one tkn1 (display units) in gwei
-    tkn2_in_gwei: price of one tkn2 (display units) in gwei
+    tkn1_in_mwei: price of one tkn1 (display units) in mwei (1mwei = 1e-12 eth = 1e6 wei)
+    tkn2_in_mwei: price of one tkn2 (display units) in mwei 
     fee: fee in per 10_000
   */
 
   /* 
-    tknX_in_gwei should be obtained like this:
+    tknX_in_mwei should be obtained like this:
     1. Get the price of one tknX display unit in native token, in display units.
-       For instance, on ethereum, the price of 1 WETH is 1e9 gwei
-    2. Multiply by 1e9
+       For instance, on ethereum, the price of 1 WETH is 1e12 mwei
+    2. Multiply by 1e12
     3. Round to nearest integer
   */
 
@@ -56,12 +56,12 @@ contract ActivateMarket is Deployer {
     IMangrove mgv,
     MgvReader reader,
     Market memory market,
-    uint tkn1_in_gwei,
-    uint tkn2_in_gwei,
+    uint tkn1_in_mwei,
+    uint tkn2_in_mwei,
     uint fee
   ) public {
     Global global = mgv.global();
-    innerRun(mgv, global.gasprice(), reader, market, tkn1_in_gwei, tkn2_in_gwei, fee);
+    innerRun(mgv, global.gasprice(), reader, market, tkn1_in_mwei, tkn2_in_mwei, fee);
   }
 
   /**
@@ -73,15 +73,15 @@ contract ActivateMarket is Deployer {
     uint gaspriceOverride,
     MgvReader reader,
     Market memory market,
-    uint tkn1_in_gwei,
-    uint tkn2_in_gwei,
+    uint tkn1_in_mwei,
+    uint tkn2_in_mwei,
     uint fee
   ) public {
     new ActivateSemibook().innerRun({
       mgv: mgv,
       gaspriceOverride: gaspriceOverride,
       olKey: toOLKey(market),
-      outbound_in_gwei: tkn1_in_gwei,
+      outbound_in_mwei: tkn1_in_mwei,
       fee: fee
     });
 
@@ -89,7 +89,7 @@ contract ActivateMarket is Deployer {
       mgv: mgv,
       gaspriceOverride: gaspriceOverride,
       olKey: toOLKey(flipped(market)),
-      outbound_in_gwei: tkn2_in_gwei,
+      outbound_in_mwei: tkn2_in_mwei,
       fee: fee
     });
 

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -734,7 +734,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
     unchecked {
       uint gasreq = sor.offerDetail.gasreq();
 
-      uint provision = 10 ** 9 * sor.offerDetail.gasprice() * (gasreq + sor.offerDetail.offer_gasbase());
+      uint provision = 1e6 * sor.offerDetail.gasprice() * (gasreq + sor.offerDetail.offer_gasbase());
 
       /* We set `gasused = min(gasused,gasreq)` since `gasreq < gasused` is possible e.g. with `gasreq = 0` (all calls consume nonzero gas). */
       if (gasused > gasreq) {
@@ -742,7 +742,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
       }
 
       /* As an invariant, `applyPenalty` is only called when `mgvData` is not in `["mgv/tradeSuccess", "mgv/notEnoughGasForMakerTrade","mgv/takerTransferFail"] */
-      uint penalty = 10 ** 9 * sor.global.gasprice() * (gasused + sor.local.offer_gasbase());
+      uint penalty = 1e6 * sor.global.gasprice() * (gasused + sor.local.offer_gasbase());
 
       if (penalty > provision) {
         penalty = provision;

--- a/src/periphery/MgvReader.sol
+++ b/src/periphery/MgvReader.sol
@@ -347,7 +347,7 @@ contract MgvReader {
       } else {
         gp = ofr_gasprice;
       }
-      return (ofr_gasreq + _local.offer_gasbase()) * gp * 10 ** 9;
+      return (ofr_gasreq + _local.offer_gasbase()) * gp * 1e6;
     }
   }
 

--- a/src/preprocessed/MgvGlobal.post.sol
+++ b/src/preprocessed/MgvGlobal.post.sol
@@ -39,7 +39,7 @@ library GlobalLib {
   uint constant monitor_bits                   = 160;
   uint constant useOracle_bits                 = 1;
   uint constant notify_bits                    = 1;
-  uint constant gasprice_bits                  = 16;
+  uint constant gasprice_bits                  = 26;
   uint constant gasmax_bits                    = 24;
   uint constant dead_bits                      = 1;
   uint constant maxRecursionDepth_bits         = 8;
@@ -89,7 +89,7 @@ library GlobalLib {
   string constant monitor_size_error                   = "mgv/config/monitor/160bits";
   string constant useOracle_size_error                 = "mgv/config/useOracle/1bits";
   string constant notify_size_error                    = "mgv/config/notify/1bits";
-  string constant gasprice_size_error                  = "mgv/config/gasprice/16bits";
+  string constant gasprice_size_error                  = "mgv/config/gasprice/26bits";
   string constant gasmax_size_error                    = "mgv/config/gasmax/24bits";
   string constant dead_size_error                      = "mgv/config/dead/1bits";
   string constant maxRecursionDepth_size_error         = "mgv/config/maxRecursionDepth/8bits";

--- a/src/preprocessed/MgvOfferDetail.post.sol
+++ b/src/preprocessed/MgvOfferDetail.post.sol
@@ -56,7 +56,7 @@ library OfferDetailLib {
   uint constant maker_bits              = 160;
   uint constant gasreq_bits             = 24;
   uint constant kilo_offer_gasbase_bits = 9;
-  uint constant gasprice_bits           = 16;
+  uint constant gasprice_bits           = 26;
 
   // number of bits before each field
   uint constant maker_before              = 0                         + 0;
@@ -86,7 +86,7 @@ library OfferDetailLib {
   string constant maker_size_error              = "mgv/config/maker/160bits";
   string constant gasreq_size_error             = "mgv/config/gasreq/24bits";
   string constant kilo_offer_gasbase_size_error = "mgv/config/kilo_offer_gasbase/9bits";
-  string constant gasprice_size_error           = "mgv/config/gasprice/16bits";
+  string constant gasprice_size_error           = "mgv/config/gasprice/26bits";
 
   // from packed to in-memory struct
   function to_struct(OfferDetail __packed) internal pure returns (OfferDetailUnpacked memory __s) { unchecked {

--- a/test/core/Density.t.sol
+++ b/test/core/Density.t.sol
@@ -117,17 +117,17 @@ contract DensityTest is Test2 {
   function test_paramsTo96X32() public {
     uint res = DensityLib.paramsTo96X32({
       outbound_decimals: 6,
-      gasprice_in_gwei: 250,
-      eth_in_usdx100: 1 * 100,
-      outbound_display_in_usdx100: 1000 * 100,
+      gasprice_in_mwei: 250 * 1e3,
+      eth_in_centiusd: 1 * 100,
+      outbound_display_in_centiusd: 1000 * 100,
       cover_factor: 1000
     });
     assertEq(toString(DensityLib.from96X32(res)), "1 * 2^-2");
     res = DensityLib.paramsTo96X32({
       outbound_decimals: 18,
-      gasprice_in_gwei: 2500,
-      eth_in_usdx100: 10000 * 100,
-      outbound_display_in_usdx100: 1 * 100,
+      gasprice_in_mwei: 2500 * 1e3,
+      eth_in_centiusd: 10000 * 100,
+      outbound_display_in_centiusd: 1 * 100,
       cover_factor: 1000
     });
     assertEq(toString(DensityLib.from96X32(res)), "1.25 * 2^64");

--- a/test/core/Gatekeeping.t.sol
+++ b/test/core/Gatekeeping.t.sol
@@ -167,8 +167,10 @@ contract GatekeepingTest is MangroveTest {
   }
 
   function test_setGasprice_ceiling() public {
-    vm.expectRevert("mgv/config/gasprice/16bits");
-    mgv.setGasprice(uint(type(uint16).max) + 1);
+    // check no revert
+    mgv.setGasprice((1 << 26) - 1);
+    vm.expectRevert("mgv/config/gasprice/26bits");
+    mgv.setGasprice(1 << 26);
   }
 
   function test_set_zero_gasbase() public {
@@ -314,8 +316,9 @@ contract GatekeepingTest is MangroveTest {
   }
 
   function test_makerGasprice_wider_than_16_bits_fails_newOfferByVolume() public {
-    vm.expectRevert("mgv/writeOffer/gasprice/16bits");
-    mkr.newOfferByVolume(1, 1, 1, 1 << 16);
+    mgv.setDensity96X32(olKey, 0);
+    vm.expectRevert("mgv/writeOffer/gasprice/tooBig");
+    mkr.newOfferByVolume(1, 1, 1, 1 << 26);
   }
 
   function test_initial_allowance_is_zero() public {

--- a/test/core/MakerOperations.t.sol
+++ b/test/core/MakerOperations.t.sol
@@ -819,7 +819,7 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     mgv.setDensity96X32(olKey, 0);
     uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 0, 0);
     tkr.clean(ofr, 0.1 ether);
-    assertEq(mgv.balanceOf(address(mkr)), 1 ether - offer_gasbase * 10 ** 9, "Wrong gasbase deducted");
+    assertEq(mgv.balanceOf(address(mkr)), 1 ether - offer_gasbase * 1e6, "Wrong gasbase deducted");
   }
 
   function test_gasbase_is_deducted_2() public {
@@ -830,7 +830,7 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     mgv.setDensity96X32(olKey, 0);
     uint ofr = mkr.newOfferByVolume(1 ether, 1 ether, 0, 0);
     tkr.clean(ofr, 0.1 ether);
-    assertEq(mgv.balanceOf(address(mkr)), 1 ether - offer_gasbase * 10 ** 9, "Wrong gasbase deducted");
+    assertEq(mgv.balanceOf(address(mkr)), 1 ether - offer_gasbase * 1e6, "Wrong gasbase deducted");
   }
 
   function test_penalty_gasprice_is_mgv_gasprice() public {

--- a/test/core/MakerPosthook.t.sol
+++ b/test/core/MakerPosthook.t.sol
@@ -8,7 +8,7 @@ contract MakerPosthookTest is MangroveTest, IMaker {
   TestTaker tkr;
   uint gasreq = 200_000;
   uint ofr;
-  uint _gasprice = 50; // will cover for a gasprice of 50 gwei/gas uint
+  uint _gasprice = 50 * 1e3; // will cover for a gasprice of 50 gwei/gas uint
   uint weiBalMaker;
   bool willFail = false;
   bool makerRevert = false;
@@ -300,9 +300,9 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     expectFrom($(mgv));
     emit OfferRetract(olKey.hash(), $(this), ofr, true);
     expectFrom($(mgv));
-    emit Credit($(this), 10694160000000000);
+    emit Credit($(this), 19191494160000000);
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), $(tkr), ofr, 1 ether, 1 ether, 8505840000000000, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), $(tkr), ofr, 1 ether, 1 ether, 8505840000000, "mgv/makerRevert");
     bool success = tkr.marketOrderWithSuccess(2 ether);
     assertTrue(!success, "market order should fail");
     assertTrue(called, "PostHook not called");
@@ -389,9 +389,9 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     expectFrom($(mgv));
     emit OfferRetract(olKey.hash(), $(this), ofr, true);
     expectFrom($(mgv));
-    emit Credit($(this), 10694160000000000);
+    emit Credit($(this), 19191494160000000);
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), $(tkr), ofr, 1 ether, 1 ether, 8505840000000000, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), $(tkr), ofr, 1 ether, 1 ether, 8505840000000, "mgv/makerRevert");
     bool success = tkr.marketOrderWithSuccess(2 ether);
     assertTrue(called, "PostHook not called");
 

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -299,9 +299,9 @@ contract TakerOperationsTest is MangroveTest {
     uint beforeWei = $(this).balance;
 
     expectFrom($(mgv));
-    emit Credit($(refusemkr), 81680000000000);
+    emit Credit($(refusemkr), 81680000000);
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), $(this), ofr, 1 ether, 1 ether, 11278320000000000, "mgv/makerTransferFail");
+    emit OfferFail(olKey.hash(), $(this), ofr, 1 ether, 1 ether, 11278320000000, "mgv/makerTransferFail");
     (uint successes,) =
       mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, tick, 100_000, 1 ether)), $(this));
     assertEq(successes, 1, "clean should succeed");
@@ -333,9 +333,9 @@ contract TakerOperationsTest is MangroveTest {
     uint beforeWei = $(this).balance;
 
     expectFrom($(mgv));
-    emit Credit($(mkr), 1126680000000000);
+    emit Credit($(mkr), 1126680000000);
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), $(this), ofr, 1 ether, 1 ether, 10233320000000000, "mgv/makerTransferFail");
+    emit OfferFail(olKey.hash(), $(this), ofr, 1 ether, 1 ether, 10233320000000, "mgv/makerTransferFail");
     (uint takerGot, uint takerGave,,) = mgv.marketOrderByTick(olKey, tick, 1 ether, true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
@@ -356,9 +356,9 @@ contract TakerOperationsTest is MangroveTest {
     uint beforeWei = $(this).balance;
 
     expectFrom($(mgv));
-    emit Credit($(mkr), 2654520000000000);
+    emit Credit($(mkr), 2654520000000);
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), $(this), ofr, 1 ether, 1 ether, 8705480000000000, "mgv/makerReceiveFail");
+    emit OfferFail(olKey.hash(), $(this), ofr, 1 ether, 1 ether, 8705480000000, "mgv/makerReceiveFail");
     (uint takerGot, uint takerGave,,) = mgv.marketOrderByTick(olKey, tick, 1 ether, true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
@@ -388,9 +388,9 @@ contract TakerOperationsTest is MangroveTest {
     uint beforeWei = $(this).balance;
 
     expectFrom($(mgv));
-    emit Credit($(failmkr), 1422160000000000);
+    emit Credit($(failmkr), 1422160000000);
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), $(this), ofr, 1 ether, 1 ether, 9937840000000000, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), $(this), ofr, 1 ether, 1 ether, 9937840000000, "mgv/makerRevert");
     (uint takerGot, uint takerGave,,) = mgv.marketOrderByTick(olKey, tick, 1 ether, true);
     uint penalty = $(this).balance - beforeWei;
     assertTrue(penalty > 0, "Taker should have been compensated");
@@ -900,9 +900,9 @@ contract TakerOperationsTest is MangroveTest {
     expectFrom($(quote));
     emit Transfer($(mgv), $(failmkr), 0 ether);
     expectFrom($(mgv));
-    emit Credit($(failmkr), 1422160000000000);
+    emit Credit($(failmkr), 1422160000000);
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), $(this), ofr, 0 ether, 0 ether, 9937840000000000, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), $(this), ofr, 0 ether, 0 ether, 9937840000000, "mgv/makerRevert");
 
     expectFrom($(mgv));
     emit CleanComplete();
@@ -933,18 +933,18 @@ contract TakerOperationsTest is MangroveTest {
     expectFrom($(quote));
     emit Transfer($(mgv), $(failmkr), 0 ether);
     expectFrom($(mgv));
-    emit Credit($(failmkr), 1422160000000000);
+    emit Credit($(failmkr), 1422160000000);
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), $(this), ofr, 0 ether, 0 ether, 9937840000000000, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), $(this), ofr, 0 ether, 0 ether, 9937840000000, "mgv/makerRevert");
 
     expectFrom($(quote));
     emit Transfer($(this), $(mgv), 0 ether);
     expectFrom($(quote));
     emit Transfer($(mgv), $(failmkr), 0 ether);
     expectFrom($(mgv));
-    emit Credit($(failmkr), 1902160000000000);
+    emit Credit($(failmkr), 1902160000000);
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), $(this), ofr2, 0 ether, 0 ether, 9457840000000000, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), $(this), ofr2, 0 ether, 0 ether, 9457840000000, "mgv/makerRevert");
 
     expectFrom($(mgv));
     emit CleanComplete();
@@ -1038,9 +1038,9 @@ contract TakerOperationsTest is MangroveTest {
     expectFrom($(quote));
     emit Transfer($(mgv), $(failNonZeroMkr), 1);
     expectFrom($(mgv));
-    emit Credit($(failNonZeroMkr), 1411600000000000);
+    emit Credit($(failNonZeroMkr), 1411600000000);
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), $(otherTkr), ofr, 1, 1, 9948400000000000, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), $(otherTkr), ofr, 1, 1, 9948400000000, "mgv/makerRevert");
     expectFrom($(mgv));
     emit CleanComplete();
 

--- a/test/preprocessed/MgvGlobalTest.post.sol
+++ b/test/preprocessed/MgvGlobalTest.post.sol
@@ -23,7 +23,7 @@ contract MgvGlobalTest is Test2 {
     assertEq(packed.monitor(),monitor,"bad monitor");
     assertEq(packed.useOracle(),useOracle,"bad useOracle");
     assertEq(packed.notify(),notify,"bad notify");
-    assertEq(packed.gasprice(),cast(gasprice,16),"bad gasprice");
+    assertEq(packed.gasprice(),cast(gasprice,26),"bad gasprice");
     assertEq(packed.gasmax(),cast(gasmax,24),"bad gasmax");
     assertEq(packed.dead(),dead,"bad dead");
     assertEq(packed.maxRecursionDepth(),cast(maxRecursionDepth,8),"bad maxRecursionDepth");
@@ -90,7 +90,7 @@ contract MgvGlobalTest is Test2 {
 
       Global modified = packed.gasprice(gasprice);
 
-      assertEq(modified.gasprice(),cast(gasprice,16),"modified: bad gasprice");
+      assertEq(modified.gasprice(),cast(gasprice,26),"modified: bad gasprice");
 
       assertEq(modified.monitor(),packed.monitor(),"modified: bad monitor");
       assertEq(modified.useOracle(),packed.useOracle(),"modified: bad useOracle");

--- a/test/preprocessed/MgvOfferDetailTest.post.sol
+++ b/test/preprocessed/MgvOfferDetailTest.post.sol
@@ -23,7 +23,7 @@ contract MgvOfferDetailTest is Test2 {
     assertEq(packed.maker(),maker,"bad maker");
     assertEq(packed.gasreq(),cast(gasreq,24),"bad gasreq");
     assertEq(packed.kilo_offer_gasbase(),cast(kilo_offer_gasbase,9),"bad kilo_offer_gasbase");
-    assertEq(packed.gasprice(),cast(gasprice,16),"bad gasprice");
+    assertEq(packed.gasprice(),cast(gasprice,26),"bad gasprice");
   }
 
   /* test_set_x tests:
@@ -74,7 +74,7 @@ contract MgvOfferDetailTest is Test2 {
 
       OfferDetail modified = packed.gasprice(gasprice);
 
-      assertEq(modified.gasprice(),cast(gasprice,16),"modified: bad gasprice");
+      assertEq(modified.gasprice(),cast(gasprice,26),"modified: bad gasprice");
 
       assertEq(modified.maker(),packed.maker(),"modified: bad maker");
       assertEq(modified.gasreq(),packed.gasreq(),"modified: bad gasreq");


### PR DESCRIPTION
(also better arg names in `DensityLib.paramsTo96X32`)

To review carefully since there's a broken symmetry: to convert gwei to wei is `* 1e9`, eth to gwei is also `* 1e9`, but now that we have mwei, the conversions are:
* eth -> mwei: `* 1e12`
* mwei -> wei: `* 1e6`