### PR TITLE
Feat/consistent offer wants

### DIFF
--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -114,7 +114,7 @@ uint constant HIDE_FIELDS_FROM_MAKER_MASK = ~(OfferLib.prev_mask_inv | OfferLib.
 library OfferExtra {
   // Compute wants from tick and gives
   function wants(Offer offer) internal pure returns (uint) {
-    return offer.tick().inboundFromOutbound(offer.gives());
+    return offer.tick().inboundFromOutboundUp(offer.gives());
   }
   // Sugar to test offer liveness
   function isLive(Offer offer) internal pure returns (bool resp) {
@@ -139,7 +139,7 @@ library OfferExtra {
 library OfferUnpackedExtra {
   // Compute wants from tick and gives
   function wants(OfferUnpacked memory offer) internal pure returns (uint) {
-    return offer.tick.inboundFromOutbound(offer.gives);
+    return offer.tick.inboundFromOutboundUp(offer.gives);
   }
   // Sugar to test offer liveness
   function isLive(OfferUnpacked memory offer) internal pure returns (bool resp) {

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -482,7 +482,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
         uint offerGives = sor.offer.gives();
         uint offerWants = sor.offer.wants();
         /* <a id="MgvOfferTaking/computeVolume"></a> Volume requested depends on total gives (or wants) by taker. Let `volume = sor.takerWants` if `mor.fillWants` is true, and `volume = sor.takerGives` otherwise; note that `volume <= fillVolume` in all cases. Example with `fillWants=true`: if `offerGives < fillVolume` the first branch of the outer `if` sets `volume = offerGives` and we are done; otherwise the 1st branch of the inner if is taken and sets `volume = fillVolume` and we are done. */
-        if ((mor.fillWants && offerGives < fillVolume) || (!mor.fillWants && offerWants < fillVolume)) {
+        if ((mor.fillWants && offerGives <= fillVolume) || (!mor.fillWants && offerWants <= fillVolume)) {
           sor.takerWants = offerGives;
           sor.takerGives = offerWants;
         } else {

--- a/src/preprocessed/MgvOffer.post.sol
+++ b/src/preprocessed/MgvOffer.post.sol
@@ -38,7 +38,7 @@ uint constant HIDE_FIELDS_FROM_MAKER_MASK = ~(OfferLib.prev_mask_inv | OfferLib.
 library OfferExtra {
   // Compute wants from tick and gives
   function wants(Offer offer) internal pure returns (uint) {
-    return offer.tick().inboundFromOutbound(offer.gives());
+    return offer.tick().inboundFromOutboundUp(offer.gives());
   }
   // Sugar to test offer liveness
   function isLive(Offer offer) internal pure returns (bool resp) {
@@ -63,7 +63,7 @@ library OfferExtra {
 library OfferUnpackedExtra {
   // Compute wants from tick and gives
   function wants(OfferUnpacked memory offer) internal pure returns (uint) {
-    return offer.tick.inboundFromOutbound(offer.gives);
+    return offer.tick.inboundFromOutboundUp(offer.gives);
   }
   // Sugar to test offer liveness
   function isLive(OfferUnpacked memory offer) internal pure returns (bool resp) {

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -474,7 +474,7 @@ contract TakerOperationsTest is MangroveTest {
     assertEq(takerGot, 2 ether, "Incorrect declared delivered amount (taker)");
   }
 
-  function test_fillGives_at_0_wants_works() public {
+  function test_fillGives_at_1_wants_works() public {
     uint wants = 0;
     uint ofr = mkr.newOfferByVolume(wants, 2 ether, 100_000, 0);
     Tick tick = mgv.offers(olKey, ofr).tick();
@@ -483,7 +483,7 @@ contract TakerOperationsTest is MangroveTest {
 
     (uint takerGot, uint takerGave,,) = mgv.marketOrderByTick(olKey, tick, 10, false);
     assertTrue(mkr.makerPosthookWasCalled(ofr), "ofr posthook must be called or test is void");
-    assertEq(takerGave, 0, "Incorrect declared delivered amount (maker)");
+    assertEq(takerGave, 1, "Incorrect declared delivered amount (maker)");
     assertEq(takerGot, 2 ether, "Incorrect declared delivered amount (taker)");
   }
 


### PR DESCRIPTION
As of now:
- We round down `offer.wants()` when there's a full fill (it's up to the maker to not set a tick+volume that yields a wants of 0)
- We round up `offer.wants()` when there's a partial fill (for fairness, so the taker cannot choose a partial fill value to repeatedly give 0 to the maker while taking a nonzero amount)
- We consider that there's a partial fill when the taker-specified volume exactly matches the offer volume

So there's a possible inconsistency between what `offer.wants()` returns and what a `clean` with the exact right amounts will ask of the taker. Same if the marketOrder has a `fillVolume` that exactly matches the offer.

There are 3 ways to resolve the inconsistency:
- round up `offer.wants()` even at full fill
- round down induced `offer.wants()` at partial fill
- consider exact match to be full fills (instead of partial fills)

For consistency / simplicity, this PR picks option 3: it considers that there's a full fill when the taker-specified volume exactly matches the offer volume. It is negligibly more gas but gains in consistency.

EDIT: now also rouding up in offer.wants(), but leaving the `<=` to make code easier to read