### PR TITLE
ci: Use ubuntu-22.0-4core runner

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -42,7 +42,7 @@ jobs:
 
   # ==== Job: Build and test mangrove-core
   mangrove-core:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.0-4core
 
     steps:
 


### PR DESCRIPTION
I've configured a hosted runner on the org that has 16GB RAM which appears to make mangrove-core build and tests go through.

Here's a run of the new workflow: https://github.com/mangrovedao/mangrove-core/actions/runs/6349484853