### PR TITLE
Configuration scripts for new deployments

### DIFF
--- a/addresses/context/arbitrum.json
+++ b/addresses/context/arbitrum.json
@@ -18,5 +18,13 @@
   {
     "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
     "name": "WETH"
+  },
+  {
+    "address": "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+    "name": "USDC"
+  },
+  {
+    "address": "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
+    "name": "USDT"
   }
 ]

--- a/script/core/ActivateMarket.s.sol
+++ b/script/core/ActivateMarket.s.sol
@@ -14,6 +14,7 @@ import {ActivateSemibook} from "./ActivateSemibook.s.sol";
  TKN1_IN_GWEI=$(cast --to-wei $(bc -l <<< 1/$NATIVE_IN_USDC) gwei) \
  TKN2_IN_GWEI=$(cast --to-wei $(bc -l <<< 1/$NATIVE_IN_ETH) gwei) \
  FEE=30 \
+ COVER_FACTOR=1000 \
  forge script --fork-url mumbai ActivateMarket*/
 
 contract ActivateMarket is Deployer {
@@ -25,7 +26,8 @@ contract ActivateMarket is Deployer {
       tkn2: IERC20(envAddressOrName("TKN2")),
       tkn1_in_gwei: vm.envUint("TKN1_IN_GWEI"),
       tkn2_in_gwei: vm.envUint("TKN2_IN_GWEI"),
-      fee: vm.envUint("FEE")
+      fee: vm.envUint("FEE"),
+      coverFactor: vm.envUint("COVER_FACTOR")
     });
   }
 
@@ -54,10 +56,11 @@ contract ActivateMarket is Deployer {
     IERC20 tkn2,
     uint tkn1_in_gwei,
     uint tkn2_in_gwei,
-    uint fee
+    uint fee,
+    uint coverFactor
   ) public {
     (MgvStructs.GlobalPacked global,) = mgv.config(address(0), address(0));
-    innerRun(mgv, global.gasprice(), reader, tkn1, tkn2, tkn1_in_gwei, tkn2_in_gwei, fee);
+    innerRun(mgv, global.gasprice(), reader, tkn1, tkn2, tkn1_in_gwei, tkn2_in_gwei, fee, coverFactor);
   }
 
   /**
@@ -72,7 +75,8 @@ contract ActivateMarket is Deployer {
     IERC20 tkn2,
     uint tkn1_in_gwei,
     uint tkn2_in_gwei,
-    uint fee
+    uint fee,
+    uint coverFactor
   ) public {
     new ActivateSemibook().innerRun({
       mgv: mgv,
@@ -80,7 +84,8 @@ contract ActivateMarket is Deployer {
       outbound_tkn: tkn1,
       inbound_tkn: tkn2,
       outbound_in_gwei: tkn1_in_gwei,
-      fee: fee
+      fee: fee,
+      coverFactor: coverFactor
     });
 
     new ActivateSemibook().innerRun({
@@ -89,7 +94,8 @@ contract ActivateMarket is Deployer {
       outbound_tkn: tkn2,
       inbound_tkn: tkn1,
       outbound_in_gwei: tkn2_in_gwei,
-      fee: fee
+      fee: fee,
+      coverFactor: coverFactor
     });
 
     new UpdateMarket().innerRun({tkn0: tkn1, tkn1: tkn2, reader: reader});

--- a/script/deployers/EvalMarketParameters.s.sol
+++ b/script/deployers/EvalMarketParameters.s.sol
@@ -5,7 +5,7 @@ import {ToyENS} from "mgv_lib/ToyENS.sol";
 
 import {Deployer} from "mgv_script/lib/Deployer.sol";
 
-import {ActivateUtils, IERC20} from "mgv_script/core/ActivateSemiBook.s.sol";
+import {ActivateUtils, IERC20} from "mgv_script/core/ActivateSemibook.s.sol";
 
 import {console} from "forge-std/console.sol";
 

--- a/script/deployers/EvalMarketParameters.s.sol
+++ b/script/deployers/EvalMarketParameters.s.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier:	AGPL-3.0
+pragma solidity ^0.8.13;
+
+import {ToyENS} from "mgv_lib/ToyENS.sol";
+
+import {Deployer} from "mgv_script/lib/Deployer.sol";
+
+import {ActivateUtils, IERC20} from "mgv_script/core/ActivateSemiBook.s.sol";
+
+import {console} from "forge-std/console.sol";
+
+/**
+ * This scripts logs gasbase and density suggested values in order to activate the (TOKEN0, TOKEN1) market using a gasprice override to compute density
+ *
+ * TOKEN0 the name of the first token
+ * TOKEN1 the name of the second token
+ * NATIVE_IN_USD the price of a native token in USD with fixed decimals precision (say n)
+ * TOKEN[0/1]_IN_USD the price of token[0/1] in USD with the n decimals precision
+ * GASPRICE_OVERRIDE is the gasprice (in gwei) to consider to compute density
+ * COVER_FACTOR to compute density, i.e density =
+ *
+ *
+ * usage with Native token being AETH (with n=1):
+ * GASPRICE_OVERRIDE=1 NATIVE_IN_USD=1600 TOKEN0=USDC TOKEN1=USDT TOKEN0_IN_USD=1 TOKEN1_IN_USD=1 COVER_FACTOR=100 forge script EvalMarketParameters --fork-url arbitrum
+ */
+
+contract EvalMarketParameters is Deployer, ActivateUtils {
+  uint nativePrice;
+
+  function run() public {
+    nativePrice = vm.envUint("NATIVE_IN_USD");
+    uint gaspriceOverride = vm.envUint("GASPRICE_OVERRIDE");
+    IERC20 token0 = IERC20(envAddressOrName("TOKEN0"));
+    IERC20 token1 = IERC20(envAddressOrName("TOKEN1"));
+    uint price0 = vm.envUint("TOKEN0_IN_USD");
+    uint price1 = vm.envUint("TOKEN1_IN_USD");
+    uint coverFactor = vm.envUint("COVER_FACTOR");
+
+    innerRun(token0, token1, price0, price1, gaspriceOverride, coverFactor);
+  }
+
+  function toGweiOfNative(uint price) internal view returns (uint) {
+    return (price * 10 ** 9) / nativePrice;
+  }
+
+  function innerRun(IERC20 token0, IERC20 token1, uint price0, uint price1, uint gaspriceOverride, uint coverFactor)
+    public
+  {
+    uint gasbase = evaluateGasbase(token0, token1);
+    console.log("gasbase:", gasbase);
+    uint density0 = evaluateDensity(token0, coverFactor, gaspriceOverride, toGweiOfNative(price0));
+    console.log("density for outbound %s: %d", token0.symbol(), density0);
+    uint density1 = evaluateDensity(token1, coverFactor, gaspriceOverride, toGweiOfNative(price1));
+    console.log("density for outbound %s: %d", token1.symbol(), density1);
+  }
+}

