### PR TITLE
Feat/align volumes and ticks

### DIFF
--- a/lib/Constants.sol
+++ b/lib/Constants.sol
@@ -46,7 +46,14 @@ uint constant MAX_RATIO_MANTISSA = 340256786836388094050805785052946541084;
 int constant MAX_RATIO_EXP = 0;
 uint constant MANTISSA_BITS = 128;
 uint constant MANTISSA_BITS_MINUS_ONE = 127;
-uint constant MAX_SAFE_VOLUME = 340282366920938463463374607431768211455;
+/* 
+With |tick|<=887272 and normalized mantissas on 128 bits, the maximum possible mantissa is 340282295208261841796968287475569060645, so the maximum safe volume before overflow is actually 340282438633630198193436196978374475856. 
+
+The immediate idea is to set MAX_SAFE_VOLUME to `(1<<max_safe_volume_bits)-1`, where `max_safe_volume_bits = 256-MANTISSA_BITS`, for simplicity. But we also have a `ByVolume` API, so we also need the ratios `inbound_amount/outbound_amount` to not correspond to a tick outside of the tick range. 
+
+Instead of fine-tuning MAX_SAFE_VOLUME to be exactly as big as it can be, we just set `max_safe_volume_bits = 256 - MANTISSA_BITS - 1`.
+*/
+uint constant MAX_SAFE_VOLUME = 170141183460469231731687303715884105727;
 // Without optimizer enabled it fails above 79. With optimizer and 200 runs it fails above 80. Set default a bit lower to be safe.
 uint constant INITIAL_MAX_RECURSION_DEPTH = 75;
 uint constant INITIAL_MAX_GASREQ_FOR_FAILING_OFFERS_MULTIPLIER = 3;

--- a/lib/Constants.sol
+++ b/lib/Constants.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.17;
 
+/* For all the relevant constants here, the non-literal expression that computes them is checked in `Constants.t.sol`. */
+
 uint constant ONE = 1; // useful to name it for drawing attention sometimes
 uint constant ONES = type(uint).max;
 uint constant TOPBIT = 1 << 255;
@@ -40,18 +42,18 @@ uint constant OFFER_MASK = 4294967295;
 // The tick range is the largest such that 1.0001^MAX_TICK fits on 128 bits (and thus can be multiplied by volumes)
 int constant MIN_TICK = -887272;
 int constant MAX_TICK = 887272;
+// These are reference values for what the function will return, not the most possible accurate values for the min and max tick.
 uint constant MIN_RATIO_MANTISSA = 170153974464283981435225617938057077692;
 int constant MIN_RATIO_EXP = 255;
 uint constant MAX_RATIO_MANTISSA = 340256786836388094050805785052946541084;
 int constant MAX_RATIO_EXP = 0;
+/* `MANTISSA_BITS is the number of bits used in the mantissa of normalized floats that represent ratios. 128 means we can multiply all allowed volumes by the mantissa and not overflow. */
 uint constant MANTISSA_BITS = 128;
 uint constant MANTISSA_BITS_MINUS_ONE = 127;
 /* 
 With |tick|<=887272 and normalized mantissas on 128 bits, the maximum possible mantissa is 340282295208261841796968287475569060645, so the maximum safe volume before overflow is actually 340282438633630198193436196978374475856. 
 
-The immediate idea is to set MAX_SAFE_VOLUME to `(1<<max_safe_volume_bits)-1`, where `max_safe_volume_bits = 256-MANTISSA_BITS`, for simplicity. But we also have a `ByVolume` API, so we also need the ratios `inbound_amount/outbound_amount` to not correspond to a tick outside of the tick range. 
-
-Instead of fine-tuning MAX_SAFE_VOLUME to be exactly as big as it can be, we just set `max_safe_volume_bits = 256 - MANTISSA_BITS - 1`.
+The immediate idea is to set MAX_SAFE_VOLUME to `(1<<max_safe_volume_bits)-1`, where `max_safe_volume_bits = 256-MANTISSA_BITS`, for simplicity. But we'd have `MAX_SAFE_VOLUME > 1.0001^MAX_TICK`, so a `*ByVolume` function called with `MAX_SAFE_VOLUME` and `1` as arguments would revert. To have uniform constraints on volumes everywhere, we just set `max_safe_volume_bits = 256 - MANTISSA_BITS - 1`.
 */
 uint constant MAX_SAFE_VOLUME = 170141183460469231731687303715884105727;
 // Without optimizer enabled it fails above 79. With optimizer and 200 runs it fails above 80. Set default a bit lower to be safe.

--- a/lib/Constants.sol
+++ b/lib/Constants.sol
@@ -37,26 +37,23 @@ int constant NUM_BINS = 2097152;
 
 uint constant OFFER_MASK = 4294967295;
 
-
-
-// +/- 2**20-1 because only 20 bits are examined by the tick->ratio function
-int constant MIN_TICK = -1048575;
-int constant MAX_TICK = 1048575;
-uint constant MIN_RATIO_MANTISSA = 4735129379934731672174804159539094721182826496;
-int constant MIN_RATIO_EXP = 303;
-uint constant MAX_RATIO_MANTISSA = 3441571814221581909035848501253497354125574144;
+// The tick range is the largest such that 1.0001^MAX_TICK fits on 128 bits (and thus can be multiplied by volumes)
+int constant MIN_TICK = -887272;
+int constant MAX_TICK = 887272;
+uint constant MIN_RATIO_MANTISSA = 170153974464283981435225617938057077692;
+int constant MIN_RATIO_EXP = 255;
+uint constant MAX_RATIO_MANTISSA = 340256786836388094050805785052946541084;
 int constant MAX_RATIO_EXP = 0;
