### PR TITLE
use remappings internally & rename `mgv_*` to `@mgv/*`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ Just `forge install mangrovedao/mangrove-core`.
 ⚠️ You will not get the usual remapping `mangrove-core/=lib/mangrove-core/src/` (because forge's remapping generation heuristic sees the `preprocessing/lib/` directory and decides to remap to the parent dir). Instead, you will get:
 
 ```
-mgv_src/=lib/mangrove-core/src/
-mgv_lib/=lib/mangrove-core/lib/
-mgv_test/=lib/mangrove-core/test/
-mgv_script/=lib/mangrove-core/script/
+@mgv/src/=lib/mangrove-core/src/
+@mgv/lib/=lib/mangrove-core/lib/
+@mgv/test/=lib/mangrove-core/test/
+@mgv/script/=lib/mangrove-core/script/
 ```
+
+Use this likely-unique prefix even internally so projects that depend on mangrove don't mess with mangrove's internal dependencies
 
 # Installing prerequisites
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Just `forge install mangrovedao/mangrove-core`.
 @mgv/script/=lib/mangrove-core/script/
 ```
 
-Use this likely-unique prefix even internally so projects that depend on mangrove don't mess with mangrove's internal dependencies
+Use this likely-unique prefix even internally so projects that depend on Mangrove don't mess with Mangrove's internal dependencies.
 
 # Installing prerequisites
 

--- a/lib/Debug.sol
+++ b/lib/Debug.sol
@@ -2,5 +2,5 @@
 
 pragma solidity ^0.8.13;
 
-import {console2 as console} from "forge-std/console2.sol";
-import "mgv_lib/preprocessed/ToString.post.sol";
+import {console2 as console} from "@mgv/forge-std/console2.sol";
+import "@mgv/lib/preprocessed/ToString.post.sol";

--- a/lib/Script2.sol
+++ b/lib/Script2.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier:	AGPL-2.0
 pragma solidity ^0.8.13;
 
-import {Script} from "forge-std/Script.sol";
-import {IERC20} from "mgv_lib/IERC20.sol";
-import {ToyENS} from "mgv_lib/ToyENS.sol";
-import "mgv_src/core/MgvLib.sol";
-import "mgv_lib/Debug.sol";
+import {Script} from "@mgv/forge-std/Script.sol";
+import {IERC20} from "@mgv/lib/IERC20.sol";
+import {ToyENS} from "@mgv/lib/ToyENS.sol";
+import "@mgv/src/core/MgvLib.sol";
+import "@mgv/lib/Debug.sol";
 
 /* Some general utility methods.
 /* You may want to inherit `MangroveTest` (which inherits Test2` which inherits `Script2`) rather than inherit `Script2` directly */

--- a/lib/Test2.sol
+++ b/lib/Test2.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.13;
 
-import {Test, console2} from "forge-std/Test.sol";
-import "mgv_lib/Script2.sol";
+import {Test, console2} from "@mgv/forge-std/Test.sol";
+import "@mgv/lib/Script2.sol";
 
 /* Some ease-of-life additions to forge-std/Test.sol */
 /* You may want to inherit `MangroveTest` (which inherits `Test2`) rather than inherit `Test2` directly */

--- a/lib/TransferLib.sol
+++ b/lib/TransferLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier:	BSD-2-Clause
 pragma solidity ^0.8.10;
 
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 ///@title This library helps with safely interacting with ERC20 tokens
 ///@notice Transferring 0 or to self will be skipped.

--- a/lib/core/DensityLib.sol
+++ b/lib/core/DensityLib.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import {Field} from "mgv_lib/core/TickTreeLib.sol";
-import {ONES} from "mgv_lib/core/Constants.sol";
-import {BitLib} from "mgv_lib/core/BitLib.sol";
+import {Field} from "@mgv/lib/core/TickTreeLib.sol";
+import {ONES} from "@mgv/lib/core/Constants.sol";
+import {BitLib} from "@mgv/lib/core/BitLib.sol";
 
 /*
 

--- a/lib/core/LocalExtra.sol
+++ b/lib/core/LocalExtra.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.17;
 
-import {Bin,TickTreeLib,Field} from "mgv_lib/core/TickTreeLib.sol";
-import {Density, DensityLib} from "mgv_lib/core/DensityLib.sol";
-import {Local,LocalUnpacked,LocalLib} from "mgv_src/preprocessed/Local.post.sol";
+import {Bin,TickTreeLib,Field} from "@mgv/lib/core/TickTreeLib.sol";
+import {Density, DensityLib} from "@mgv/lib/core/DensityLib.sol";
+import {Local,LocalUnpacked,LocalLib} from "@mgv/src/preprocessed/Local.post.sol";
 
 
 

--- a/lib/core/OfferDetailExtra.sol
+++ b/lib/core/OfferDetailExtra.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.17;
 
-import {OfferDetail,OfferDetailUnpacked} from "mgv_src/preprocessed/OfferDetail.post.sol";
+import {OfferDetail,OfferDetailUnpacked} from "@mgv/src/preprocessed/OfferDetail.post.sol";
 
 
 /* Extra functions for the offer details */

--- a/lib/core/OfferExtra.sol
+++ b/lib/core/OfferExtra.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.17;
 
-import "mgv_lib/core/TickTreeLib.sol";
-import "mgv_lib/core/TickLib.sol";
-import {Offer,OfferUnpacked,OfferLib} from "mgv_src/preprocessed/Offer.post.sol";
+import "@mgv/lib/core/TickTreeLib.sol";
+import "@mgv/lib/core/TickLib.sol";
+import {Offer,OfferUnpacked,OfferLib} from "@mgv/src/preprocessed/Offer.post.sol";
 
 
 /* cleanup-mask: 0s at location of fields to hide from maker, 1s elsewhere */

--- a/lib/core/TickLib.sol
+++ b/lib/core/TickLib.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.17;
 
-import {Bin} from "mgv_lib/core/TickTreeLib.sol";
-import "mgv_lib/core/BitLib.sol";
-import "mgv_lib/core/Constants.sol";
+import {Bin} from "@mgv/lib/core/TickTreeLib.sol";
+import "@mgv/lib/core/BitLib.sol";
+import "@mgv/lib/core/Constants.sol";
 
 /* This file is inspired by Uniswap's approach to ticks, with the following notable changes:
 - directly compute ticks base 1.0001 (not base `sqrt(1.0001)`)

--- a/lib/core/TickTreeLib.sol
+++ b/lib/core/TickTreeLib.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.17;
 
-import "mgv_lib/core/Constants.sol";
-import {Tick} from "mgv_lib/core/TickLib.sol";
-import {BitLib} from "mgv_lib/core/BitLib.sol";
-import {console2 as csf} from "forge-std/console2.sol";
-import {Local} from "mgv_src/preprocessed/Local.post.sol";
+import "@mgv/lib/core/Constants.sol";
+import {Tick} from "@mgv/lib/core/TickLib.sol";
+import {BitLib} from "@mgv/lib/core/BitLib.sol";
+import {console2 as csf} from "@mgv/forge-std/console2.sol";
+import {Local} from "@mgv/src/preprocessed/Local.post.sol";
 
 
 /* # Libraries for tick tree manipulation 

--- a/lib/preprocessed/ToString.post.sol
+++ b/lib/preprocessed/ToString.post.sol
@@ -8,18 +8,18 @@ pragma solidity ^0.8.13;
 
 // Debugging utilities
 address constant VM_ADDRESS = address(uint160(uint(keccak256("hevm cheat code"))));
-import {Vm} from "forge-std/Vm.sol";
+import {Vm} from "@mgv/forge-std/Vm.sol";
 Vm constant vm = Vm(VM_ADDRESS);
 
 // Manual user-defined types
-import "mgv_lib/core/TickTreeLib.sol";
-import "mgv_lib/core/TickLib.sol";
-import {Density,DensityLib} from "mgv_lib/core/DensityLib.sol";
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/lib/core/TickTreeLib.sol";
+import "@mgv/lib/core/TickLib.sol";
+import {Density,DensityLib} from "@mgv/lib/core/DensityLib.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 
 
-import {Offer, OfferUnpacked} from "mgv_src/preprocessed/Offer.post.sol";
+import {Offer, OfferUnpacked} from "@mgv/src/preprocessed/Offer.post.sol";
 function toString(Offer __packed) pure returns (string memory) {
   return toString(__packed.to_struct());
 }
@@ -28,7 +28,7 @@ function toString(OfferUnpacked memory __unpacked) pure returns (string memory) 
   return string.concat("Offer{","prev: ", vm.toString(__unpacked.prev), ", ", "next: ", vm.toString(__unpacked.next), ", ", "tick: ", toString(__unpacked.tick), ", ", "gives: ", vm.toString(__unpacked.gives),"}");
 }
 
-import {OfferDetail, OfferDetailUnpacked} from "mgv_src/preprocessed/OfferDetail.post.sol";
+import {OfferDetail, OfferDetailUnpacked} from "@mgv/src/preprocessed/OfferDetail.post.sol";
 function toString(OfferDetail __packed) pure returns (string memory) {
   return toString(__packed.to_struct());
 }
@@ -37,7 +37,7 @@ function toString(OfferDetailUnpacked memory __unpacked) pure returns (string me
   return string.concat("OfferDetail{","maker: ", vm.toString(__unpacked.maker), ", ", "gasreq: ", vm.toString(__unpacked.gasreq), ", ", "kilo_offer_gasbase: ", vm.toString(__unpacked.kilo_offer_gasbase), ", ", "gasprice: ", vm.toString(__unpacked.gasprice),"}");
 }
 
-import {Global, GlobalUnpacked} from "mgv_src/preprocessed/Global.post.sol";
+import {Global, GlobalUnpacked} from "@mgv/src/preprocessed/Global.post.sol";
 function toString(Global __packed) pure returns (string memory) {
   return toString(__packed.to_struct());
 }
@@ -46,7 +46,7 @@ function toString(GlobalUnpacked memory __unpacked) pure returns (string memory)
   return string.concat("Global{","monitor: ", vm.toString(__unpacked.monitor), ", ", "useOracle: ", vm.toString(__unpacked.useOracle), ", ", "notify: ", vm.toString(__unpacked.notify), ", ", "gasprice: ", vm.toString(__unpacked.gasprice), ", ", "gasmax: ", vm.toString(__unpacked.gasmax), ", ", "dead: ", vm.toString(__unpacked.dead), ", ", "maxRecursionDepth: ", vm.toString(__unpacked.maxRecursionDepth), ", ", "maxGasreqForFailingOffers: ", vm.toString(__unpacked.maxGasreqForFailingOffers),"}");
 }
 
-import {Local, LocalUnpacked} from "mgv_src/preprocessed/Local.post.sol";
+import {Local, LocalUnpacked} from "@mgv/src/preprocessed/Local.post.sol";
 function toString(Local __packed) pure returns (string memory) {
   return toString(__packed.to_struct());
 }

--- a/preprocessing/StructTest.pre.sol.ts
+++ b/preprocessing/StructTest.pre.sol.ts
@@ -5,8 +5,8 @@ export const template = ({ preamble, struct_utilities, struct: s }) => {
 
 pragma solidity ^0.8.13;
 
-import "mgv_lib/Test2.sol";
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/lib/Test2.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 // Warning: fuzzer will run tests with malformed packed arguments, e.g. bool fields that are > 1.
 

--- a/preprocessing/ToString.pre.sol.ts
+++ b/preprocessing/ToString.pre.sol.ts
@@ -14,10 +14,10 @@ import {Vm} from "forge-std/Vm.sol";
 Vm constant vm = Vm(VM_ADDRESS);
 
 // Manual user-defined types
-import "mgv_lib/core/TickTreeLib.sol";
-import "mgv_lib/core/TickLib.sol";
-import {Density,DensityLib} from "mgv_lib/core/DensityLib.sol";
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/lib/core/TickTreeLib.sol";
+import "@mgv/lib/core/TickLib.sol";
+import {Density,DensityLib} from "@mgv/lib/core/DensityLib.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 
 ${structs.map(s => {
@@ -32,7 +32,7 @@ ${structs.map(s => {
   const elements = `"${s.Name}{",${fields.join(', ", ", ')},"}"`;
 
   return `
-import {${s.Packed}, ${s.Unpacked}} from "mgv_src/preprocessed/${s.filenames.src}";
+import {${s.Packed}, ${s.Unpacked}} from "@mgv/src/preprocessed/${s.filenames.src}";
 function toString(${s.Packed} __packed) pure returns (string memory) {
   return toString(__packed.to_struct());
 }

--- a/preprocessing/lib/preproc.ts
+++ b/preprocessing/lib/preproc.ts
@@ -16,7 +16,7 @@ export const struct_utilities = `/* since you can't convert bool to uint in an e
 function uint_of_bool(bool b) pure returns (uint u) {
   assembly ("memory-safe") { u := b }
 }
-import "mgv_lib/core/Constants.sol";`;
+import "@mgv/lib/core/Constants.sol";`;
 
 const field_var = (_name: string, prop: string) => {
   return `${_name}_${prop}`;

--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -178,9 +178,9 @@ const struct_defs = {
       /* * `gives` is the amount of `outbound_tkn` the offer will give if successfully executed. _127 bits wide_. */
       fields.gives,
     ],
