### PR TITLE
feat(gasreq): Adds virtual to makerPosthook and enables gasreq measurement

### DIFF
--- a/gas-measurement.sh
+++ b/gas-measurement.sh
@@ -33,7 +33,7 @@ function compare_gas_measurement_json() {
   local json_file_new=$2
   local json_file_diff=$3
 
-  jq -s 'flatten | group_by(.fileAndContract + .test) | map({fileAndContract: .[0].fileAndContract, test: .[0].test, description: .[0].description, gas_before: .[0].gas, gas_after: .[1].gas, gas_delta: (.[1].gas - .[0].gas)})' \
+  jq -s 'flatten | group_by(.fileAndContract + .test) | map({fileAndContract: .[0].fileAndContract, test: .[0].test, description: .[0].description, gas_before: .[0].gas, gas_after: .[1].gas, gas_delta: (if .[0].gas != null and .[1].gas != null then .[1].gas - .[0].gas else null end)})' \
     <(jq '. | map({fileAndContract: .fileAndContract, test: .test, gas: .gas, description: .description, source: "before"})' "${json_file_old}") \
     <(jq '. | map({fileAndContract: .fileAndContract, test: .test, gas: .gas, description: .description, source: "after"})' "${json_file_new}") \
     > "${json_file_diff}"

--- a/src/core/MgvOfferTaking.sol
+++ b/src/core/MgvOfferTaking.sol
@@ -733,6 +733,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
   /* ## Maker Posthook */
   function makerPosthook(MgvLib.SingleOrder memory sor, uint gasLeft, bytes32 makerData, bytes32 mgvData)
     internal
+    virtual
     returns (uint gasused, bool callSuccess, bytes32 posthookData)
   {
     unchecked {

--- a/test/core/MakerOperations.t.sol
+++ b/test/core/MakerOperations.t.sol
@@ -3,9 +3,9 @@
 pragma solidity ^0.8.10;
 
 import "@mgv/test/lib/MangroveTest.sol";
+import {OfferData} from "@mgv/test/lib/agents/TestMaker.sol";
 import "@mgv/src/core/MgvLib.sol";
 import {Density, DensityLib} from "@mgv/lib/core/DensityLib.sol";
-import "@mgv/lib/core/Constants.sol";
 
 contract TestMonitor is IMgvMonitor {
   function notifySuccess(MgvLib.SingleOrder calldata sor, address taker) external {}

--- a/test/core/Scenarii.t.sol
+++ b/test/core/Scenarii.t.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.10;
 
 import "@mgv/test/lib/MangroveTest.sol";
-import "@mgv/src/core/MgvLib.sol";
+import {TestMoriartyMaker} from "@mgv/test/lib/agents/TestMoriartyMaker.sol";
 
 contract ScenariiTest is MangroveTest {
   TestTaker taker;

--- a/test/core/gas/OfferGasBase.t.sol
+++ b/test/core/gas/OfferGasBase.t.sol
@@ -10,6 +10,18 @@ contract OfferGasBaseTest_Generic_A_B is OfferGasBaseBaseTest {
   }
 }
 
+contract OfferGasBaseGasreqMeasuringTest_Generic_A_B is OfferGasBaseBaseTest {
+  function setUpOptions() internal virtual override {
+    super.setUpOptions();
+    options.measureGasusedMangrove = true;
+  }
+
+  function setUp() public override {
+    super.setUpGeneric();
+    this.setUpTokens(options.base.symbol, options.quote.symbol);
+  }
+}
+
 contract OfferGasBaseTest_Polygon_WETH_DAI is OfferGasBaseBaseTest {
   function setUp() public override {
     super.setUpPolygon();

--- a/test/core/gas/README.md
+++ b/test/core/gas/README.md
@@ -132,4 +132,4 @@ We do not expect clean to be used from maker contracts, so only external calls.
 
 ### `gasreq`
 
-Strats will need to set a gasreq, for this the `OfferGasReqBaseTest` in `@mgv/test/lib/gas/OfferGasReqBase.t.sol` can be implemented. See examples in the strat library..
+Strats will need to set a gasreq, for this the `OfferGasReqBaseTest` in `@mgv/test/lib/gas/OfferGasReqBase.t.sol` can be implemented. See examples in the strat library.

--- a/test/core/gas/README.md
+++ b/test/core/gas/README.md
@@ -132,4 +132,4 @@ We do not expect clean to be used from maker contracts, so only external calls.
 
 ### `gasreq`
 
-Strats will need to set a gasreq, for this the `OfferGasReqBaseTest` in `@mgv/test/lib/gas/OfferGasReqBase.t.sol` can be implemented. See examples in the strat library. Results should be compared to output for the `OfferGasBaseBaseTest` implementors.
+Strats will need to set a gasreq, for this the `OfferGasReqBaseTest` in `@mgv/test/lib/gas/OfferGasReqBase.t.sol` can be implemented. See examples in the strat library..

--- a/test/lib/MangroveTest.sol
+++ b/test/lib/MangroveTest.sol
@@ -4,16 +4,13 @@ pragma solidity ^0.8.13;
 import {Test2, toFixed, Test, console, toString, vm} from "@mgv/lib/Test2.sol";
 import {TestTaker} from "@mgv/test/lib/agents/TestTaker.sol";
 import {TestSender} from "@mgv/test/lib/agents/TestSender.sol";
-import {TrivialTestMaker, TestMaker, OfferData} from "@mgv/test/lib/agents/TestMaker.sol";
+import {TestMaker} from "@mgv/test/lib/agents/TestMaker.sol";
 import {MakerDeployer} from "@mgv/test/lib/agents/MakerDeployer.sol";
-import {TestMoriartyMaker} from "@mgv/test/lib/agents/TestMoriartyMaker.sol";
 import {TestToken} from "@mgv/test/lib/tokens/TestToken.sol";
 import {TransferLib} from "@mgv/lib/TransferLib.sol";
 
-import {MgvOfferTakingWithPermit} from "@mgv/src/core/MgvOfferTakingWithPermit.sol";
 import {Mangrove} from "@mgv/src/core/Mangrove.sol";
 import {MgvReader} from "@mgv/src/periphery/MgvReader.sol";
-import {TickLib} from "@mgv/lib/core/TickLib.sol";
 import {IMangrove} from "@mgv/src/IMangrove.sol";
 import "@mgv/src/core/MgvLib.sol";
 

--- a/test/lib/gas/MangroveMeasureGasused.sol
+++ b/test/lib/gas/MangroveMeasureGasused.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier:	AGPL-3.0
+pragma solidity ^0.8.10;
+
+import {Mangrove} from "@mgv/src/core/Mangrove.sol";
+import {MgvLib} from "@mgv/src/core/MgvLib.sol";
+import "@mgv/lib/Debug.sol";
+
+///@notice Mangrove instrumented to measure gasused
+contract MangroveMeasureGasused is Mangrove {
+  // The measured gas usage for the nth invocation of posthook.
+  uint[] public totalGasUsed;
+
+  constructor(address governance, uint gasprice, uint gasmax) Mangrove(governance, gasprice, gasmax) {}
+
+  function makerPosthook(MgvLib.SingleOrder memory sor, uint gasLeft, bytes32 makerData, bytes32 mgvData)
+    internal
+    virtual
+    override
+    returns (uint posthookGas, bool callSuccess, bytes32 posthookData)
+  {
+    unchecked {
+      (posthookGas, callSuccess, posthookData) = super.makerPosthook(sor, gasLeft, makerData, mgvData);
+      uint gasreq = sor.offerDetail.gasreq();
+      //c.f. super.postExecute: gasLeft = gasreq - gasused; so
+      uint gasUsedExecute = gasreq - gasLeft;
+      totalGasUsed.push(gasUsedExecute + posthookGas);
+    }
+  }
+}

--- a/test/lib/gas/OfferGasReqBase.t.sol
+++ b/test/lib/gas/OfferGasReqBase.t.sol
@@ -9,6 +9,7 @@ import {OLKey} from "@mgv/src/core/MgvLib.sol";
 import {TestToken} from "@mgv/test/lib/tokens/TestToken.sol";
 import {GasTestBaseStored} from "./GasTestBase.t.sol";
 import {MgvOracle} from "@mgv/src/periphery/MgvOracle.sol";
+import {console2} from "@mgv/forge-std/console2.sol";
 
 ///@notice base class for creating tests of gasreq for contracts. Probe the `this.getMeasuredGasused` for measured gasreq.
 abstract contract OfferGasReqBaseTest is MangroveTest, GasTestBaseStored {
@@ -86,5 +87,10 @@ abstract contract OfferGasReqBaseTest is MangroveTest, GasTestBaseStored {
     takerOl.approveMgv(quote, type(uint).max);
     deal($(quote), $(takerOl), 200000 ether);
     takers[olKey.hash()] = takerOl;
+  }
+
+  /// @notice output the measured gasused for a given posthook in format collectable by gas-measurement.
+  function logGasreqAsGasUsed(uint posthookIndex) internal view {
+    console2.log("Gas used: %s", getMeasuredGasused(posthookIndex));
   }
 }

--- a/test/lib/gas/OfferGasReqBase.t.sol
+++ b/test/lib/gas/OfferGasReqBase.t.sol
@@ -10,7 +10,7 @@ import {TestToken} from "@mgv/test/lib/tokens/TestToken.sol";
 import {GasTestBaseStored} from "./GasTestBase.t.sol";
 import {MgvOracle} from "@mgv/src/periphery/MgvOracle.sol";
 
-///@notice base class for creating tests of gasreq for contracts. Compare results to implementors of OfferGasBaseBaseTest.
+///@notice base class for creating tests of gasreq for contracts. Probe the `this.getMeasuredGasused` for measured gasreq.
 abstract contract OfferGasReqBaseTest is MangroveTest, GasTestBaseStored {
   GenericFork internal fork;
   MgvOracle internal oracle;
@@ -28,11 +28,16 @@ abstract contract OfferGasReqBaseTest is MangroveTest, GasTestBaseStored {
     }
   }
 
+  function setUpOptions() internal virtual {
+    options.measureGasusedMangrove = true;
+  }
+
   function getStored() internal view override returns (IMangrove, TestTaker, OLKey memory, uint) {
     return (mgv, takers[olKey.hash()], olKey, 0);
   }
 
   function setUpGeneric() public virtual {
+    setUpOptions();
     super.setUp();
     oracle = new MgvOracle({governance_: $(this), initialMutator_: $(this), initialGasPrice_: options.gasprice});
     mgv.setMonitor(address(oracle));
@@ -44,6 +49,7 @@ abstract contract OfferGasReqBaseTest is MangroveTest, GasTestBaseStored {
   }
 
   function setUpPolygon() public virtual {
+    setUpOptions();
     super.setUp();
     fork = new PinnedPolygonFork(39880000);
     fork.setUp();


### PR DESCRIPTION
In order to measure gasreq, we add virtual to makerPosthook, so that a special Mangrove can be crafted which captures the gas used for a maker.

This is then used in the strat library to measure gasreq for Kandel and MangroveOrder.

Additionally, a more expensive gasbase case was found - we missed an oracle, and leaving behind offers is more expensive.

gas-measurement is made resilient to test-changes when using diff.