-uint constant MANTISSA_BITS = 152;
-uint constant MANTISSA_BITS_MINUS_ONE = 151;
-// Maximum volume that can be multiplied by a ratio mantissa
-uint constant MAX_SAFE_VOLUME = 20282409603651670423947251286015;
+uint constant MANTISSA_BITS = 128;
+uint constant MANTISSA_BITS_MINUS_ONE = 127;
+uint constant MAX_SAFE_VOLUME = 340282366920938463463374607431768211455;
 // Without optimizer enabled it fails above 79. With optimizer and 200 runs it fails above 80. Set default a bit lower to be safe.
 uint constant INITIAL_MAX_RECURSION_DEPTH = 75;
 uint constant INITIAL_MAX_GASREQ_FOR_FAILING_OFFERS_MULTIPLIER = 3;
 
-// Price math limits the allowed ticks to a subset of the full range
-int constant MIN_BIN_ALLOWED = -1048575;
-int constant MAX_BIN_ALLOWED = 1048575;
+// Tick range limits the allowed bins to a subset of the full range
+int constant MIN_BIN_ALLOWED = MIN_TICK;
+int constant MAX_BIN_ALLOWED = MAX_TICK;
 
 // log_1.0001(2)
 uint constant LOG_BP_SHIFT = 235;

--- a/lib/TickLib.sol
+++ b/lib/TickLib.sol
@@ -184,10 +184,10 @@ library TickLib {
       log2ratio := or(log2ratio, shl(50, highbit))
     }
 
-    int log_bp_ratio = log2ratio * 127869479499801913173570;
+    int log_bp_ratio = log2ratio * 127869479499801913173571;
 
-    int tickLow = int((log_bp_ratio - 1701479891078076505009565712080972645) >> 128);
-    int tickHigh = int((log_bp_ratio + 290040965921304576580754310682015830659) >> 128);
+    int tickLow = int((log_bp_ratio - 1701496478404567508395759362389778998) >> 128);
+    int tickHigh = int((log_bp_ratio + 289637967442836606107396900709005211253) >> 128);
 
     (uint mantissaHigh, uint expHigh) = ratioFromTick(Tick.wrap(tickHigh));
 