-    additionalDefinitions: `import {Bin} from "mgv_lib/core/TickTreeLib.sol";
-import {Tick} from "mgv_lib/core/TickLib.sol";
-import {OfferExtra,OfferUnpackedExtra} from "mgv_lib/core/OfferExtra.sol";
+    additionalDefinitions: `import {Bin} from "@mgv/lib/core/TickTreeLib.sol";
+import {Tick} from "@mgv/lib/core/TickLib.sol";
+import {OfferExtra,OfferUnpackedExtra} from "@mgv/lib/core/OfferExtra.sol";
 
 using OfferExtra for Offer global;
 using OfferUnpackedExtra for OfferUnpacked global;
@@ -238,7 +238,7 @@ They have the following fields: */
       /* * `gasprice` is in Mwei/gas and _26 bits wide_, which accommodates 0.001 to ~67k gwei / gas.  `gasprice` is also the name of a global Mangrove parameter. When an offer is created, the offer's `gasprice` is set to the max of the user-specified `gasprice` and Mangrove's global `gasprice`. */
       fields.gasprice,
     ],
-    additionalDefinitions: (struct) => `import {OfferDetailExtra,OfferDetailUnpackedExtra} from "mgv_lib/core/OfferDetailExtra.sol";
+    additionalDefinitions: (struct) => `import {OfferDetailExtra,OfferDetailUnpackedExtra} from "@mgv/lib/core/OfferDetailExtra.sol";
 using OfferDetailExtra for OfferDetail global;
 using OfferDetailUnpackedExtra for OfferDetailUnpacked global;
 `,
@@ -307,10 +307,10 @@ using OfferDetailUnpackedExtra for OfferDetailUnpacked global;
       id_field("last"),
     ],
     /* Import additional libraries for `Local` and `LocalExtra`. */
-    additionalDefinitions: (struct) => `import {Density, DensityLib} from "mgv_lib/core/DensityLib.sol";
-import {Bin,TickTreeLib,Field} from "mgv_lib/core/TickTreeLib.sol";
+    additionalDefinitions: (struct) => `import {Density, DensityLib} from "@mgv/lib/core/DensityLib.sol";
+import {Bin,TickTreeLib,Field} from "@mgv/lib/core/TickTreeLib.sol";
 /* Globally enable global.method(...) */
-import {LocalExtra,LocalUnpackedExtra} from "mgv_lib/core/LocalExtra.sol";
+import {LocalExtra,LocalUnpackedExtra} from "@mgv/lib/core/LocalExtra.sol";
 using LocalExtra for Local global;
 using LocalUnpackedExtra for LocalUnpacked global;
 `,

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,5 @@
-mgv_src/=src/
-mgv_lib/=lib/
-mgv_test/=test/
-mgv_script/=script/
+@mgv/src/=src/
+@mgv/lib/=lib/
+@mgv/test/=test/
+@mgv/script/=script/
+@mgv/forge-std/=lib/forge-std/src/

--- a/script/README.md
+++ b/script/README.md
@@ -9,9 +9,9 @@ This is a script example:
 // This script is SmallMgvReaderDeployer.s.sol
 pragma solidity ^0.8.13;
 