--- a/script/deployers/MumbaiActivateMarket.s.sol
+++ b/script/deployers/MumbaiActivateMarket.s.sol
@@ -68,7 +68,8 @@ contract MumbaiActivateMarket is Deployer {
       tkn2: token1,
       tkn1_in_gwei: toGweiOfMatic(price0),
       tkn2_in_gwei: toGweiOfMatic(price1),
-      fee: 0
+      fee: 0,
+      coverFactor: 1000
     });
 
     new ActivateMangroveOrder().innerRun({

--- a/script/deployers/MumbaiMangroveFullTestnetDeployer.s.sol
+++ b/script/deployers/MumbaiMangroveFullTestnetDeployer.s.sol
@@ -81,7 +81,8 @@ contract MumbaiMangroveFullTestnetDeployer is Deployer {
       tkn2: usdc,
       tkn1_in_gwei: toGweiOfMatic(prices[0]),
       tkn2_in_gwei: toGweiOfMatic(prices[1]),
-      fee: 0
+      fee: 0,
+      coverFactor: 1000
     });
     new ActivateMarket().innerRun({
       mgv: mgv,
@@ -91,7 +92,8 @@ contract MumbaiMangroveFullTestnetDeployer is Deployer {
       tkn2: dai,
       tkn1_in_gwei: toGweiOfMatic(prices[2]),
       tkn2_in_gwei: toGweiOfMatic(prices[0]),
-      fee: 0
+      fee: 0,
+      coverFactor: 1000
     });
     new ActivateMarket().innerRun({
       mgv: mgv,
@@ -101,7 +103,8 @@ contract MumbaiMangroveFullTestnetDeployer is Deployer {
       tkn2: usdc,
       tkn1_in_gwei: toGweiOfMatic(prices[2]),
       tkn2_in_gwei: toGweiOfMatic(prices[1]),
-      fee: 0
+      fee: 0,
+      coverFactor: 1000
     });
 
     // Activate MangroveOrder on markets

--- a/script/toy/MangroveJs.s.sol
+++ b/script/toy/MangroveJs.s.sol
@@ -112,10 +112,10 @@ contract MangroveJsDeploy is Deployer {
 
     ActivateMarket activateMarket = new ActivateMarket();
 
-    activateMarket.innerRun(mgv, mgvReader, tokenA, tokenB, 2 * 1e9, 3 * 1e9, 0);
-    activateMarket.innerRun(mgv, mgvReader, dai, usdc, 1e9 / 1000, 1e9 / 1000, 0);
-    activateMarket.innerRun(mgv, mgvReader, weth, dai, 1e9, 1e9 / 1000, 0);
-    activateMarket.innerRun(mgv, mgvReader, weth, usdc, 1e9, 1e9 / 1000, 0);
+    activateMarket.innerRun(mgv, mgvReader, tokenA, tokenB, 2 * 1e9, 3 * 1e9, 0, 1000);
+    activateMarket.innerRun(mgv, mgvReader, dai, usdc, 1e9 / 1000, 1e9 / 1000, 0, 1000);
+    activateMarket.innerRun(mgv, mgvReader, weth, dai, 1e9, 1e9 / 1000, 0, 1000);
+    activateMarket.innerRun(mgv, mgvReader, weth, usdc, 1e9, 1e9 / 1000, 0, 1000);
 
     MangroveOrderDeployer mgoeDeployer = new MangroveOrderDeployer();
     mgoeDeployer.innerRun({admin: broadcaster(), mgv: IMangrove(payable(mgv))});


### PR DESCRIPTION
This PR does the following:
* adds ERC20 addresses for arbitrum context 
* adds a generic script that infers and logs density and gasbase for a specific market. 
The script required some minor refactoring of existing scripts (only in use for testnet)