--- a/lib/TickLib.sol
+++ b/lib/TickLib.sol
@@ -295,23 +295,23 @@ library TickLib {
   // first return value is the mantissa, second value is -exp
   function ratioFromTick(Tick tick) internal pure returns (uint man, uint exp) {
     unchecked {
-    (man, exp) = nonNormalizedRatioFromTick(tick);
-    int shiftedTick = Tick.unwrap(tick) << LOG_BP_SHIFT;
-    int log2ratio;
-    // floor log2 of ratio towards negative infinity
-    assembly ("memory-safe") {
-      log2ratio := sdiv(shiftedTick,LOG_BP_2X235)
-      log2ratio := sub(log2ratio,slt(smod(shiftedTick,LOG_BP_2X235),0))
-    }
-    int diff = log2ratio+int(exp)-int(MANTISSA_BITS_MINUS_ONE);
-    if (diff > 0) {
-      // For |tick| <= 887272, this drops at most 5 bits of precision
-      man = man >> uint(diff);
-    } else {
-      man = man << uint(-diff);
-    }
-    // For |tick| << 887272, log2ratio <= 127
-    exp = uint(int(MANTISSA_BITS_MINUS_ONE)-log2ratio);
+      (man, exp) = nonNormalizedRatioFromTick(tick);
+      int shiftedTick = Tick.unwrap(tick) << LOG_BP_SHIFT;
+      int log2ratio;
+      // floor log2 of ratio towards negative infinity
+      assembly ("memory-safe") {
+        log2ratio := sdiv(shiftedTick,LOG_BP_2X235)
+        log2ratio := sub(log2ratio,slt(smod(shiftedTick,LOG_BP_2X235),0))
+      }
+      int diff = log2ratio+int(exp)-int(MANTISSA_BITS_MINUS_ONE);
+      if (diff > 0) {
+        // For |tick| <= 887272, this drops at most 5 bits of precision
+        man = man >> uint(diff);
+      } else {
+        man = man << uint(-diff);
+      }
+      // For |tick| << 887272, log2ratio <= 127
+      exp = uint(int(MANTISSA_BITS_MINUS_ONE)-log2ratio);
     }
   }
 

--- a/lib/TickLib.sol
+++ b/lib/TickLib.sol
@@ -293,11 +293,14 @@ library TickLib {
   // return ratio from tick, as a normalized float
   // first return value is the mantissa, second value is -exp
   function ratioFromTick(Tick tick) internal pure returns (uint man, uint exp) {
+    unchecked {
     (man, exp) = nonNormalizedRatioFromTick(tick);
-    int log2ratio = (int(Tick.unwrap(tick)) << LOG_BP_SHIFT) / int(LOG_BP_2X235);
-    // floor(log) towards negative infinity
-    if (Tick.unwrap(tick) < 0 && int(Tick.unwrap(tick)) << LOG_BP_SHIFT % LOG_BP_2X235 != 0) {
-      log2ratio = log2ratio - 1;
+    int shiftedTick = Tick.unwrap(tick) << LOG_BP_SHIFT;
+    int log2ratio;
+    // floor log2 of ratio towards negative infinity
+    assembly ("memory-safe") {
+      log2ratio := sdiv(shiftedTick,LOG_BP_2X235)
+      log2ratio := sub(log2ratio,slt(smod(shiftedTick,LOG_BP_2X235),0))
     }
     int diff = log2ratio+int(exp)-int(MANTISSA_BITS_MINUS_ONE);
     if (diff > 0) {
@@ -308,6 +311,7 @@ library TickLib {
     }
     // For |tick| << 887272, log2ratio <= 127
     exp = uint(int(MANTISSA_BITS_MINUS_ONE)-log2ratio);
+    }
   }
 
   // normalize a ratio float

--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -72,7 +72,7 @@ uni.hospitable(true);
 /* Struct fields that are common to multiple structs are factored here. Multiple field names refer to offer identifiers, so the `id` field is a function that takes a name as argument. */
 
 const fields = {
-  gives: { name: "gives", bits: 128, type: "uint" },
+  gives: { name: "gives", bits: 127, type: "uint" },
   gasprice: { name: "gasprice", bits: 26, type: "uint" },
   gasreq: { name: "gasreq", bits: 24, type: "uint" },
   kilo_offer_gasbase: { name: "kilo_offer_gasbase", bits: 9, type: "uint" },
@@ -97,7 +97,7 @@ const struct_defs = {
       /* * `next` points to the immediately worse offer. The worst offer's `next` is 0. _32 bits wide_. */
       id_field("next"),
       {name:"tick",bits:21,type:"Tick",underlyingType: "int"},
-      /* * `gives` is the amount of `outbound_tkn` the offer will give if successfully executed.  _128 bits wide_. */
+      /* * `gives` is the amount of `outbound_tkn` the offer will give if successfully executed.  _127 bits wide_. */
       fields.gives,
     ],
     additionalDefinitions: `import "mgv_lib/BinLib.sol";

--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -72,7 +72,7 @@ uni.hospitable(true);
 /* Struct fields that are common to multiple structs are factored here. Multiple field names refer to offer identifiers, so the `id` field is a function that takes a name as argument. */
 
 const fields = {
-  gives: { name: "gives", bits: 96, type: "uint" },
+  gives: { name: "gives", bits: 128, type: "uint" },
   gasprice: { name: "gasprice", bits: 26, type: "uint" },
   gasreq: { name: "gasreq", bits: 24, type: "uint" },
   kilo_offer_gasbase: { name: "kilo_offer_gasbase", bits: 9, type: "uint" },
@@ -97,9 +97,7 @@ const struct_defs = {
       /* * `next` points to the immediately worse offer. The worst offer's `next` is 0. _32 bits wide_. */
       id_field("next"),
       {name:"tick",bits:21,type:"Tick",underlyingType: "int"},
-      /* * `gives` is the amount of `outbound_tkn` the offer will give if successfully executed.
-      _96 bits wide_, so assuming the usual 18 decimals, amounts can only go up to
-      10 billions. */
+      /* * `gives` is the amount of `outbound_tkn` the offer will give if successfully executed.  _128 bits wide_. */
       fields.gives,
     ],
     additionalDefinitions: `import "mgv_lib/BinLib.sol";

--- a/src/MgvOfferMaking.sol
+++ b/src/MgvOfferMaking.sol
@@ -237,7 +237,7 @@ contract MgvOfferMaking is MgvHasOffers {
       );
 
       /* The following checks are for the maker's convenience only. */
-      require(uint96(ofp.gives) == ofp.gives, "mgv/writeOffer/gives/96bits");
+      require(OfferLib.gives_check(ofp.gives), "mgv/writeOffer/gives/tooBig");
 
       uint tickSpacing = ofp.olKey.tickSpacing;
       // normalize tick to tickSpacing

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -534,7 +534,9 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
         /* We update the totals in the multiorder based on the adjusted `sor.takerWants`/`sor.takerGives`. */
         mor.totalGot += sor.takerWants;
+        require(mor.totalGot >= sor.takerWants, "mgv/totalGot/overflow");
         mor.totalGave += sor.takerGives;
+        require(mor.totalGave >= sor.takerGives, "mgv/totalGot/overflow");
       } else {
         /* In case of failure, `retdata` encodes a short [status code](#MgvOfferTaking/statusCodes), the gas used by the offer, and an arbitrary 256 bits word sent by the maker.  */
         (mgvData, gasused, makerData) = innerDecode(retdata);

--- a/src/MgvOfferTaking.sol
+++ b/src/MgvOfferTaking.sol
@@ -399,7 +399,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
         mor.maxTick = tick;
       }
       {
-        require(uint96(takerWants) == takerWants, "mgv/clean/takerWants/96bits");
+        require(takerWants <= MAX_SAFE_VOLUME, "mgv/clean/takerWants/tooBig");
         mor.fillVolume = takerWants;
       }
       mor.taker = taker;
@@ -533,13 +533,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
         }
 
         /* We update the totals in the multiorder based on the adjusted `sor.takerWants`/`sor.takerGives`. */
-        /* no overflow: sor.takerWants is on <= 104 bits */
         mor.totalGot += sor.takerWants;
-        /* sor.takerGives can be on 248 bits (max offer.gives * max ratio). Very remote overflow chances here. You would need both:
-        a) sum of offer.wants() so far to > 256 bits. With a max offerGives volume on 96 bits and a max tick of 2^20-1, wants is on 248 bits. So you'd need to go through 2^(256-248)=256 offers, which is currently above the max possible number of taken offers.
-        b) taker able to transfer more than 2^255-1 tokens, since this value is updated after the execution of the offer. It is theoretically possible if the maker sends the tokens back to the taker for instance.
-
-        Even then, you'd only be returning an undervalued totalGave value. */
         mor.totalGave += sor.takerGives;
       } else {
         /* In case of failure, `retdata` encodes a short [status code](#MgvOfferTaking/statusCodes), the gas used by the offer, and an arbitrary 256 bits word sent by the maker.  */

--- a/src/preprocessed/MgvOffer.post.sol
+++ b/src/preprocessed/MgvOffer.post.sol
@@ -87,7 +87,7 @@ library OfferLib {
   uint constant prev_bits  = 32;
   uint constant next_bits  = 32;
   uint constant tick_bits  = 21;
-  uint constant gives_bits = 128;
+  uint constant gives_bits = 127;
 
   // number of bits before each field
   uint constant prev_before  = 0           + 0;
@@ -117,7 +117,7 @@ library OfferLib {
   string constant prev_size_error  = "mgv/config/prev/32bits";
   string constant next_size_error  = "mgv/config/next/32bits";
   string constant tick_size_error  = "mgv/config/tick/21bits";
-  string constant gives_size_error = "mgv/config/gives/128bits";
+  string constant gives_size_error = "mgv/config/gives/127bits";
 
   // from packed to in-memory struct
   function to_struct(Offer __packed) internal pure returns (OfferUnpacked memory __s) { unchecked {

--- a/src/preprocessed/MgvOffer.post.sol
+++ b/src/preprocessed/MgvOffer.post.sol
@@ -87,7 +87,7 @@ library OfferLib {
   uint constant prev_bits  = 32;
   uint constant next_bits  = 32;
   uint constant tick_bits  = 21;
-  uint constant gives_bits = 96;
+  uint constant gives_bits = 128;
 
   // number of bits before each field
   uint constant prev_before  = 0           + 0;
@@ -117,7 +117,7 @@ library OfferLib {
   string constant prev_size_error  = "mgv/config/prev/32bits";
   string constant next_size_error  = "mgv/config/next/32bits";
   string constant tick_size_error  = "mgv/config/tick/21bits";
-  string constant gives_size_error = "mgv/config/gives/96bits";
+  string constant gives_size_error = "mgv/config/gives/128bits";
 
   // from packed to in-memory struct
   function to_struct(Offer __packed) internal pure returns (OfferUnpacked memory __s) { unchecked {

--- a/test-ratios/TickRatioConversion.sol
+++ b/test-ratios/TickRatioConversion.sol
@@ -51,12 +51,14 @@ abstract contract TickRatioConversionTest is Test2 {
         tick_counter = ref.tick;
       }
       // Check no tick missing
-      require(
-        tick_counter++ == ref.tick, string.concat("Missing tick ", vm.toString(ref.tick), " in file ", ratios_file)
-      );
+      require(tick_counter++ == ref.tick, string.concat("Missing tick ", vm.toString(ref.tick)));
+
+      (uint cur_sig, uint cur_exp) = TickLib.ratioFromTick(Tick.wrap(ref.tick));
+
+      // Check normalization
+      assertEq(BitLib.fls(cur_sig), MANTISSA_BITS_MINUS_ONE, string.concat("Wrong fls ", vm.toString(ref.tick)));
 
       // Compare to reference
-      (uint cur_sig, uint cur_exp) = TickLib.ratioFromTick(Tick.wrap(ref.tick));
       // compute abs error relative to reference
       (uint big, uint small) = cur_sig > ref_sig ? (cur_sig, ref_sig) : (ref_sig, cur_sig);
       uint absRelErr = (big - small) * RELATIVE_ERROR_THRESHOLD / ref_sig;

--- a/test-ratios/generate_ratios_worker.js
+++ b/test-ratios/generate_ratios_worker.js
@@ -11,10 +11,10 @@ const config = {
 
 const M = Math.create(Math.all, config);
 
-const MIN_TICK = -1048575;
-const MAX_TICK = 1048575;
+const MIN_TICK = -887272;
+const MAX_TICK = 887272;
 const TICK_SPAN = MAX_TICK - MIN_TICK;
-const SIGLOG2 = 151;
+const SIGLOG2 = 127;
 
 const priceToFloat = (price) => {
   const l2 = M.floor(M.log2(price));

--- a/test/core/Constant.t.sol
+++ b/test/core/Constant.t.sol
@@ -37,7 +37,7 @@ contract ConstantsTest is MangroveTest {
     assertGt(LEVEL_SIZE, 0, "level size too small");
   }
 
-  // checks that there is no overflow
+  // checks that there is no overflow, assert is useless but should prevent optimizing away
   function test_maxSafeVolumeIsSafeLowLevel() public {
     assertGt(MAX_SAFE_VOLUME * ((1 << MANTISSA_BITS) - 1), 0);
   }
@@ -56,6 +56,10 @@ contract ConstantsTest is MangroveTest {
   function test_log_bp_shift() public {
     assertLe(BitLib.fls(uint(MAX_TICK)), 256 - LOG_BP_SHIFT, "MAX_TICK");
     assertLe(BitLib.fls(uint(-MIN_TICK)), 256 - LOG_BP_SHIFT, "MIN_TICK");
+  }
+
+  function test_offer_limit_is_volume_limit() public {
+    assertEq((1 << OfferLib.gives_bits) - 1, MAX_SAFE_VOLUME);
   }
 
   // Since constant expressions are (as of solidity 0.8.21) not evaluated at compile time, we write all constants in Constants.sol as literals and test their values here:

--- a/test/core/Constant.t.sol
+++ b/test/core/Constant.t.sol
@@ -38,7 +38,7 @@ contract ConstantsTest is MangroveTest {
   }
 
   // checks that there is no overflow, assert is useless but should prevent optimizing away
-  function test_maxSafeVolumeIsSafeLowLevel() public {
+  function test_max_safe_volume_is_safe_low_level() public {
     assertGt(MAX_SAFE_VOLUME * ((1 << MANTISSA_BITS) - 1), 0);
   }
 
@@ -78,8 +78,7 @@ contract ConstantsTest is MangroveTest {
     assertEq(NUM_BINS, NUM_LEAFS * LEAF_SIZE, "NUM_BINS");
     assertEq(OFFER_MASK, ONES >> (256 - OFFER_BITS), "OFFER_MASK");
     assertEq(MANTISSA_BITS_MINUS_ONE, MANTISSA_BITS - 1, "MANTISSA_BITS_MINUS_ONE");
-    // With |tick|<887272 and normalized mantissas on 128 bits, the maximum possible mantissa is 340282295208261841796968287475569060645, so the max safe volume is 340282438633630198193436196978374475856. We set it to `(1<<128)-1` for simplicity.
-    assertEq(MAX_SAFE_VOLUME, (1 << (256 - MANTISSA_BITS)) - 1, "MAX_SAFE_VOLUME");
+    assertEq(MAX_SAFE_VOLUME, (1 << (256 - MANTISSA_BITS - 1)) - 1, "MAX_SAFE_VOLUME");
     assertEq(MIN_BIN_ALLOWED, MIN_TICK, "MIN_BIN_ALLOWED");
     assertEq(MAX_BIN_ALLOWED, MAX_TICK, "MAX_BIN_ALLOWED");
   }

--- a/test/core/Constant.t.sol
+++ b/test/core/Constant.t.sol
@@ -73,9 +73,8 @@ contract ConstantsTest is MangroveTest {
     assertEq(NUM_LEAFS, NUM_LEVEL3 * LEVEL_SIZE, "NUM_LEAFS");
     assertEq(NUM_BINS, NUM_LEAFS * LEAF_SIZE, "NUM_BINS");
     assertEq(OFFER_MASK, ONES >> (256 - OFFER_BITS), "OFFER_MASK");
-    assertEq(MIN_TICK, -((1 << 20) - 1), "MIN_TICK");
-    assertEq(MAX_TICK, -MIN_TICK, "MAX_TICK");
     assertEq(MANTISSA_BITS_MINUS_ONE, MANTISSA_BITS - 1, "MANTISSA_BITS_MINUS_ONE");
+    // With |tick|<887272 and normalized mantissas on 128 bits, the maximum possible mantissa is 340282295208261841796968287475569060645, so the max safe volume is 340282438633630198193436196978374475856. We set it to `(1<<128)-1` for simplicity.
     assertEq(MAX_SAFE_VOLUME, (1 << (256 - MANTISSA_BITS)) - 1, "MAX_SAFE_VOLUME");
     assertEq(MIN_BIN_ALLOWED, MIN_TICK, "MIN_BIN_ALLOWED");
     assertEq(MAX_BIN_ALLOWED, MAX_TICK, "MAX_BIN_ALLOWED");

--- a/test/core/Field.t.sol
+++ b/test/core/Field.t.sol
@@ -150,11 +150,11 @@ contract FieldTest is MangroveTest {
     uint exp;
 
     //inboundFromOutboundUp
-    (sig, exp) = TickLib.nonNormalizedRatioFromTick(tick);
+    (sig, exp) = TickLib.ratioFromTick(tick);
     assertEq(tick.inboundFromOutboundUp(amt), divExpUp_spec(sig * amt, exp));
 
     //outboundFromInboundUp
-    (sig, exp) = TickLib.nonNormalizedRatioFromTick(Tick.wrap(-Tick.unwrap(tick)));
+    (sig, exp) = TickLib.ratioFromTick(Tick.wrap(-Tick.unwrap(tick)));
     assertEq(tick.outboundFromInboundUp(amt), divExpUp_spec(sig * amt, exp));
   }
 

--- a/test/core/Gatekeeping.t.sol
+++ b/test/core/Gatekeeping.t.sol
@@ -251,11 +251,6 @@ contract GatekeepingTest is MangroveTest {
     mgv.newOfferByVolume(olKey, 1 ether, 1 ether, 0, 0);
   }
 
-  function test_makerGives_wider_than_96_bits_fails_newOfferByVolume() public {
-    vm.expectRevert("mgv/writeOffer/gives/96bits");
-    mkr.newOfferByVolume(1, 1 << 96, 10_000);
-  }
-
   function test_makerGasreq_wider_than_24_bits_fails_newOfferByVolume() public {
     vm.expectRevert("mgv/writeOffer/gasreq/tooHigh");
     mkr.newOfferByVolume(1, 1, 1 << 24);

--- a/test/core/Gatekeeping.t.sol
+++ b/test/core/Gatekeeping.t.sol
@@ -188,12 +188,12 @@ contract GatekeepingTest is MangroveTest {
   }
 
   function test_makerWants_too_big_fails_newOfferByVolume() public {
-    vm.expectRevert("ratioFromVolumes/inbound/tooBig");
+    vm.expectRevert("mgv/ratioFromVol/inbound/tooBig");
     mkr.newOfferByVolume(MAX_SAFE_VOLUME + 1, 1 ether, 10_000, 0);
   }
 
   function test_makerGives_too_big_fails_newOfferByVolume() public {
-    vm.expectRevert("ratioFromVolumes/outbound/tooBig");
+    vm.expectRevert("mgv/ratioFromVol/outbound/tooBig");
     mkr.newOfferByVolume(1 ether, MAX_SAFE_VOLUME + 1, 10_000, 0);
   }
 
@@ -935,19 +935,5 @@ contract GatekeepingTest is MangroveTest {
     deal(address(token), address(mgv), amount - 1);
     vm.expectRevert("mgv/withdrawERC20Fail");
     mgv.withdrawERC20(address(token), amount);
-  }
-
-  function test_marketOrderByTick_extrema() public {
-    vm.expectRevert("mgv/mOrder/tick/outOfRange");
-    mgv.marketOrderByTick(olKey, Tick.wrap(MAX_TICK + 1), 100, true);
-    vm.expectRevert("mgv/mOrder/tick/outOfRange");
-    mgv.marketOrderByTick(olKey, Tick.wrap(MIN_TICK - 1), 100, true);
-  }
-
-  function test_marketOrderForByTick_extrema(address taker) public {
-    vm.expectRevert("mgv/mOrder/tick/outOfRange");
-    mgv.marketOrderForByTick(olKey, Tick.wrap(MAX_TICK + 1), 100, true, taker);
-    vm.expectRevert("mgv/mOrder/tick/outOfRange");
-    mgv.marketOrderForByTick(olKey, Tick.wrap(MIN_TICK - 1), 100, true, taker);
   }
 }

--- a/test/core/MakerOperations.t.sol
+++ b/test/core/MakerOperations.t.sol
@@ -1067,7 +1067,16 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     mgv.updateOfferByTick(olKey, Tick.wrap(0), 1 ether, 100_000, 30, ofrId);
   }
 
-  function test_new_offer_extremas() public {
+  function test_new_offer_extremas_ok() public {
+    mkr.provisionMgv(1 ether);
+    mgv.setDensity96X32(olKey, 0);
+    uint ofr = mkr.newOfferByTick(Tick.wrap(0), MAX_SAFE_VOLUME, 100_000, 0);
+    mkr.updateOfferByTick(Tick.wrap(0), MAX_SAFE_VOLUME, 100_000, 0, ofr);
+    mkr.updateOfferByTick(Tick.wrap(MAX_TICK), 1, 100_000, 0, ofr);
+    mkr.newOfferByTick(Tick.wrap(MAX_TICK), 1, 100_000, 0);
+  }
+
+  function test_new_offer_extremas_ko() public {
     mgv.setDensity96X32(olKey, 0);
     vm.expectRevert("mgv/writeOffer/gives/tooBig");
     uint ofr = mkr.newOfferByTick(Tick.wrap(0), MAX_SAFE_VOLUME + 1, 100_000, 0);

--- a/test/core/MakerOperations.t.sol
+++ b/test/core/MakerOperations.t.sol
@@ -1066,4 +1066,16 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     vm.expectRevert("mgv/updateOffer/unauthorized");
     mgv.updateOfferByTick(olKey, Tick.wrap(0), 1 ether, 100_000, 30, ofrId);
   }
+
+  function test_new_offer_extremas() public {
+    mgv.setDensity96X32(olKey, 0);
+    vm.expectRevert("mgv/writeOffer/gives/tooBig");
+    uint ofr = mkr.newOfferByTick(Tick.wrap(0), MAX_SAFE_VOLUME + 1, 100_000, 0);
+    vm.expectRevert("mgv/writeOffer/gives/tooBig");
+    mkr.updateOfferByTick(Tick.wrap(0), MAX_SAFE_VOLUME + 1, 100_000, 0, ofr);
+    vm.expectRevert("mgv/writeOffer/tick/outOfRange");
+    mkr.updateOfferByTick(Tick.wrap(MAX_TICK + 1), 1, 100_000, 0, ofr);
+    vm.expectRevert("mgv/writeOffer/tick/outOfRange");
+    mkr.newOfferByTick(Tick.wrap(MAX_TICK + 1), 1, 100_000, 0);
+  }
 }

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -708,15 +708,15 @@ contract TakerOperationsTest is MangroveTest {
   function test_marketOrderByTick_extrema_ko() public {
     vm.expectRevert("mgv/mOrder/tick/outOfRange");
     mgv.marketOrderByTick(olKey, Tick.wrap(MAX_TICK + 1), 100, true);
+
     vm.expectRevert("mgv/mOrder/tick/outOfRange");
     mgv.marketOrderByTick(olKey, Tick.wrap(MIN_TICK - 1), 100, true);
-  }
 
-  function test_marketOrderForByTick_extrema_ko(address taker) public {
     vm.expectRevert("mgv/mOrder/tick/outOfRange");
-    mgv.marketOrderForByTick(olKey, Tick.wrap(MAX_TICK + 1), 100, true, taker);
+    mgv.marketOrderForByTick(olKey, Tick.wrap(MAX_TICK + 1), 100, true, address(0));
+
     vm.expectRevert("mgv/mOrder/tick/outOfRange");
-    mgv.marketOrderForByTick(olKey, Tick.wrap(MIN_TICK - 1), 100, true, taker);
+    mgv.marketOrderForByTick(olKey, Tick.wrap(MIN_TICK - 1), 100, true, address(0));
   }
 
   function test_clean_with_0_wants_ejects_offer() public {

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -658,15 +658,65 @@ contract TakerOperationsTest is MangroveTest {
     }
   }
 
-  function test_marketOrderByVolume_takerGives_extrema() public {
-    vm.expectRevert("ratioFromVolumes/inbound/tooBig");
+  // none should revert
+  function test_marketOrderByVolume_takerGives_extrema_volumes_ok() public {
+    mgv.marketOrderByVolume(olKey, MAX_SAFE_VOLUME, 1, true);
+    mgv.marketOrderByVolume(olKey, MAX_SAFE_VOLUME, 1, false);
+    mgv.marketOrderByVolume(olKey, 1, MAX_SAFE_VOLUME, true);
+    mgv.marketOrderByVolume(olKey, 1, MAX_SAFE_VOLUME, false);
+    mgv.marketOrderForByVolume(olKey, MAX_SAFE_VOLUME, 1, true, address(this));
+    mgv.marketOrderForByVolume(olKey, MAX_SAFE_VOLUME, 1, false, address(this));
+    mgv.marketOrderForByVolume(olKey, 1, MAX_SAFE_VOLUME, true, address(this));
+    mgv.marketOrderForByVolume(olKey, 1, MAX_SAFE_VOLUME, false, address(this));
+  }
+
+  function test_marketOrderByVolume_takerGives_extrema_ko() public {
+    vm.expectRevert("mgv/ratioFromVol/inbound/tooBig");
     mgv.marketOrderByVolume(olKey, 0, MAX_SAFE_VOLUME + 1, true);
-    vm.expectRevert("ratioFromVolumes/outbound/tooBig");
+
+    vm.expectRevert("mgv/ratioFromVol/outbound/tooBig");
     mgv.marketOrderByVolume(olKey, MAX_SAFE_VOLUME + 1, 0, true);
-    vm.expectRevert("ratioFromVolumes/inbound/tooBig");
+
+    vm.expectRevert("mgv/ratioFromVol/inbound/tooBig");
     mgv.marketOrderByVolume(olKey, 0, MAX_SAFE_VOLUME + 1, false);
-    vm.expectRevert("ratioFromVolumes/outbound/tooBig");
+
+    vm.expectRevert("mgv/ratioFromVol/outbound/tooBig");
     mgv.marketOrderByVolume(olKey, MAX_SAFE_VOLUME + 1, 0, false);
+
+    vm.expectRevert("mgv/ratioFromVol/inbound/tooBig");
+    mgv.marketOrderForByVolume(olKey, 0, MAX_SAFE_VOLUME + 1, true, address(0));
+
+    vm.expectRevert("mgv/ratioFromVol/outbound/tooBig");
+    mgv.marketOrderForByVolume(olKey, MAX_SAFE_VOLUME + 1, 0, true, address(0));
+
+    vm.expectRevert("mgv/ratioFromVol/inbound/tooBig");
+    mgv.marketOrderForByVolume(olKey, 0, MAX_SAFE_VOLUME + 1, false, address(0));
+
+    vm.expectRevert("mgv/ratioFromVol/outbound/tooBig");
+    mgv.marketOrderForByVolume(olKey, MAX_SAFE_VOLUME + 1, 0, false, address(0));
+  }
+
+  function test_marketOrderByTick_extrema_volume_ok() public {
+    mgv.marketOrderByTick(olKey, Tick.wrap(0), MAX_SAFE_VOLUME, true);
+  }
+
+  function test_marketOrderByTick_extrema_volume_ko() public {
+    vm.expectRevert("mgv/mOrder/fillVolume/tooBig");
+    mgv.marketOrderByTick(olKey, Tick.wrap(0), MAX_SAFE_VOLUME + 1, true);
+  }
+
+  function test_marketOrderByTick_extrema_ko() public {
+    vm.expectRevert("mgv/mOrder/tick/outOfRange");
+    mgv.marketOrderByTick(olKey, Tick.wrap(MAX_TICK + 1), 100, true);
+    vm.expectRevert("mgv/mOrder/tick/outOfRange");
+    mgv.marketOrderByTick(olKey, Tick.wrap(MIN_TICK - 1), 100, true);
+  }
+
+  function test_marketOrderForByTick_extrema_ko(address taker) public {
+    vm.expectRevert("mgv/mOrder/tick/outOfRange");
+    mgv.marketOrderForByTick(olKey, Tick.wrap(MAX_TICK + 1), 100, true, taker);
+    vm.expectRevert("mgv/mOrder/tick/outOfRange");
+    mgv.marketOrderForByTick(olKey, Tick.wrap(MIN_TICK - 1), 100, true, taker);
   }
 
   function test_clean_with_0_wants_ejects_offer() public {

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -802,10 +802,11 @@ contract TakerOperationsTest is MangroveTest {
     assertTrue(mgv.best(olKey) == ofr, "clean must have left ofr in the book");
   }
 
-  function test_gives_volume_above_96bits_fails_clean() public {
+  function test_gives_volume_tooBig_fails_clean() public {
     uint ofr = failmkr.newOfferByTick(Tick.wrap(0), 1 ether, 100_000);
-    (uint successes,) =
-      mgv.cleanByImpersonation(olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, Tick.wrap(0), 0, 1 << 96)), $(this));
+    (uint successes,) = mgv.cleanByImpersonation(
+      olKey, wrap_dynamic(MgvLib.CleanTarget(ofr, Tick.wrap(0), 0, MAX_SAFE_VOLUME + 1)), $(this)
+    );
     assertEq(successes, 0, "cleaning should have failed");
     assertTrue(mgv.best(olKey) == ofr, "clean must have left ofr in the book");
   }

--- a/test/core/TickAndBin.t.sol
+++ b/test/core/TickAndBin.t.sol
@@ -47,6 +47,10 @@ contract TickAndBinTest is MangroveTest {
   }
 
   function test_ratioFromTick() public {
+    // The expected values given below are computed by doing:
+    // let price = 1.0001^tick
+    // let sig = round(price * 2^exp) with exp chosen such that sig uses 128 bits
+    // add or remove as necessary to match the error of the `ratioFromTick` function
     inner_test_ratioFromTick({
       tick: Tick.wrap(MAX_TICK),
       expected_sig: MAX_RATIO_MANTISSA,

--- a/test/core/TickAndBin.t.sol
+++ b/test/core/TickAndBin.t.sol
@@ -133,6 +133,30 @@ contract TickAndBinTest is MangroveTest {
     assertEq(Bin.wrap(bin).level2Index(), index);
   }
 
+  function test_normalizeRatio_ko() public {
+    vm.expectRevert("mgv/normalizeRatio/mantissaIs0");
+    TickLib.normalizeRatio(0, 0);
+    vm.expectRevert("mgv/normalizeRatio/lowExp");
+    TickLib.normalizeRatio(type(uint).max, 0);
+  }
+
+  function test_tickFromNormalizedRatio_ko() public {
+    vm.expectRevert("mgv/tickFromRatio/tooLow");
+    TickLib.tickFromNormalizedRatio(MIN_RATIO_MANTISSA - 1, uint(MIN_RATIO_EXP));
+    vm.expectRevert("mgv/tickFromRatio/tooLow");
+    TickLib.tickFromNormalizedRatio(MIN_RATIO_MANTISSA, uint(MIN_RATIO_EXP + 1));
+    vm.expectRevert("mgv/tickFromRatio/tooHigh");
+    TickLib.tickFromNormalizedRatio(MAX_RATIO_MANTISSA + 1, uint(MAX_RATIO_EXP));
+    vm.expectRevert("mgv/tickFromRatio/tooHigh");
+    TickLib.tickFromNormalizedRatio(MAX_RATIO_MANTISSA, uint(MAX_RATIO_EXP - 1));
+  }
+
+  // check no revert
+  function test_tickFromNormalizedRatio_ok() public pure {
+    TickLib.tickFromNormalizedRatio(MIN_RATIO_MANTISSA, uint(MIN_RATIO_EXP));
+    TickLib.tickFromNormalizedRatio(MAX_RATIO_MANTISSA, uint(MAX_RATIO_EXP));
+  }
+
   function test_bestBinFromBranch_matches_positions_accessor(
     uint binPosInLeaf,
     uint _level3,

--- a/test/core/TickAndBin.t.sol
+++ b/test/core/TickAndBin.t.sol
@@ -48,33 +48,40 @@ contract TickAndBinTest is MangroveTest {
 
   function test_ratioFromTick() public {
     inner_test_ratioFromTick({
-      tick: Tick.wrap(2 ** 20 - 1),
-      expected_sig: 3441571814221581909035848501253497354125574144,
-      expected_exp: 0
+      tick: Tick.wrap(MAX_TICK),
+      expected_sig: MAX_RATIO_MANTISSA,
+      expected_exp: uint(MAX_RATIO_EXP)
     });
 
     inner_test_ratioFromTick({
+      tick: Tick.wrap(MIN_TICK),
+      expected_sig: MIN_RATIO_MANTISSA,
+      expected_exp: uint(MIN_RATIO_EXP)
+    });
+
+    // The +12 is the error
+    inner_test_ratioFromTick({
       tick: Tick.wrap(138162),
-      expected_sig: 5444510673556857440102348422228887810808479744,
-      expected_exp: 132
+      expected_sig: 324518124673179235464474464787774551547 + 12,
+      expected_exp: 108
     });
 
     inner_test_ratioFromTick({
       tick: Tick.wrap(-1),
-      expected_sig: 5708419928830956428590284849313049240594808832,
-      expected_exp: 152
+      expected_sig: 340248342086729790484326174814286782777,
+      expected_exp: 128
     });
 
     inner_test_ratioFromTick({
       tick: Tick.wrap(0),
-      expected_sig: 2854495385411919762116571938898990272765493248,
-      expected_exp: 151
+      expected_sig: 170141183460469231731687303715884105728,
+      expected_exp: 127
     });
 
     inner_test_ratioFromTick({
       tick: Tick.wrap(1),
-      expected_sig: 2854780834950460954092783596092880171791548416,
-      expected_exp: 151
+      expected_sig: 170158197578815278654860472446255694138,
+      expected_exp: 127
     });
   }
 

--- a/test/core/ticktree/TickTreeMarketOrder.t.sol
+++ b/test/core/ticktree/TickTreeMarketOrder.t.sol
@@ -166,7 +166,7 @@ contract TickTreeMarketOrderTest is TickTreeTest {
     run_market_order_scenario(
       MarketOrderScenario({
         lowerBin: BinListScenario({bin: Bin.wrap(0), size: 0, offersToTake: 0}),
-        middleBin: BinListScenario({bin: Bin.wrap(-1048575), size: 2, offersToTake: 2}),
+        middleBin: BinListScenario({bin: BIN_MIN_ALLOWED, size: 2, offersToTake: 2}),
         higherBin: BinListScenario({bin: Bin.wrap(0), size: 0, offersToTake: 0})
       }),
       true

--- a/test/preprocessed/MgvOfferTest.post.sol
+++ b/test/preprocessed/MgvOfferTest.post.sol
@@ -23,7 +23,7 @@ contract MgvOfferTest is Test2 {
     assertEq(packed.prev(),cast(prev,32),"bad prev");
     assertEq(packed.next(),cast(next,32),"bad next");
     assertEq(Tick.unwrap(packed.tick()),cast(Tick.unwrap(tick),21),"bad tick");
-    assertEq(packed.gives(),cast(gives,128),"bad gives");
+    assertEq(packed.gives(),cast(gives,127),"bad gives");
   }
 
   /* test_set_x tests:
@@ -74,7 +74,7 @@ contract MgvOfferTest is Test2 {
 
       Offer modified = packed.gives(gives);
 
-      assertEq(modified.gives(),cast(gives,128),"modified: bad gives");
+      assertEq(modified.gives(),cast(gives,127),"modified: bad gives");
 
       assertEq(modified.prev(),packed.prev(),"modified: bad prev");
       assertEq(modified.next(),packed.next(),"modified: bad next");

--- a/test/preprocessed/MgvOfferTest.post.sol
+++ b/test/preprocessed/MgvOfferTest.post.sol
@@ -23,7 +23,7 @@ contract MgvOfferTest is Test2 {
     assertEq(packed.prev(),cast(prev,32),"bad prev");
     assertEq(packed.next(),cast(next,32),"bad next");
     assertEq(Tick.unwrap(packed.tick()),cast(Tick.unwrap(tick),21),"bad tick");
-    assertEq(packed.gives(),cast(gives,96),"bad gives");
+    assertEq(packed.gives(),cast(gives,128),"bad gives");
   }
 
   /* test_set_x tests:
@@ -74,7 +74,7 @@ contract MgvOfferTest is Test2 {
 
       Offer modified = packed.gives(gives);
 
-      assertEq(modified.gives(),cast(gives,96),"modified: bad gives");
+      assertEq(modified.gives(),cast(gives,128),"modified: bad gives");
 
       assertEq(modified.prev(),packed.prev(),"modified: bad prev");
       assertEq(modified.next(),packed.next(),"modified: bad next");


### PR DESCRIPTION
- tickrange is now (like uniswap -887272;887272. It's the largest tickrange such that the resulting prices fit in 128 bits.
- volumes (`fillVolume`, `takerWants`, `takerGives`, `offer.gives`) are on 127 bits
- tick math adjusted
- some solidity->assembly optimizations
- error messages adjusted, tests added