-import {Mangrove} from "mgv_src/core/Mangrove.sol";
-import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
-import {Deployer} from "mgv_script/lib/Deployer.sol";
+import {Mangrove} from "@mgv/src/core/Mangrove.sol";
+import {MgvReader} from "@mgv/src/periphery/MgvReader.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
 import "forge-std/console.sol";
 
 contract SmallMgvReaderDeployer is Deployer {

--- a/script/core/ActivateMarket.s.sol
+++ b/script/core/ActivateMarket.s.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.13;
 
-import {Deployer} from "mgv_script/lib/Deployer.sol";
-import {UpdateMarket} from "mgv_script/periphery/UpdateMarket.s.sol";
-import "mgv_src/periphery/MgvReader.sol";
-import {IERC20} from "mgv_lib/IERC20.sol";
-import "mgv_src/core/MgvLib.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
+import {UpdateMarket} from "@mgv/script/periphery/UpdateMarket.s.sol";
+import "@mgv/src/periphery/MgvReader.sol";
+import {IERC20} from "@mgv/lib/IERC20.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 import {ActivateSemibook} from "./ActivateSemibook.s.sol";
 /* Example: activate (USDC,WETH) offer lists. Assume $NATIVE_IN_USDC is the price of ETH/MATIC/native token in USDC; same for $NATIVE_IN_ETH.

--- a/script/core/ActivateSemibook.s.sol
+++ b/script/core/ActivateSemibook.s.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.13;
 
-import {Deployer} from "mgv_script/lib/Deployer.sol";
-import "mgv_lib/Test2.sol";
-import {IERC20} from "mgv_lib/IERC20.sol";
-import "mgv_src/core/MgvLib.sol";
-import {IMangrove} from "mgv_src/IMangrove.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
+import "@mgv/lib/Test2.sol";
+import {IERC20} from "@mgv/lib/IERC20.sol";
+import "@mgv/src/core/MgvLib.sol";
+import {IMangrove} from "@mgv/src/IMangrove.sol";
 
 uint constant COVER_FACTOR = 1000;
 

--- a/script/core/DeactivateMarket.s.sol
+++ b/script/core/DeactivateMarket.s.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.13;
 
-import {Deployer} from "mgv_script/lib/Deployer.sol";
-import {IMangrove} from "mgv_src/IMangrove.sol";
-import "mgv_src/periphery/MgvReader.sol";
-import {UpdateMarket} from "mgv_script/periphery/UpdateMarket.s.sol";
-import {IERC20} from "mgv_lib/IERC20.sol";
-import "mgv_src/core/MgvLib.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
+import {IMangrove} from "@mgv/src/IMangrove.sol";
+import "@mgv/src/periphery/MgvReader.sol";
+import {UpdateMarket} from "@mgv/script/periphery/UpdateMarket.s.sol";
+import {IERC20} from "@mgv/lib/IERC20.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 /* Deactivate a market (aka two mangrove offer lists) & update MgvReader. */
 contract DeactivateMarket is Deployer {

--- a/script/core/UseOracle.s.sol
+++ b/script/core/UseOracle.s.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.13;
 
-import {Deployer} from "mgv_script/lib/Deployer.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
 
-import {IMangrove} from "mgv_src/IMangrove.sol";
-import "mgv_src/core/MgvLib.sol";
+import {IMangrove} from "@mgv/src/IMangrove.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 contract UseOracle is Deployer {
   function run() public {

--- a/script/core/deployers/ArbitrumMangroveDeployer.s.sol
+++ b/script/core/deployers/ArbitrumMangroveDeployer.s.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.13;
 
-import {ToyENS} from "mgv_lib/ToyENS.sol";
+import {ToyENS} from "@mgv/lib/ToyENS.sol";
 
-import {Deployer} from "mgv_script/lib/Deployer.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
 import {MangroveDeployer} from "./MangroveDeployer.s.sol";
 
 /**

--- a/script/core/deployers/MangroveDeployer.s.sol
+++ b/script/core/deployers/MangroveDeployer.s.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.13;
 
-import {Mangrove} from "mgv_src/core/Mangrove.sol";
-import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
-import {MgvOracle} from "mgv_src/periphery/MgvOracle.sol";
-import {IMangrove} from "mgv_src/IMangrove.sol";
-import {Deployer} from "mgv_script/lib/Deployer.sol";
-import {MgvReaderDeployer} from "mgv_script/periphery/deployers/MgvReaderDeployer.s.sol";
+import {Mangrove} from "@mgv/src/core/Mangrove.sol";
+import {MgvReader} from "@mgv/src/periphery/MgvReader.sol";
+import {MgvOracle} from "@mgv/src/periphery/MgvOracle.sol";
+import {IMangrove} from "@mgv/src/IMangrove.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
+import {MgvReaderDeployer} from "@mgv/script/periphery/deployers/MgvReaderDeployer.s.sol";
 
 contract MangroveDeployer is Deployer {
   IMangrove public mgv;

--- a/script/core/deployers/MumbaiMangroveDeployer.s.sol
+++ b/script/core/deployers/MumbaiMangroveDeployer.s.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.13;
 
-import {ToyENS} from "mgv_lib/ToyENS.sol";
+import {ToyENS} from "@mgv/lib/ToyENS.sol";
 
-import {Deployer} from "mgv_script/lib/Deployer.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
 import {MangroveDeployer} from "./MangroveDeployer.s.sol";
 
 /**

--- a/script/core/deployers/PolygonMangroveDeployer.s.sol
+++ b/script/core/deployers/PolygonMangroveDeployer.s.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.13;
 
-import {ToyENS} from "mgv_lib/ToyENS.sol";
+import {ToyENS} from "@mgv/lib/ToyENS.sol";
 
-import {Deployer} from "mgv_script/lib/Deployer.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
 import {MangroveDeployer} from "./MangroveDeployer.s.sol";
 
 /**

--- a/script/core/monitors/EvalSnipeOffer.s.sol
+++ b/script/core/monitors/EvalSnipeOffer.s.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.13;
 
-import {Deployer} from "mgv_script/lib/Deployer.sol";
-import {Test2, toFixed, console2 as console} from "mgv_lib/Test2.sol";
-import {VolumeData, IMangrove} from "mgv_src/periphery/MgvReader.sol";
-import {IERC20} from "mgv_lib/IERC20.sol";
-import "mgv_src/core/MgvLib.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
+import {Test2, toFixed, console2 as console} from "@mgv/lib/Test2.sol";
+import {VolumeData, IMangrove} from "@mgv/src/periphery/MgvReader.sol";
+import {IERC20} from "@mgv/lib/IERC20.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 /**
  * Script simulates a series of cleans on the offer at coordinate (TKN_OUT, TKN_IN, OFFER_ID)

--- a/script/core/monitors/MarketHealth.s.sol
+++ b/script/core/monitors/MarketHealth.s.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.13;
 
-import {Deployer} from "mgv_script/lib/Deployer.sol";
-import {Test2, toFixed, console2 as console} from "mgv_lib/Test2.sol";
-import {MgvReader, VolumeData, IMangrove} from "mgv_src/periphery/MgvReader.sol";
-import {IERC20} from "mgv_lib/IERC20.sol";
-import "mgv_src/core/MgvLib.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
+import {Test2, toFixed, console2 as console} from "@mgv/lib/Test2.sol";
+import {MgvReader, VolumeData, IMangrove} from "@mgv/src/periphery/MgvReader.sol";
+import {IERC20} from "@mgv/lib/IERC20.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 /**
  * @notice Script to obtain data about a given mangrove offer list. Data is outputted to terminal as space separated values.

--- a/script/lib/Deployer.sol
+++ b/script/lib/Deployer.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.13;
 
-import {Script2} from "mgv_lib/Script2.sol";
-import {ToyENS} from "mgv_lib/ToyENS.sol";
-import {GenericFork} from "mgv_test/lib/forks/Generic.sol";
-import {PolygonFork} from "mgv_test/lib/forks/Polygon.sol";
-import {MumbaiFork} from "mgv_test/lib/forks/Mumbai.sol";
-import {EthereumFork} from "mgv_test/lib/forks/Ethereum.sol";
-import {ArbitrumFork} from "mgv_test/lib/forks/Arbitrum.sol";
-import {LocalFork} from "mgv_test/lib/forks/Local.sol";
-import {TestnetZkevmFork} from "mgv_test/lib/forks/TestnetZkevm.sol";
-import {GoerliFork} from "mgv_test/lib/forks/Goerli.sol";
-import {ZkevmFork} from "mgv_test/lib/forks/Zkevm.sol";
-import {console2 as console} from "forge-std/console2.sol";
+import {Script2} from "@mgv/lib/Script2.sol";
+import {ToyENS} from "@mgv/lib/ToyENS.sol";
+import {GenericFork} from "@mgv/test/lib/forks/Generic.sol";
+import {PolygonFork} from "@mgv/test/lib/forks/Polygon.sol";
+import {MumbaiFork} from "@mgv/test/lib/forks/Mumbai.sol";
+import {EthereumFork} from "@mgv/test/lib/forks/Ethereum.sol";
+import {ArbitrumFork} from "@mgv/test/lib/forks/Arbitrum.sol";
+import {LocalFork} from "@mgv/test/lib/forks/Local.sol";
+import {TestnetZkevmFork} from "@mgv/test/lib/forks/TestnetZkevm.sol";
+import {GoerliFork} from "@mgv/test/lib/forks/Goerli.sol";
+import {ZkevmFork} from "@mgv/test/lib/forks/Zkevm.sol";
+import {console2 as console} from "@mgv/forge-std/console2.sol";
 
 address constant ANVIL_DEFAULT_FIRST_ACCOUNT = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
 string constant SINGLETON_FORK = "Deployer:Fork";

--- a/script/lib/GetTokenDealSlot.sol
+++ b/script/lib/GetTokenDealSlot.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.13;
 
-import {Deployer} from "mgv_script/lib/Deployer.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
 import "forge-std/StdStorage.sol";
 import "forge-std/console.sol";
 

--- a/script/periphery/CopyOpenSemibooks.s.sol
+++ b/script/periphery/CopyOpenSemibooks.s.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.13;
 
-import "mgv_src/periphery/MgvReader.sol";
-import {Deployer} from "mgv_script/lib/Deployer.sol";
-import "mgv_src/core/MgvLib.sol";
-import "mgv_lib/Debug.sol";
+import "@mgv/src/periphery/MgvReader.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
+import "@mgv/src/core/MgvLib.sol";
+import "@mgv/lib/Debug.sol";
 
 /* 
 Given two instances of MgvReader (previousReader and currentReader), copy the

--- a/script/periphery/UpdateMarket.s.sol
+++ b/script/periphery/UpdateMarket.s.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.13;
 
-import "mgv_src/periphery/MgvReader.sol";
-import {IERC20} from "mgv_lib/IERC20.sol";
-import {Deployer} from "mgv_script/lib/Deployer.sol";
-import "mgv_lib/Debug.sol";
+import "@mgv/src/periphery/MgvReader.sol";
+import {IERC20} from "@mgv/lib/IERC20.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
+import "@mgv/lib/Debug.sol";
 
 /* Update market information on MgvReader.
    

--- a/script/periphery/deployers/MgvReaderDeployer.s.sol
+++ b/script/periphery/deployers/MgvReaderDeployer.s.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.13;
 
-import {Script, console} from "forge-std/Script.sol";
-import {Deployer} from "mgv_script/lib/Deployer.sol";
+import {Script, console} from "@mgv/forge-std/Script.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
 
-import {IMangrove} from "mgv_src/IMangrove.sol";
-import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
+import {IMangrove} from "@mgv/src/IMangrove.sol";
+import {MgvReader} from "@mgv/src/periphery/MgvReader.sol";
 
 /**
  * @notice deploys a MgvReader instance

--- a/script/toy/deployers/ERC20Deployer.sol
+++ b/script/toy/deployers/ERC20Deployer.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.13;
 
-import "mgv_src/core/MgvLib.sol";
-import {TestToken} from "mgv_test/lib/tokens/TestToken.sol";
-import {Deployer} from "mgv_script/lib/Deployer.sol";
+import "@mgv/src/core/MgvLib.sol";
+import {TestToken} from "@mgv/test/lib/tokens/TestToken.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
 
 /* 
 This script deploys a testToken ERC20. Grants admin rights to `broadcaster`*/

--- a/script/toy/deployers/PixieMATICDeployer.s.sol
+++ b/script/toy/deployers/PixieMATICDeployer.s.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.13;
 
-import {Script, console} from "forge-std/Script.sol";
-import {Deployer} from "mgv_script/lib/Deployer.sol";
-import {PixieMATIC} from "mgv_src/toy/PixieMATIC.sol";
+import {Script, console} from "@mgv/forge-std/Script.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
+import {PixieMATIC} from "@mgv/src/toy/PixieMATIC.sol";
 
 /**
  * @notice deploys a PixieMATIC instance

--- a/script/toy/deployers/PixieUSDCDeployer.s.sol
+++ b/script/toy/deployers/PixieUSDCDeployer.s.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.13;
 
-import {Script, console} from "forge-std/Script.sol";
-import {Deployer} from "mgv_script/lib/Deployer.sol";
-import {PixieUSDC} from "mgv_src/toy/PixieUSDC.sol";
+import {Script, console} from "@mgv/forge-std/Script.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
+import {PixieUSDC} from "@mgv/src/toy/PixieUSDC.sol";
 
 /**
  * @notice deploys a PixieUSDC instance

--- a/src/IMangrove.sol
+++ b/src/IMangrove.sol
@@ -3,7 +3,7 @@
 
 pragma solidity >=0.7.0 <0.9.0;
 
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 ///@title Interface for the Mangrove contract.
 interface IMangrove is HasMgvEvents {

--- a/src/core/Mangrove.sol
+++ b/src/core/Mangrove.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.10;
 
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 import {MgvOfferMaking} from "./MgvOfferMaking.sol";
 import {MgvOfferTakingWithPermit} from "./MgvOfferTakingWithPermit.sol";
-import {MgvAppendix} from "mgv_src/core/MgvAppendix.sol";
-import {MgvGovernable} from "mgv_src/core/MgvGovernable.sol";
+import {MgvAppendix} from "@mgv/src/core/MgvAppendix.sol";
+import {MgvGovernable} from "@mgv/src/core/MgvGovernable.sol";
 
 /* <a id="Mangrove"></a> The `Mangrove` contract inherits both the maker and taker functionality. It also deploys `MgvAppendix` when constructed. */
 contract Mangrove is MgvOfferTakingWithPermit, MgvOfferMaking {

--- a/src/core/MgvAppendix.sol
+++ b/src/core/MgvAppendix.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.10;
 
-import "mgv_src/core/MgvLib.sol";
-import {MgvView} from "mgv_src/core/MgvView.sol";
-import {MgvGovernable} from "mgv_src/core/MgvGovernable.sol";
+import "@mgv/src/core/MgvLib.sol";
+import {MgvView} from "@mgv/src/core/MgvView.sol";
+import {MgvGovernable} from "@mgv/src/core/MgvGovernable.sol";
 
 /* The `MgvAppendix` contract contains Mangrove functions related to:
  - Getters (view functions)

--- a/src/core/MgvCommon.sol
+++ b/src/core/MgvCommon.sol
@@ -5,7 +5,7 @@
 
 pragma solidity ^0.8.10;
 
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 /* `MgvCommon` contains state variables used everywhere in the operation of Mangrove and related gatekeeping functions. The main `Mangrove` contract inherits from `MgvCommon`, and the auxiliary `MgvAppendix` contract inherits from `MgvCommon` as well. This way, when `Mangrove` delegatecalls to `MgvAppendix`, the storage slots match. */
 contract MgvCommon is HasMgvEvents {

--- a/src/core/MgvGovernable.sol
+++ b/src/core/MgvGovernable.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.10;
 
 import {MgvLib, IMgvMonitor, IERC20, Leaf, Field, Density, DensityLib, OLKey, DirtyFieldLib} from "./MgvLib.sol";
-import "mgv_src/core/MgvCommon.sol";
+import "@mgv/src/core/MgvCommon.sol";
 
 /* Contains governance functions, to reduce Mangrove contract size */
 contract MgvGovernable is MgvCommon {

--- a/src/core/MgvHasOffers.sol
+++ b/src/core/MgvHasOffers.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.10;
 
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/src/core/MgvLib.sol";
 import {MgvCommon} from "./MgvCommon.sol";
 
 /* `MgvHasOffers` contains the state variables and functions common to both market-maker operations and market-taker operations. Mostly: storing offers, removing them, updating market makers' provisions. */

--- a/src/core/MgvLib.sol
+++ b/src/core/MgvLib.sol
@@ -4,11 +4,11 @@
 
 pragma solidity ^0.8.10;
 
-import "mgv_src/preprocessed/Structs.post.sol";
-import {IERC20} from "mgv_lib/IERC20.sol";
-import {Density, DensityLib} from "mgv_lib/core/DensityLib.sol";
-import "mgv_lib/core/TickTreeLib.sol";
-import "mgv_lib/core/TickLib.sol";
+import "@mgv/src/preprocessed/Structs.post.sol";
+import {IERC20} from "@mgv/lib/IERC20.sol";
+import {Density, DensityLib} from "@mgv/lib/core/DensityLib.sol";
+import "@mgv/lib/core/TickTreeLib.sol";
+import "@mgv/lib/core/TickLib.sol";
 
 /* `OLKey` (for "OfferListKey") contains the information that characterizes an offer list:
   * `outbound_tkn`, token that goes from the maker to the taker (to remember the direction, imagine the token as going out of the Mangrove offer, towards the taker)

--- a/src/core/MgvOfferMaking.sol
+++ b/src/core/MgvOfferMaking.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.10;
 
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/src/core/MgvLib.sol";
 import {MgvHasOffers} from "./MgvHasOffers.sol";
-import "mgv_lib/Debug.sol";
+import "@mgv/lib/Debug.sol";
 
 /* `MgvOfferMaking` contains market-making-related functions. */
 contract MgvOfferMaking is MgvHasOffers {

--- a/src/core/MgvOfferTaking.sol
+++ b/src/core/MgvOfferTaking.sol
@@ -18,8 +18,8 @@ import {
   OLKey
 } from "./MgvLib.sol";
 import {MgvHasOffers} from "./MgvHasOffers.sol";
-import {TickTreeLib} from "mgv_lib/core/TickTreeLib.sol";
-import "mgv_lib/Debug.sol";
+import {TickTreeLib} from "@mgv/lib/core/TickTreeLib.sol";
+import "@mgv/lib/Debug.sol";
 
 /* There are 2 ways to take offers in Mangrove:
 - **Market order**. A market order walks the offer list from the best offer and up, can specify a limit price, as well as a buy/sell behaviour (i.e. whether to limit the order buy the amount bought or by the amount sold).

--- a/src/core/MgvOfferTakingWithPermit.sol
+++ b/src/core/MgvOfferTakingWithPermit.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.10;
 
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 import {MgvOfferTaking} from "./MgvOfferTaking.sol";
-import {TickTreeLib} from "mgv_lib/core/TickTreeLib.sol";
-import "mgv_src/core/MgvLib.sol";
-import "mgv_lib/Debug.sol";
+import {TickTreeLib} from "@mgv/lib/core/TickTreeLib.sol";
+import "@mgv/src/core/MgvLib.sol";
+import "@mgv/lib/Debug.sol";
 
 abstract contract MgvOfferTakingWithPermit is MgvOfferTaking {
   // Since DOMAIN_SEPARATOR is immutable, it cannot use MgvAppendix to provide an accessor (because the value will come from code, not from storage), so we generate the accessor here.

--- a/src/core/MgvView.sol
+++ b/src/core/MgvView.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.10;
 
-import "mgv_src/core/MgvLib.sol";
-import "mgv_src/core/MgvCommon.sol";
+import "@mgv/src/core/MgvLib.sol";
+import "@mgv/src/core/MgvCommon.sol";
 
 /* Contains view functions, to reduce Mangrove contract size */
 contract MgvView is MgvCommon {

--- a/src/periphery/MgvOracle.sol
+++ b/src/periphery/MgvOracle.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.10;
 
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 /* The purpose of the Oracle contract is to act as a gas price and density
  * oracle for Mangrove. It bridges to an external oracle, and allows

--- a/src/periphery/MgvReader.sol
+++ b/src/periphery/MgvReader.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.10;
 
-import "mgv_src/core/MgvLib.sol";
-import {IMangrove} from "mgv_src/IMangrove.sol";
+import "@mgv/src/core/MgvLib.sol";
+import {IMangrove} from "@mgv/src/IMangrove.sol";
 
 struct VolumeData {
   uint totalGot;

--- a/src/preprocessed/Global.post.sol
+++ b/src/preprocessed/Global.post.sol
@@ -12,7 +12,7 @@ pragma solidity ^0.8.13;
 function uint_of_bool(bool b) pure returns (uint u) {
   assembly ("memory-safe") { u := b }
 }
-import "mgv_lib/core/Constants.sol";
+import "@mgv/lib/core/Constants.sol";
 
 struct GlobalUnpacked {
   address monitor;

--- a/src/preprocessed/Local.post.sol
+++ b/src/preprocessed/Local.post.sol
@@ -12,7 +12,7 @@ pragma solidity ^0.8.13;
 function uint_of_bool(bool b) pure returns (uint u) {
   assembly ("memory-safe") { u := b }
 }
-import "mgv_lib/core/Constants.sol";
+import "@mgv/lib/core/Constants.sol";
 
 struct LocalUnpacked {
   bool active;
@@ -33,10 +33,10 @@ type Local is uint;
 using LocalLib for Local global;
 
 ////////////// ADDITIONAL DEFINITIONS, IF ANY ////////////////
-import {Density, DensityLib} from "mgv_lib/core/DensityLib.sol";
-import {Bin,TickTreeLib,Field} from "mgv_lib/core/TickTreeLib.sol";
+import {Density, DensityLib} from "@mgv/lib/core/DensityLib.sol";
+import {Bin,TickTreeLib,Field} from "@mgv/lib/core/TickTreeLib.sol";
 /* Globally enable global.method(...) */
-import {LocalExtra,LocalUnpackedExtra} from "mgv_lib/core/LocalExtra.sol";
+import {LocalExtra,LocalUnpackedExtra} from "@mgv/lib/core/LocalExtra.sol";
 using LocalExtra for Local global;
 using LocalUnpackedExtra for LocalUnpacked global;
 

--- a/src/preprocessed/Offer.post.sol
+++ b/src/preprocessed/Offer.post.sol
@@ -12,7 +12,7 @@ pragma solidity ^0.8.13;
 function uint_of_bool(bool b) pure returns (uint u) {
   assembly ("memory-safe") { u := b }
 }
-import "mgv_lib/core/Constants.sol";
+import "@mgv/lib/core/Constants.sol";
 
 struct OfferUnpacked {
   uint prev;
@@ -26,9 +26,9 @@ type Offer is uint;
 using OfferLib for Offer global;
 
 ////////////// ADDITIONAL DEFINITIONS, IF ANY ////////////////
-import {Bin} from "mgv_lib/core/TickTreeLib.sol";
-import {Tick} from "mgv_lib/core/TickLib.sol";
-import {OfferExtra,OfferUnpackedExtra} from "mgv_lib/core/OfferExtra.sol";
+import {Bin} from "@mgv/lib/core/TickTreeLib.sol";
+import {Tick} from "@mgv/lib/core/TickLib.sol";
+import {OfferExtra,OfferUnpackedExtra} from "@mgv/lib/core/OfferExtra.sol";
 
 using OfferExtra for Offer global;
 using OfferUnpackedExtra for OfferUnpacked global;

--- a/src/preprocessed/OfferDetail.post.sol
+++ b/src/preprocessed/OfferDetail.post.sol
@@ -12,7 +12,7 @@ pragma solidity ^0.8.13;
 function uint_of_bool(bool b) pure returns (uint u) {
   assembly ("memory-safe") { u := b }
 }
-import "mgv_lib/core/Constants.sol";
+import "@mgv/lib/core/Constants.sol";
 
 struct OfferDetailUnpacked {
   address maker;
@@ -26,7 +26,7 @@ type OfferDetail is uint;
 using OfferDetailLib for OfferDetail global;
 
 ////////////// ADDITIONAL DEFINITIONS, IF ANY ////////////////
-import {OfferDetailExtra,OfferDetailUnpackedExtra} from "mgv_lib/core/OfferDetailExtra.sol";
+import {OfferDetailExtra,OfferDetailUnpackedExtra} from "@mgv/lib/core/OfferDetailExtra.sol";
 using OfferDetailExtra for OfferDetail global;
 using OfferDetailUnpackedExtra for OfferDetailUnpacked global;
 

--- a/src/toy/ERC20.sol
+++ b/src/toy/ERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.8.0;
 
-import {IERC20} from "mgv_lib/IERC20.sol";
+import {IERC20} from "@mgv/lib/IERC20.sol";
 import "./ERC20Lib.sol";
 
 /**

--- a/test-ratios/TickRatioConversion.sol
+++ b/test-ratios/TickRatioConversion.sol
@@ -2,10 +2,10 @@
 
 pragma solidity ^0.8.10;
 
-import "mgv_lib/Test2.sol";
-import "mgv_src/core/MgvLib.sol";
-import "mgv_lib/Debug.sol";
-import "mgv_lib/core/TickLib.sol";
+import "@mgv/lib/Test2.sol";
+import "@mgv/src/core/MgvLib.sol";
+import "@mgv/lib/Debug.sol";
+import "@mgv/lib/core/TickLib.sol";
 
 // Will check that ratios are within 1/RELATIVE_ERROR_THRESHOLD of reference ratios
 uint constant RELATIVE_ERROR_THRESHOLD = 1e15;

--- a/test/core/BasicMakerOperations.t.sol
+++ b/test/core/BasicMakerOperations.t.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.10;
 
-import "mgv_test/lib/MangroveTest.sol";
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/test/lib/MangroveTest.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 contract BasicMakerOperationsTest is MangroveTest {
   TestMaker mkr;

--- a/test/core/Constants.t.sol
+++ b/test/core/Constants.t.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.10;
 
-import "mgv_test/lib/MangroveTest.sol";
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/test/lib/MangroveTest.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 // In these tests, the testing contract is the market maker.
 contract ConstantsTest is MangroveTest {

--- a/test/core/Density.t.sol
+++ b/test/core/Density.t.sol
@@ -4,10 +4,10 @@
 
 pragma solidity ^0.8.10;
 
-// import "mgv_test/lib/MangroveTest.sol";
-import "mgv_lib/Test2.sol";
-import "mgv_src/core/MgvLib.sol";
-import {DensityLib} from "mgv_lib/core/DensityLib.sol";
+// import "@mgv/test/lib/MangroveTest.sol";
+import "@mgv/lib/Test2.sol";
+import "@mgv/src/core/MgvLib.sol";
+import {DensityLib} from "@mgv/lib/core/DensityLib.sol";
 
 // In these tests, the testing contract is the market maker.
 contract DensityTest is Test2 {

--- a/test/core/DynamicTicks.t.sol
+++ b/test/core/DynamicTicks.t.sol
@@ -2,11 +2,11 @@
 
 pragma solidity ^0.8.10;
 
-import "mgv_test/lib/MangroveTest.sol";
-import "mgv_src/core/MgvLib.sol";
-import {DensityLib} from "mgv_lib/core/DensityLib.sol";
-import {stdError} from "forge-std/StdError.sol";
-import "mgv_lib/core/Constants.sol";
+import "@mgv/test/lib/MangroveTest.sol";
+import "@mgv/src/core/MgvLib.sol";
+import {DensityLib} from "@mgv/lib/core/DensityLib.sol";
+import {stdError} from "@mgv/forge-std/StdError.sol";
+import "@mgv/lib/core/Constants.sol";
 
 // In these tests, the testing contract is the market maker.
 contract DynamicBinsTest is MangroveTest {

--- a/test/core/Field.t.sol
+++ b/test/core/Field.t.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.10;
 
-import "mgv_lib/Test2.sol";
-import "mgv_src/core/MgvLib.sol";
-import "mgv_test/lib/MangroveTest.sol";
+import "@mgv/lib/Test2.sol";
+import "@mgv/src/core/MgvLib.sol";
+import "@mgv/test/lib/MangroveTest.sol";
 
 contract FieldTest is MangroveTest {
   function test_flipBit0(uint _field, uint8 posInLevel) public {

--- a/test/core/Gatekeeping.t.sol
+++ b/test/core/Gatekeeping.t.sol
@@ -2,10 +2,10 @@
 
 pragma solidity ^0.8.10;
 
-import "mgv_test/lib/MangroveTest.sol";
-import "mgv_src/core/MgvLib.sol";
-import {DensityLib} from "mgv_lib/core/DensityLib.sol";
-import "mgv_lib/core/Constants.sol";
+import "@mgv/test/lib/MangroveTest.sol";
+import "@mgv/src/core/MgvLib.sol";
+import {DensityLib} from "@mgv/lib/core/DensityLib.sol";
+import "@mgv/lib/core/Constants.sol";
 
 // In these tests, the testing contract is the market maker.
 contract GatekeepingTest is MangroveTest {

--- a/test/core/IMangroveAbi.t.sol
+++ b/test/core/IMangroveAbi.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.10;
 
-import {Test2} from "mgv_lib/Test2.sol";
-import {stdJson} from "forge-std/StdJson.sol";
-import "mgv_lib/Debug.sol";
-import {Mangrove} from "mgv_src/core/Mangrove.sol";
-import {MgvAppendix} from "mgv_src/core/MgvAppendix.sol";
+import {Test2} from "@mgv/lib/Test2.sol";
+import {stdJson} from "@mgv/forge-std/StdJson.sol";
+import "@mgv/lib/Debug.sol";
+import {Mangrove} from "@mgv/src/core/Mangrove.sol";
+import {MgvAppendix} from "@mgv/src/core/MgvAppendix.sol";
 
 using stdJson for string;
 

--- a/test/core/Leaf.t.sol
+++ b/test/core/Leaf.t.sol
@@ -2,10 +2,10 @@
 
 pragma solidity ^0.8.10;
 
-import "mgv_lib/Test2.sol";
-import "mgv_src/core/MgvLib.sol";
-import "mgv_test/lib/MangroveTest.sol";
-import "mgv_lib/Debug.sol";
+import "@mgv/lib/Test2.sol";
+import "@mgv/src/core/MgvLib.sol";
+import "@mgv/test/lib/MangroveTest.sol";
+import "@mgv/lib/Debug.sol";
 
 // In these tests, the testing contract is the market maker.
 contract LeafTest is MangroveTest {

--- a/test/core/MakerOperations.t.sol
+++ b/test/core/MakerOperations.t.sol
@@ -2,10 +2,10 @@
 
 pragma solidity ^0.8.10;
 
-import "mgv_test/lib/MangroveTest.sol";
-import "mgv_src/core/MgvLib.sol";
-import {Density, DensityLib} from "mgv_lib/core/DensityLib.sol";
-import "mgv_lib/core/Constants.sol";
+import "@mgv/test/lib/MangroveTest.sol";
+import "@mgv/src/core/MgvLib.sol";
+import {Density, DensityLib} from "@mgv/lib/core/DensityLib.sol";
+import "@mgv/lib/core/Constants.sol";
 
 contract TestMonitor is IMgvMonitor {
   function notifySuccess(MgvLib.SingleOrder calldata sor, address taker) external {}

--- a/test/core/MakerPosthook.t.sol
+++ b/test/core/MakerPosthook.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.10;
 
-import "mgv_test/lib/MangroveTest.sol";
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/test/lib/MangroveTest.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 contract MakerPosthookTest is MangroveTest, IMaker {
   TestTaker tkr;

--- a/test/core/Monitor.t.sol
+++ b/test/core/Monitor.t.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.10;
 
-import "mgv_test/lib/MangroveTest.sol";
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/test/lib/MangroveTest.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 contract MonitorTest is MangroveTest {
   TestMaker mkr;

--- a/test/core/Permit.t.sol
+++ b/test/core/Permit.t.sol
@@ -41,14 +41,14 @@ pragma solidity ^0.8.10;
 
   owner._signTypedData(domain, types, data);*/
 
-import {MangroveTest} from "mgv_test/lib/MangroveTest.sol";
-import {TrivialTestMaker, TestMaker} from "mgv_test/lib/agents/TestMaker.sol";
-import {Vm} from "forge-std/Vm.sol";
-import {console2 as console, StdStorage, stdStorage} from "forge-std/Test.sol";
-import {IMangrove} from "mgv_src/IMangrove.sol";
-import "mgv_lib/core/TickTreeLib.sol";
-import "mgv_lib/core/TickLib.sol";
-import "mgv_src/core/MgvLib.sol";
+import {MangroveTest} from "@mgv/test/lib/MangroveTest.sol";
+import {TrivialTestMaker, TestMaker} from "@mgv/test/lib/agents/TestMaker.sol";
+import {Vm} from "@mgv/forge-std/Vm.sol";
+import {console2 as console, StdStorage, stdStorage} from "@mgv/forge-std/Test.sol";
+import {IMangrove} from "@mgv/src/IMangrove.sol";
+import "@mgv/lib/core/TickTreeLib.sol";
+import "@mgv/lib/core/TickLib.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 contract PermitTest is MangroveTest, TrivialTestMaker {
   using stdStorage for StdStorage;

--- a/test/core/Scenarii.t.sol
+++ b/test/core/Scenarii.t.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.10;
 
-import "mgv_test/lib/MangroveTest.sol";
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/test/lib/MangroveTest.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 contract ScenariiTest is MangroveTest {
   TestTaker taker;

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -2,10 +2,10 @@
 
 pragma solidity ^0.8.10;
 
-import "mgv_test/lib/MangroveTest.sol";
-import "mgv_lib/core/Constants.sol";
-import "mgv_lib/core/TickTreeLib.sol";
-import "mgv_lib/core/TickLib.sol";
+import "@mgv/test/lib/MangroveTest.sol";
+import "@mgv/lib/core/Constants.sol";
+import "@mgv/lib/core/TickTreeLib.sol";
+import "@mgv/lib/core/TickLib.sol";
 
 /* The following constructs an ERC20 with a transferFrom callback method,
    and a TestTaker which throws away any funds received upon getting

--- a/test/core/TheClog.t.sol
+++ b/test/core/TheClog.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.10;
 
-import {MangroveTest} from "mgv_test/lib/MangroveTest.sol";
-import {TestTaker} from "mgv_test/lib/agents/TestTaker.sol";
-import "mgv_src/core/MgvLib.sol";
-import {console2 as console} from "forge-std/console2.sol";
+import {MangroveTest} from "@mgv/test/lib/MangroveTest.sol";
+import {TestTaker} from "@mgv/test/lib/agents/TestTaker.sol";
+import "@mgv/src/core/MgvLib.sol";
+import {console2 as console} from "@mgv/forge-std/console2.sol";
 
 contract TooDeepRecursionClogTest is MangroveTest, IMaker {
   bool internal shouldFail = false;

--- a/test/core/TickAndBin.t.sol
+++ b/test/core/TickAndBin.t.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.10;
 
-import "mgv_lib/Test2.sol";
-import "mgv_src/core/MgvLib.sol";
-import "mgv_test/lib/MangroveTest.sol";
+import "@mgv/lib/Test2.sol";
+import "@mgv/src/core/MgvLib.sol";
+import "@mgv/test/lib/MangroveTest.sol";
 
 contract TickAndBinTest is MangroveTest {
   function test_posInLeaf_auto(int bin) public {

--- a/test/core/gas/CleanOtherOfferList.t.sol
+++ b/test/core/gas/CleanOtherOfferList.t.sol
@@ -17,9 +17,9 @@ import {
   LEVEL1_HIGHER_BIN,
   ROOT_LOWER_BIN,
   ROOT_HIGHER_BIN
-} from "mgv_test/lib/gas/GasTestBase.t.sol";
-import {IMangrove, TestTaker} from "mgv_test/lib/MangroveTest.sol";
-import "mgv_src/core/MgvLib.sol";
+} from "@mgv/test/lib/gas/GasTestBase.t.sol";
+import {IMangrove, TestTaker} from "@mgv/test/lib/MangroveTest.sol";
+import "@mgv/src/core/MgvLib.sol";
 import {TickTreeBoundariesGasTest} from "./TickTreeBoundariesGasTest.t.sol";
 
 // Similar to RetractOffer tests.

--- a/test/core/gas/MarketOrderOtherOfferList.t.sol
+++ b/test/core/gas/MarketOrderOtherOfferList.t.sol
@@ -16,13 +16,13 @@ import {
   LEVEL1_HIGHER_BIN,
   ROOT_LOWER_BIN,
   ROOT_HIGHER_BIN
-} from "mgv_test/lib/gas/GasTestBase.t.sol";
-import {IMangrove, TestTaker} from "mgv_test/lib/MangroveTest.sol";
-import "mgv_src/core/MgvLib.sol";
+} from "@mgv/test/lib/gas/GasTestBase.t.sol";
+import {IMangrove, TestTaker} from "@mgv/test/lib/MangroveTest.sol";
+import "@mgv/src/core/MgvLib.sol";
 import {TickTreeBoundariesGasTest} from "./TickTreeBoundariesGasTest.t.sol";
-import {TickTreeLib, Bin, LEAF_SIZE, LEVEL_SIZE, ROOT_SIZE} from "mgv_lib/core/TickTreeLib.sol";
-import "mgv_src/core/MgvLib.sol";
-import "mgv_lib/Debug.sol";
+import {TickTreeLib, Bin, LEAF_SIZE, LEVEL_SIZE, ROOT_SIZE} from "@mgv/lib/core/TickTreeLib.sol";
+import "@mgv/src/core/MgvLib.sol";
+import "@mgv/lib/Debug.sol";
 
 contract ExternalMarketOrderOtherOfferList_WithNoOtherOffersGasTest is GasTestBase {
   Bin internal bin;

--- a/test/core/gas/NewOfferOtherOfferList.t.sol
+++ b/test/core/gas/NewOfferOtherOfferList.t.sol
@@ -2,11 +2,11 @@
 
 pragma solidity ^0.8.18;
 
-import {SingleGasTestBase, GasTestBase, MIDDLE_BIN} from "mgv_test/lib/gas/GasTestBase.t.sol";
-import {IMangrove, TestTaker} from "mgv_test/lib/MangroveTest.sol";
+import {SingleGasTestBase, GasTestBase, MIDDLE_BIN} from "@mgv/test/lib/gas/GasTestBase.t.sol";
+import {IMangrove, TestTaker} from "@mgv/test/lib/MangroveTest.sol";
 import {TickTreeBoundariesGasTest} from "./TickTreeBoundariesGasTest.t.sol";
-import {IMangrove, TestTaker} from "mgv_test/lib/MangroveTest.sol";
-import "mgv_src/core/MgvLib.sol";
+import {IMangrove, TestTaker} from "@mgv/test/lib/MangroveTest.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 contract ExternalNewOfferOtherOfferList_AlwaysEmptyGasTest is SingleGasTestBase {
   function impl(IMangrove mgv, TestTaker, OLKey memory _olKey, uint) internal override {

--- a/test/core/gas/NewOfferSameOfferList.t.sol
+++ b/test/core/gas/NewOfferSameOfferList.t.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.18;
 
-import {SingleGasTestBase, GasTestBase, MIDDLE_BIN} from "mgv_test/lib/gas/GasTestBase.t.sol";
-import {IMangrove, TestTaker} from "mgv_test/lib/MangroveTest.sol";
-import "mgv_src/core/MgvLib.sol";
+import {SingleGasTestBase, GasTestBase, MIDDLE_BIN} from "@mgv/test/lib/gas/GasTestBase.t.sol";
+import {IMangrove, TestTaker} from "@mgv/test/lib/MangroveTest.sol";
+import "@mgv/src/core/MgvLib.sol";
 import {TickTreeBoundariesGasTest} from "./TickTreeBoundariesGasTest.t.sol";
 
 contract PosthookSuccessNewOfferSameList_WithNoOtherOffersGasTest is TickTreeBoundariesGasTest, GasTestBase {

--- a/test/core/gas/OfferGasBase.t.sol
+++ b/test/core/gas/OfferGasBase.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.10;
 
-import {OfferGasBaseBaseTest} from "mgv_test/lib/gas/OfferGasBaseBase.t.sol";
+import {OfferGasBaseBaseTest} from "@mgv/test/lib/gas/OfferGasBaseBase.t.sol";
 
 contract OfferGasBaseTest_Generic_A_B is OfferGasBaseBaseTest {
   function setUp() public override {

--- a/test/core/gas/README.md
+++ b/test/core/gas/README.md
@@ -132,4 +132,4 @@ We do not expect clean to be used from maker contracts, so only external calls.
 
 ### `gasreq`
 
-Strats will need to set a gasreq, for this the `OfferGasReqBaseTest` in `mgv_test/lib/gas/OfferGasReqBase.t.sol` can be implemented. See examples in the strat library. Results should be compared to output for the `OfferGasBaseBaseTest` implementors.
+Strats will need to set a gasreq, for this the `OfferGasReqBaseTest` in `@mgv/test/lib/gas/OfferGasReqBase.t.sol` can be implemented. See examples in the strat library. Results should be compared to output for the `OfferGasBaseBaseTest` implementors.

--- a/test/core/gas/RetractOfferOtherOfferList.t.sol
+++ b/test/core/gas/RetractOfferOtherOfferList.t.sol
@@ -16,9 +16,9 @@ import {
   LEVEL1_HIGHER_BIN,
   ROOT_LOWER_BIN,
   ROOT_HIGHER_BIN
-} from "mgv_test/lib/gas/GasTestBase.t.sol";
-import {IMangrove, TestTaker} from "mgv_test/lib/MangroveTest.sol";
-import "mgv_src/core/MgvLib.sol";
+} from "@mgv/test/lib/gas/GasTestBase.t.sol";
+import {IMangrove, TestTaker} from "@mgv/test/lib/MangroveTest.sol";
+import "@mgv/src/core/MgvLib.sol";
 import {TickTreeBoundariesGasTest} from "./TickTreeBoundariesGasTest.t.sol";
 
 contract ExternalRetractOfferOtherOfferList_WithNoOtherOffersGasTest is GasTestBase {

--- a/test/core/gas/RetractOfferSameOfferList.t.sol
+++ b/test/core/gas/RetractOfferSameOfferList.t.sol
@@ -2,12 +2,12 @@
 
 pragma solidity ^0.8.18;
 
-import {SingleGasTestBase, GasTestBase, IMIDDLE_BIN, MIDDLE_BIN} from "mgv_test/lib/gas/GasTestBase.t.sol";
-import {IMangrove, TestTaker} from "mgv_test/lib/MangroveTest.sol";
+import {SingleGasTestBase, GasTestBase, IMIDDLE_BIN, MIDDLE_BIN} from "@mgv/test/lib/gas/GasTestBase.t.sol";
+import {IMangrove, TestTaker} from "@mgv/test/lib/MangroveTest.sol";
 import {TickTreeBoundariesGasTest} from "./TickTreeBoundariesGasTest.t.sol";
-import "mgv_src/core/MgvLib.sol";
-import {LEAF_SIZE, LEVEL_SIZE} from "mgv_lib/core/TickTreeLib.sol";
-import "mgv_lib/Debug.sol";
+import "@mgv/src/core/MgvLib.sol";
+import {LEAF_SIZE, LEVEL_SIZE} from "@mgv/lib/core/TickTreeLib.sol";
+import "@mgv/lib/Debug.sol";
 
 Bin constant LOW_BIN = Bin.wrap(IMIDDLE_BIN - LEAF_SIZE * 2 * (LEVEL_SIZE ** 3) / 3);
 

--- a/test/core/gas/TickTreeBoundariesGasTest.t.sol
+++ b/test/core/gas/TickTreeBoundariesGasTest.t.sol
@@ -15,10 +15,10 @@ import {
   LEVEL1_HIGHER_BIN,
   ROOT_LOWER_BIN,
   ROOT_HIGHER_BIN
-} from "mgv_test/lib/gas/GasTestBase.t.sol";
+} from "@mgv/test/lib/gas/GasTestBase.t.sol";
 
-import {IMangrove, TestTaker, OLKey} from "mgv_test/lib/MangroveTest.sol";
-import "mgv_lib/Debug.sol";
+import {IMangrove, TestTaker, OLKey} from "@mgv/test/lib/MangroveTest.sol";
+import "@mgv/lib/Debug.sol";
 
 /// Implements tests for all boundaries of bin values. Starting from a MIDDLE_BIN it goes above and below creating new branches for all levels.
 abstract contract TickTreeBoundariesGasTest is GasTestBaseStored {

--- a/test/core/gas/UpdateOfferOtherOfferList.t.sol
+++ b/test/core/gas/UpdateOfferOtherOfferList.t.sol
@@ -2,10 +2,10 @@
 
 pragma solidity ^0.8.18;
 
-import {SingleGasTestBase, GasTestBase, MIDDLE_BIN} from "mgv_test/lib/gas/GasTestBase.t.sol";
-import {IMangrove, TestTaker} from "mgv_test/lib/MangroveTest.sol";
+import {SingleGasTestBase, GasTestBase, MIDDLE_BIN} from "@mgv/test/lib/gas/GasTestBase.t.sol";
+import {IMangrove, TestTaker} from "@mgv/test/lib/MangroveTest.sol";
 import {TickTreeBoundariesGasTest} from "./TickTreeBoundariesGasTest.t.sol";
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 contract ExternalUpdateOfferOtherOfferList_WithNoOtherOffersGasTest is SingleGasTestBase {
   function setUp() public virtual override {

--- a/test/core/gas/UpdateOfferOtherOfferListDetails.t.sol
+++ b/test/core/gas/UpdateOfferOtherOfferListDetails.t.sol
@@ -2,10 +2,10 @@
 
 pragma solidity ^0.8.18;
 
-import {SingleGasTestBase, GasTestBase, MIDDLE_BIN, LEVEL2_HIGHER_BIN} from "mgv_test/lib/gas/GasTestBase.t.sol";
-import {IMangrove, TestTaker} from "mgv_test/lib/MangroveTest.sol";
+import {SingleGasTestBase, GasTestBase, MIDDLE_BIN, LEVEL2_HIGHER_BIN} from "@mgv/test/lib/gas/GasTestBase.t.sol";
+import {IMangrove, TestTaker} from "@mgv/test/lib/MangroveTest.sol";
 import {TickTreeBoundariesGasTest} from "./TickTreeBoundariesGasTest.t.sol";
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 contract ExternalUpdateOfferOtherOfferList_DeadDeprovisioned is SingleGasTestBase {
   function setUp() public virtual override {

--- a/test/core/gas/UpdateOfferSameOfferList.t.sol
+++ b/test/core/gas/UpdateOfferSameOfferList.t.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.18;
 
-import {SingleGasTestBase, GasTestBase, MIDDLE_BIN} from "mgv_test/lib/gas/GasTestBase.t.sol";
-import {IMangrove, TestTaker} from "mgv_test/lib/MangroveTest.sol";
-import "mgv_src/core/MgvLib.sol";
+import {SingleGasTestBase, GasTestBase, MIDDLE_BIN} from "@mgv/test/lib/gas/GasTestBase.t.sol";
+import {IMangrove, TestTaker} from "@mgv/test/lib/MangroveTest.sol";
+import "@mgv/src/core/MgvLib.sol";
 import {TickTreeBoundariesGasTest} from "./TickTreeBoundariesGasTest.t.sol";
 
 // Note: These are very similar to the NewOffer tests.

--- a/test/core/ticktree/TickTreeCleanOffer.t.sol
+++ b/test/core/ticktree/TickTreeCleanOffer.t.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.18;
 
 import {TickTreeTest, TestTickTree} from "./TickTreeTest.t.sol";
-import "mgv_src/core/MgvLib.sol";
-import "mgv_lib/Debug.sol";
+import "@mgv/src/core/MgvLib.sol";
+import "@mgv/lib/Debug.sol";
 
 // Tests of Mangrove.cleanByImpersonation's interaction with the tick tree.
 //

--- a/test/core/ticktree/TickTreeMarketOrder.t.sol
+++ b/test/core/ticktree/TickTreeMarketOrder.t.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.18;
 
 import "./TickTreeTest.t.sol";
-import "mgv_src/core/MgvLib.sol";
-import "mgv_lib/Debug.sol";
+import "@mgv/src/core/MgvLib.sol";
+import "@mgv/lib/Debug.sol";
 
 // Tests of Mangrove.marketOrder's interaction with the tick tree.
 //

--- a/test/core/ticktree/TickTreeNewOffer.t.sol
+++ b/test/core/ticktree/TickTreeNewOffer.t.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.18;
 
 import {TickTreeTest, TestTickTree} from "./TickTreeTest.t.sol";
-import "mgv_src/core/MgvLib.sol";
-import "mgv_lib/Debug.sol";
+import "@mgv/src/core/MgvLib.sol";
+import "@mgv/lib/Debug.sol";
 
 // Tests of Mangrove.newOffer's interaction with the tick tree.
 //

--- a/test/core/ticktree/TickTreeRetractOffer.t.sol
+++ b/test/core/ticktree/TickTreeRetractOffer.t.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.18;
 
 import {TickTreeTest, TestTickTree} from "./TickTreeTest.t.sol";
-import "mgv_src/core/MgvLib.sol";
-import "mgv_lib/Debug.sol";
+import "@mgv/src/core/MgvLib.sol";
+import "@mgv/lib/Debug.sol";
 
 // Tests of Mangrove.retractOffer's interaction with the tick tree.
 //

--- a/test/core/ticktree/TickTreeTest.t.sol
+++ b/test/core/ticktree/TickTreeTest.t.sol
@@ -22,10 +22,10 @@ import {
   MID_ROOT_POS,
   MIN_BIN_ALLOWED,
   MAX_BIN_ALLOWED
-} from "mgv_test/lib/TestTickTree.sol";
-import {TestTaker, MangroveTest, IMaker, TestMaker} from "mgv_test/lib/MangroveTest.sol";
-import "mgv_src/core/MgvLib.sol";
-import "mgv_lib/Debug.sol";
+} from "@mgv/test/lib/TestTickTree.sol";
+import {TestTaker, MangroveTest, IMaker, TestMaker} from "@mgv/test/lib/MangroveTest.sol";
+import "@mgv/src/core/MgvLib.sol";
+import "@mgv/lib/Debug.sol";
 
 // Base class for test of Mangrove's tick tree data structure
 //

--- a/test/core/ticktree/TickTreeTestAssumptions.t.sol
+++ b/test/core/ticktree/TickTreeTestAssumptions.t.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.18;
 
 import "./TickTreeTest.t.sol";
-import "mgv_src/core/MgvLib.sol";
-import "mgv_lib/Debug.sol";
+import "@mgv/src/core/MgvLib.sol";
+import "@mgv/lib/Debug.sol";
 
 // Tests of the assumptions made about bins in the TickTreeTests.
 contract TickTreeTestAssumptionsTest is TickTreeTest {

--- a/test/core/ticktree/TickTreeUpdateOffer.t.sol
+++ b/test/core/ticktree/TickTreeUpdateOffer.t.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.18;
 
 import {TickTreeTest, TestTickTree} from "./TickTreeTest.t.sol";
-import "mgv_src/core/MgvLib.sol";
-import "mgv_lib/Debug.sol";
+import "@mgv/src/core/MgvLib.sol";
+import "@mgv/lib/Debug.sol";
 
 // Tests of Mangrove.updateOffer's interaction with the tick tree.
 //

--- a/test/lib/AllMethodIdentifiersTest.sol
+++ b/test/lib/AllMethodIdentifiersTest.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.13;
 
-import {stdJson} from "forge-std/StdJson.sol";
-import {Vm} from "forge-std/Vm.sol";
+import {stdJson} from "@mgv/forge-std/StdJson.sol";
+import {Vm} from "@mgv/forge-std/Vm.sol";
 
 library AllMethodIdentifiersTest {
   ///@notice Reads all methodIdentifiers (selectors) from ABI pointed to by relative path from project root.

--- a/test/lib/MangroveTest.sol
+++ b/test/lib/MangroveTest.sol
@@ -1,21 +1,21 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.13;
 
-import {Test2, toFixed, Test, console, toString, vm} from "mgv_lib/Test2.sol";
-import {TestTaker} from "mgv_test/lib/agents/TestTaker.sol";
-import {TestSender} from "mgv_test/lib/agents/TestSender.sol";
-import {TrivialTestMaker, TestMaker, OfferData} from "mgv_test/lib/agents/TestMaker.sol";
-import {MakerDeployer} from "mgv_test/lib/agents/MakerDeployer.sol";
-import {TestMoriartyMaker} from "mgv_test/lib/agents/TestMoriartyMaker.sol";
-import {TestToken} from "mgv_test/lib/tokens/TestToken.sol";
-import {TransferLib} from "mgv_lib/TransferLib.sol";
+import {Test2, toFixed, Test, console, toString, vm} from "@mgv/lib/Test2.sol";
+import {TestTaker} from "@mgv/test/lib/agents/TestTaker.sol";
+import {TestSender} from "@mgv/test/lib/agents/TestSender.sol";
+import {TrivialTestMaker, TestMaker, OfferData} from "@mgv/test/lib/agents/TestMaker.sol";
+import {MakerDeployer} from "@mgv/test/lib/agents/MakerDeployer.sol";
+import {TestMoriartyMaker} from "@mgv/test/lib/agents/TestMoriartyMaker.sol";
+import {TestToken} from "@mgv/test/lib/tokens/TestToken.sol";
+import {TransferLib} from "@mgv/lib/TransferLib.sol";
 
-import {MgvOfferTakingWithPermit} from "mgv_src/core/MgvOfferTakingWithPermit.sol";
-import {Mangrove} from "mgv_src/core/Mangrove.sol";
-import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
-import {TickLib} from "mgv_lib/core/TickLib.sol";
-import {IMangrove} from "mgv_src/IMangrove.sol";
-import "mgv_src/core/MgvLib.sol";
+import {MgvOfferTakingWithPermit} from "@mgv/src/core/MgvOfferTakingWithPermit.sol";
+import {Mangrove} from "@mgv/src/core/Mangrove.sol";
+import {MgvReader} from "@mgv/src/periphery/MgvReader.sol";
+import {TickLib} from "@mgv/lib/core/TickLib.sol";
+import {IMangrove} from "@mgv/src/IMangrove.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 /* *************************************************************** 
    import this file and inherit MangroveTest to get up and running 

--- a/test/lib/TestTickTree.sol
+++ b/test/lib/TestTickTree.sol
@@ -2,12 +2,12 @@
 
 pragma solidity ^0.8.18;
 
-import {MangroveTest} from "mgv_test/lib/MangroveTest.sol";
-import {IMangrove} from "mgv_src/IMangrove.sol";
-import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
-import "mgv_src/core/MgvLib.sol";
-import {MgvCommon} from "mgv_src/core/MgvCommon.sol";
-import "mgv_lib/Debug.sol";
+import {MangroveTest} from "@mgv/test/lib/MangroveTest.sol";
+import {IMangrove} from "@mgv/src/IMangrove.sol";
+import {MgvReader} from "@mgv/src/periphery/MgvReader.sol";
+import "@mgv/src/core/MgvLib.sol";
+import {MgvCommon} from "@mgv/src/core/MgvCommon.sol";
+import "@mgv/lib/Debug.sol";
 
 int constant MIN_LEAF_INDEX = -NUM_LEAFS / 2;
 int constant MAX_LEAF_INDEX = -MIN_LEAF_INDEX - 1;

--- a/test/lib/agents/MakerDeployer.sol
+++ b/test/lib/agents/MakerDeployer.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.10;
 
-import "mgv_src/core/Mangrove.sol";
+import "@mgv/src/core/Mangrove.sol";
 import "./TestMaker.sol";
-import "mgv_test/lib/tokens/TestToken.sol";
+import "@mgv/test/lib/tokens/TestToken.sol";
 
 contract MakerDeployer {
   address payable[] makers;

--- a/test/lib/agents/TestMaker.sol
+++ b/test/lib/agents/TestMaker.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.13;
 
-import "mgv_src/IMangrove.sol";
-import "mgv_src/core/MgvLib.sol";
-import {Test} from "forge-std/Test.sol";
-import {TransferLib} from "mgv_lib/TransferLib.sol";
+import "@mgv/src/IMangrove.sol";
+import "@mgv/src/core/MgvLib.sol";
+import {Test} from "@mgv/forge-std/Test.sol";
+import {TransferLib} from "@mgv/lib/TransferLib.sol";
 
 contract TrivialTestMaker is IMaker {
   function makerExecute(MgvLib.SingleOrder calldata) external virtual returns (bytes32) {

--- a/test/lib/agents/TestMoriartyMaker.sol
+++ b/test/lib/agents/TestMoriartyMaker.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.10;
 
-import {IMangrove} from "mgv_src/IMangrove.sol";
-import "mgv_src/core/MgvLib.sol";
+import {IMangrove} from "@mgv/src/IMangrove.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 contract TestMoriartyMaker is IMaker {
   IMangrove mgv;

--- a/test/lib/agents/TestTaker.sol
+++ b/test/lib/agents/TestTaker.sol
@@ -2,10 +2,10 @@
 
 pragma solidity ^0.8.10;
 
-import {IMangrove} from "mgv_src/IMangrove.sol";
-import "mgv_src/core/MgvLib.sol";
-import {Script2} from "mgv_lib/Script2.sol";
-import {TransferLib} from "mgv_lib/TransferLib.sol";
+import {IMangrove} from "@mgv/src/IMangrove.sol";
+import "@mgv/src/core/MgvLib.sol";
+import {Script2} from "@mgv/lib/Script2.sol";
+import {TransferLib} from "@mgv/lib/TransferLib.sol";
 
 contract TestTaker is Script2 {
   IMangrove mgv;

--- a/test/lib/forks/Generic.sol
+++ b/test/lib/forks/Generic.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.10;
 
-import {Script, console, stdJson} from "forge-std/Script.sol";
-import {ToyENS} from "mgv_lib/ToyENS.sol";
+import {Script, console, stdJson} from "@mgv/forge-std/Script.sol";
+import {ToyENS} from "@mgv/lib/ToyENS.sol";
 
 /* A record entry in an addresses JSON file */
 struct Record {

--- a/test/lib/gas/GasTestBase.t.sol
+++ b/test/lib/gas/GasTestBase.t.sol
@@ -2,10 +2,10 @@
 
 pragma solidity ^0.8.18;
 
-import {IMangrove, TestTaker, MangroveTest, IMaker} from "mgv_test/lib/MangroveTest.sol";
-import "mgv_src/core/MgvLib.sol";
-import "mgv_lib/Debug.sol";
-import {TickTreeLib, Bin, LEAF_SIZE, LEVEL_SIZE} from "mgv_lib/core/TickTreeLib.sol";
+import {IMangrove, TestTaker, MangroveTest, IMaker} from "@mgv/test/lib/MangroveTest.sol";
+import "@mgv/src/core/MgvLib.sol";
+import "@mgv/lib/Debug.sol";
+import {TickTreeLib, Bin, LEAF_SIZE, LEVEL_SIZE} from "@mgv/lib/core/TickTreeLib.sol";
 
 // A bin with room for bits above and below at all bin levels, except at root which has only 2 bits.
 // forgefmt: disable-start

--- a/test/lib/gas/OfferGasBaseBase.t.sol
+++ b/test/lib/gas/OfferGasBaseBase.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.10;
 
-import {console} from "mgv_test/lib/MangroveTest.sol";
-import {IMangrove} from "mgv_src/IMangrove.sol";
-import {TransferLib} from "mgv_lib/TransferLib.sol";
-import {OLKey} from "mgv_src/core/MgvLib.sol";
-import {MIDDLE_BIN} from "mgv_test/lib/gas/GasTestBase.t.sol";
+import {console} from "@mgv/test/lib/MangroveTest.sol";
+import {IMangrove} from "@mgv/src/IMangrove.sol";
+import {TransferLib} from "@mgv/lib/TransferLib.sol";
+import {OLKey} from "@mgv/src/core/MgvLib.sol";
+import {MIDDLE_BIN} from "@mgv/test/lib/gas/GasTestBase.t.sol";
 import {OfferPosthookFailGasDeltaTest} from "./OfferPosthookFailGasDelta.t.sol";
-import {OfferGasReqBaseTest} from "mgv_test/lib/gas/OfferGasReqBase.t.sol";
+import {OfferGasReqBaseTest} from "@mgv/test/lib/gas/OfferGasReqBase.t.sol";
 
 ///@notice base class for measuring gasbase for a pair.
 abstract contract OfferGasBaseBaseTest is OfferGasReqBaseTest {

--- a/test/lib/gas/OfferGasReqBase.t.sol
+++ b/test/lib/gas/OfferGasReqBase.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.10;
 
-import {MangroveTest, MgvReader, TestTaker} from "mgv_test/lib/MangroveTest.sol";
-import {IMangrove} from "mgv_src/IMangrove.sol";
-import {PinnedPolygonFork} from "mgv_test/lib/forks/Polygon.sol";
-import {GenericFork} from "mgv_test/lib/forks/Generic.sol";
-import {OLKey} from "mgv_src/core/MgvLib.sol";
-import {TestToken} from "mgv_test/lib/tokens/TestToken.sol";
+import {MangroveTest, MgvReader, TestTaker} from "@mgv/test/lib/MangroveTest.sol";
+import {IMangrove} from "@mgv/src/IMangrove.sol";
+import {PinnedPolygonFork} from "@mgv/test/lib/forks/Polygon.sol";
+import {GenericFork} from "@mgv/test/lib/forks/Generic.sol";
+import {OLKey} from "@mgv/src/core/MgvLib.sol";
+import {TestToken} from "@mgv/test/lib/tokens/TestToken.sol";
 import {GasTestBaseStored} from "./GasTestBase.t.sol";
 
 ///@notice base class for creating tests of gasreq for contracts. Compare results to implementors of OfferGasBaseBaseTest.

--- a/test/lib/gas/OfferPosthookFailGasDelta.t.sol
+++ b/test/lib/gas/OfferPosthookFailGasDelta.t.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.10;
 
-import {MangroveTest, MgvReader, TestMaker, TestTaker, TestSender, console} from "mgv_test/lib/MangroveTest.sol";
-import {IMangrove} from "mgv_src/IMangrove.sol";
-import {PinnedPolygonFork} from "mgv_test/lib/forks/Polygon.sol";
-import {TransferLib} from "mgv_lib/TransferLib.sol";
-import "mgv_src/core/MgvLib.sol";
-import {Mangrove} from "mgv_src/core/Mangrove.sol";
-import {TestToken} from "mgv_test/lib/tokens/TestToken.sol";
-import {MIDDLE_BIN} from "mgv_test/lib/gas/GasTestBase.t.sol";
-import "mgv_lib/Debug.sol";
-import {TestTaker, IMaker} from "mgv_test/lib/MangroveTest.sol";
-import {GasTestBaseStored} from "mgv_test/lib/gas/GasTestBase.t.sol";
-import {Test2} from "mgv_lib/Test2.sol";
+import {MangroveTest, MgvReader, TestMaker, TestTaker, TestSender, console} from "@mgv/test/lib/MangroveTest.sol";
+import {IMangrove} from "@mgv/src/IMangrove.sol";
+import {PinnedPolygonFork} from "@mgv/test/lib/forks/Polygon.sol";
+import {TransferLib} from "@mgv/lib/TransferLib.sol";
+import "@mgv/src/core/MgvLib.sol";
+import {Mangrove} from "@mgv/src/core/Mangrove.sol";
+import {TestToken} from "@mgv/test/lib/tokens/TestToken.sol";
+import {MIDDLE_BIN} from "@mgv/test/lib/gas/GasTestBase.t.sol";
+import "@mgv/lib/Debug.sol";
+import {TestTaker, IMaker} from "@mgv/test/lib/MangroveTest.sol";
+import {GasTestBaseStored} from "@mgv/test/lib/gas/GasTestBase.t.sol";
+import {Test2} from "@mgv/lib/Test2.sol";
 
 /// A mangrove instrumented to measure gas usage during posthook
 contract BeforePosthookGasMeasuringMangrove is Mangrove, Test2 {

--- a/test/lib/tokens/TestToken.sol
+++ b/test/lib/tokens/TestToken.sol
@@ -5,7 +5,7 @@
 
 pragma solidity ^0.8.10;
 
-import "mgv_src/toy/ERC20BL.sol";
+import "@mgv/src/toy/ERC20BL.sol";
 
 contract TestToken is ERC20BL {
   // Weird behavior encoder

--- a/test/periphery/MgvOracle.t.sol
+++ b/test/periphery/MgvOracle.t.sol
@@ -3,12 +3,12 @@ pragma solidity ^0.8.10;
 
 // pragma experimental ABIEncoderV2;
 
-import {MangroveTest} from "mgv_test/lib/MangroveTest.sol";
-import {MgvOracle} from "mgv_src/periphery/MgvOracle.sol";
-import {Density, DensityLib} from "mgv_lib/core/DensityLib.sol";
-import "mgv_src/core/MgvLib.sol";
+import {MangroveTest} from "@mgv/test/lib/MangroveTest.sol";
+import {MgvOracle} from "@mgv/src/periphery/MgvOracle.sol";
+import {Density, DensityLib} from "@mgv/lib/core/DensityLib.sol";
+import "@mgv/src/core/MgvLib.sol";
 
-import {Test2} from "mgv_lib/Test2.sol";
+import {Test2} from "@mgv/lib/Test2.sol";
 
 contract MgvOracleForInternal is MgvOracle {
   constructor(address _governance, address _initialMutator, uint _initialGasPrice)

--- a/test/periphery/MgvReader.t.sol
+++ b/test/periphery/MgvReader.t.sol
@@ -2,11 +2,11 @@
 
 pragma solidity ^0.8.10;
 
-import "mgv_test/lib/MangroveTest.sol";
+import "@mgv/test/lib/MangroveTest.sol";
 
-import "mgv_src/periphery/MgvReader.sol";
-import "mgv_src/core/MgvLib.sol";
-import {stdError} from "forge-std/StdError.sol";
+import "@mgv/src/periphery/MgvReader.sol";
+import "@mgv/src/core/MgvLib.sol";
+import {stdError} from "@mgv/forge-std/StdError.sol";
 
 // In these tests, the testing contract is the market maker.
 contract MgvReaderTest is MangroveTest {

--- a/test/preprocessed/GlobalTest.post.sol
+++ b/test/preprocessed/GlobalTest.post.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.13;
 
-import "mgv_lib/Test2.sol";
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/lib/Test2.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 // Warning: fuzzer will run tests with malformed packed arguments, e.g. bool fields that are > 1.
 

--- a/test/preprocessed/LocalTest.post.sol
+++ b/test/preprocessed/LocalTest.post.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.13;
 
-import "mgv_lib/Test2.sol";
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/lib/Test2.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 // Warning: fuzzer will run tests with malformed packed arguments, e.g. bool fields that are > 1.
 

--- a/test/preprocessed/MgvGlobalTest.post.sol
+++ b/test/preprocessed/MgvGlobalTest.post.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.13;
 
-import "mgv_lib/Test2.sol";
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/lib/Test2.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 // Warning: fuzzer will run tests with malformed packed arguments, e.g. bool fields that are > 1.
 

--- a/test/preprocessed/MgvLocalTest.post.sol
+++ b/test/preprocessed/MgvLocalTest.post.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.13;
 
-import "mgv_lib/Test2.sol";
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/lib/Test2.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 // Warning: fuzzer will run tests with malformed packed arguments, e.g. bool fields that are > 1.
 

--- a/test/preprocessed/MgvOfferDetailTest.post.sol
+++ b/test/preprocessed/MgvOfferDetailTest.post.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.13;
 
-import "mgv_lib/Test2.sol";
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/lib/Test2.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 // Warning: fuzzer will run tests with malformed packed arguments, e.g. bool fields that are > 1.
 

--- a/test/preprocessed/MgvOfferTest.post.sol
+++ b/test/preprocessed/MgvOfferTest.post.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.13;
 
-import "mgv_lib/Test2.sol";
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/lib/Test2.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 // Warning: fuzzer will run tests with malformed packed arguments, e.g. bool fields that are > 1.
 

--- a/test/preprocessed/OfferDetailTest.post.sol
+++ b/test/preprocessed/OfferDetailTest.post.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.13;
 
-import "mgv_lib/Test2.sol";
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/lib/Test2.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 // Warning: fuzzer will run tests with malformed packed arguments, e.g. bool fields that are > 1.
 

--- a/test/preprocessed/OfferTest.post.sol
+++ b/test/preprocessed/OfferTest.post.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.13;
 
-import "mgv_lib/Test2.sol";
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/lib/Test2.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 // Warning: fuzzer will run tests with malformed packed arguments, e.g. bool fields that are > 1.
 

--- a/test/script/core/DeactivateMarket.t.sol
+++ b/test/script/core/DeactivateMarket.t.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.10;
 
-import {Deployer} from "mgv_script/lib/Deployer.sol";
-import {MangroveDeployer} from "mgv_script/core/deployers/MangroveDeployer.s.sol";
-import "mgv_script/core/DeactivateMarket.s.sol";
-import {UpdateMarket} from "mgv_script/periphery/UpdateMarket.s.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
+import {MangroveDeployer} from "@mgv/script/core/deployers/MangroveDeployer.s.sol";
+import "@mgv/script/core/DeactivateMarket.s.sol";
+import {UpdateMarket} from "@mgv/script/periphery/UpdateMarket.s.sol";
 
-import {Test2} from "mgv_lib/Test2.sol";
+import {Test2} from "@mgv/lib/Test2.sol";
 
-import {Mangrove} from "mgv_src/core/Mangrove.sol";
-import {IMangrove} from "mgv_src/IMangrove.sol";
-import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
-import {IERC20} from "mgv_lib/IERC20.sol";
-import "mgv_src/core/MgvLib.sol";
+import {Mangrove} from "@mgv/src/core/Mangrove.sol";
+import {IMangrove} from "@mgv/src/IMangrove.sol";
+import {MgvReader} from "@mgv/src/periphery/MgvReader.sol";
+import {IERC20} from "@mgv/lib/IERC20.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 contract DeactivateMarketTest is Test2 {
   MangroveDeployer deployer;

--- a/test/script/core/UpdateMarket.t.sol
+++ b/test/script/core/UpdateMarket.t.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.10;
 
-import {Deployer} from "mgv_script/lib/Deployer.sol";
-import {MangroveDeployer} from "mgv_script/core/deployers/MangroveDeployer.s.sol";
-import {UpdateMarket} from "mgv_script/periphery/UpdateMarket.s.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
+import {MangroveDeployer} from "@mgv/script/core/deployers/MangroveDeployer.s.sol";
+import {UpdateMarket} from "@mgv/script/periphery/UpdateMarket.s.sol";
 
-import {Test2} from "mgv_lib/Test2.sol";
+import {Test2} from "@mgv/lib/Test2.sol";
 
-import {Mangrove} from "mgv_src/core/Mangrove.sol";
-import {IMangrove} from "mgv_src/IMangrove.sol";
-import "mgv_src/periphery/MgvReader.sol";
-import {IERC20} from "mgv_lib/IERC20.sol";
-import "mgv_src/core/MgvLib.sol";
+import {Mangrove} from "@mgv/src/core/Mangrove.sol";
+import {IMangrove} from "@mgv/src/IMangrove.sol";
+import "@mgv/src/periphery/MgvReader.sol";
+import {IERC20} from "@mgv/lib/IERC20.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 contract UpdateMarketTest is Test2 {
   MangroveDeployer deployer;

--- a/test/script/core/deployers/BaseMangroveDeployer.t.sol
+++ b/test/script/core/deployers/BaseMangroveDeployer.t.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.10;
 
-import {Deployer} from "mgv_script/lib/Deployer.sol";
-import {MangroveDeployer} from "mgv_script/core/deployers/MangroveDeployer.s.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
+import {MangroveDeployer} from "@mgv/script/core/deployers/MangroveDeployer.s.sol";
 
-import {Test2, Test} from "mgv_lib/Test2.sol";
+import {Test2, Test} from "@mgv/lib/Test2.sol";
 
-import "mgv_src/core/MgvLib.sol";
-import {Mangrove} from "mgv_src/core/Mangrove.sol";
-import {MgvReader, Market} from "mgv_src/periphery/MgvReader.sol";
-import {MgvOracle} from "mgv_src/periphery/MgvOracle.sol";
-import {IMangrove} from "mgv_src/IMangrove.sol";
+import "@mgv/src/core/MgvLib.sol";
+import {Mangrove} from "@mgv/src/core/Mangrove.sol";
+import {MgvReader, Market} from "@mgv/src/periphery/MgvReader.sol";
+import {MgvOracle} from "@mgv/src/periphery/MgvOracle.sol";
+import {IMangrove} from "@mgv/src/IMangrove.sol";
 
 /**
  * Base test suite for [Chain]MangroveDeployer scripts

--- a/test/script/core/deployers/MangroveDeployer.t.sol
+++ b/test/script/core/deployers/MangroveDeployer.t.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.10;
 
-import {Deployer} from "mgv_script/lib/Deployer.sol";
-import {MangroveDeployer} from "mgv_script/core/deployers/MangroveDeployer.s.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
+import {MangroveDeployer} from "@mgv/script/core/deployers/MangroveDeployer.s.sol";
 
 import {BaseMangroveDeployerTest} from "./BaseMangroveDeployer.t.sol";
 
-import {Test2, Test} from "mgv_lib/Test2.sol";
+import {Test2, Test} from "@mgv/lib/Test2.sol";
 
-import "mgv_src/core/MgvLib.sol";
-import {Mangrove} from "mgv_src/core/Mangrove.sol";
-import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
-import {MgvOracle} from "mgv_src/periphery/MgvOracle.sol";
-import {IMangrove} from "mgv_src/IMangrove.sol";
+import "@mgv/src/core/MgvLib.sol";
+import {Mangrove} from "@mgv/src/core/Mangrove.sol";
+import {MgvReader} from "@mgv/src/periphery/MgvReader.sol";
+import {MgvOracle} from "@mgv/src/periphery/MgvOracle.sol";
+import {IMangrove} from "@mgv/src/IMangrove.sol";
 
 contract MangroveDeployerTest is BaseMangroveDeployerTest {
   function setUp() public {

--- a/test/script/core/deployers/MumbaiMangroveDeployer.t.sol
+++ b/test/script/core/deployers/MumbaiMangroveDeployer.t.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.10;
 
-import {Deployer} from "mgv_script/lib/Deployer.sol";
-import {MumbaiMangroveDeployer} from "mgv_script/core/deployers/MumbaiMangroveDeployer.s.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
+import {MumbaiMangroveDeployer} from "@mgv/script/core/deployers/MumbaiMangroveDeployer.s.sol";
 
 import {BaseMangroveDeployerTest} from "./BaseMangroveDeployer.t.sol";
 
-import {Test2, Test} from "mgv_lib/Test2.sol";
+import {Test2, Test} from "@mgv/lib/Test2.sol";
 
-import "mgv_src/core/MgvLib.sol";
-import {Mangrove} from "mgv_src/core/Mangrove.sol";
-import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
-import {MgvOracle} from "mgv_src/periphery/MgvOracle.sol";
-import {IMangrove} from "mgv_src/IMangrove.sol";
+import "@mgv/src/core/MgvLib.sol";
+import {Mangrove} from "@mgv/src/core/Mangrove.sol";
+import {MgvReader} from "@mgv/src/periphery/MgvReader.sol";
+import {MgvOracle} from "@mgv/src/periphery/MgvOracle.sol";
+import {IMangrove} from "@mgv/src/IMangrove.sol";
 
 contract MumbaiMangroveDeployerTest is BaseMangroveDeployerTest {
   function setUp() public {

--- a/test/script/core/deployers/PolygonMangroveDeployer.t.sol
+++ b/test/script/core/deployers/PolygonMangroveDeployer.t.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.10;
 
-import {Deployer} from "mgv_script/lib/Deployer.sol";
-import {PolygonMangroveDeployer} from "mgv_script/core/deployers/PolygonMangroveDeployer.s.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
+import {PolygonMangroveDeployer} from "@mgv/script/core/deployers/PolygonMangroveDeployer.s.sol";
 
 import {BaseMangroveDeployerTest} from "./BaseMangroveDeployer.t.sol";
 
-import {Test2, Test} from "mgv_lib/Test2.sol";
+import {Test2, Test} from "@mgv/lib/Test2.sol";
 
-import "mgv_src/core/MgvLib.sol";
-import {Mangrove} from "mgv_src/core/Mangrove.sol";
-import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
-import {MgvOracle} from "mgv_src/periphery/MgvOracle.sol";
-import {IMangrove} from "mgv_src/IMangrove.sol";
+import "@mgv/src/core/MgvLib.sol";
+import {Mangrove} from "@mgv/src/core/Mangrove.sol";
+import {MgvReader} from "@mgv/src/periphery/MgvReader.sol";
+import {MgvOracle} from "@mgv/src/periphery/MgvOracle.sol";
+import {IMangrove} from "@mgv/src/IMangrove.sol";
 
 contract PolygonMangroveDeployerTest is BaseMangroveDeployerTest {
   function setUp() public {

--- a/test/script/periphery/CopyOpenSemibooks.t.sol
+++ b/test/script/periphery/CopyOpenSemibooks.t.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.10;
 
-import {Deployer} from "mgv_script/lib/Deployer.sol";
-import {MangroveDeployer} from "mgv_script/core/deployers/MangroveDeployer.s.sol";
+import {Deployer} from "@mgv/script/lib/Deployer.sol";
+import {MangroveDeployer} from "@mgv/script/core/deployers/MangroveDeployer.s.sol";
 
-import "mgv_test/lib/MangroveTest.sol";
-import {Mangrove} from "mgv_src/core/Mangrove.sol";
-import "mgv_src/periphery/MgvReader.sol";
-import {CopyOpenSemibooks} from "mgv_script/periphery/CopyOpenSemibooks.s.sol";
-import "mgv_src/core/MgvLib.sol";
+import "@mgv/test/lib/MangroveTest.sol";
+import {Mangrove} from "@mgv/src/core/Mangrove.sol";
+import "@mgv/src/periphery/MgvReader.sol";
+import {CopyOpenSemibooks} from "@mgv/script/periphery/CopyOpenSemibooks.s.sol";
+import "@mgv/src/core/MgvLib.sol";
 
 contract CopyOpenSemibooksTest is MangroveTest {
   // MangroveDeployer deployer;

--- a/test/self/BitLib.t.sol
+++ b/test/self/BitLib.t.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.10;
 
-import "mgv_lib/Test2.sol";
-import {BitLib} from "mgv_lib/core/BitLib.sol";
+import "@mgv/lib/Test2.sol";
+import {BitLib} from "@mgv/lib/core/BitLib.sol";
 
 contract BitLibTest is Test2 {
   // adapted from solady's LibBit.t.sol

--- a/test/self/Script2.t.sol
+++ b/test/self/Script2.t.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.10;
 
-import "mgv_test/lib/MangroveTest.sol";
+import "@mgv/test/lib/MangroveTest.sol";
 
 contract Script2Test is Test2 {
   function aeq(uint amt, uint unit, uint dp, string memory expected) internal {

--- a/test/toy_strategies/TestToken.t.sol
+++ b/test/toy_strategies/TestToken.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier:	AGPL-3.0
 pragma solidity ^0.8.10;
 
-import "mgv_test/lib/MangroveTest.sol";
+import "@mgv/test/lib/MangroveTest.sol";
 
 contract TestTokenTest is MangroveTest {
   function setUp() public override {


### PR DESCRIPTION
Closes #611

also changes remappings from `mgv_X -> X/` to `@mgv/X -> X/` (more clear this is a remapping thanks to the `@`, and `/` makes more sense than `_`).

note that when `mangrove` is imported, the remapping will become `@mgv/X -> lib/mangrove-core/X/`