### PR TITLE
fix: Address audit findings

### DIFF
--- a/lib/core/BitLib.sol
+++ b/lib/core/BitLib.sol
@@ -28,7 +28,6 @@ library BitLib {
     }
   }
 
-  // The fls function below is general-purpose and used by tests but not by Mangrove itself
   // Function fls is MIT License. Copyright (c) 2022 Solady.
 /// @dev find last set.
     /// Returns the index of the most significant bit of `x`,

--- a/lib/core/TickLib.sol
+++ b/lib/core/TickLib.sol
@@ -96,7 +96,7 @@ library TickLib {
 
   /* ### (inbound,outbound) → ratio */
 
-  /* `ratioFromVolumes` converts a pair of (inbound,outbound) volumes to a floating-point, normalized ratio.
+  /* `ratioFromVolumes` converts a pair of (inbound,outbound) volumes to a floating-point, normalized ratio. It rounds down.
   * `outboundAmt = 0` has a special meaning and the highest possible price will be returned.
   * `inboundAmt = 0` has a special meaning if `outboundAmt != 0` and the lowest possible price will be returned.
   */
@@ -276,6 +276,8 @@ library TickLib {
   /* Compute 1.0001^tick and returns it as a (mantissa,exponent) pair. Works by checking each set bit of `|tick|` multiplying by `1.0001^(-2**i)<<128` if the ith bit of tick is set. Since we inspect the absolute value of `tick`, `-1048576` is not a valid tick. If the tick is positive this computes `1.0001^-tick`, and we take the inverse at the end. For maximum precision some powers of 1.0001 are shifted until they occupy 128 bits. The `extra_shift` is recorded and added to the exponent.
 
   Since the resulting mantissa is left-shifted by 128 bits, if tick was positive, we divide `2**256` by the mantissa to get the 128-bit left-shifted inverse of the mantissa.
+
+  The error (relative to 1.0001^tick) may be negative or positive.
   */
   function nonNormalizedRatioFromTick(Tick tick) internal pure returns (uint man, uint exp) {
     uint absTick = Tick.unwrap(tick) < 0 ? uint(-Tick.unwrap(tick)) : uint(Tick.unwrap(tick));

--- a/lib/core/TickLib.sol
+++ b/lib/core/TickLib.sol
@@ -122,7 +122,7 @@ library TickLib {
     }
   }
 
-  /* ### (inbound,outbound) → ratio */
+  /* ### (inbound,outbound) → tick */
   function tickFromVolumes(uint inboundAmt, uint outboundAmt) internal pure returns (Tick tick) {
     (uint man, uint exp) = ratioFromVolumes(inboundAmt, outboundAmt);
     return tickFromNormalizedRatio(man,exp);

--- a/lib/core/TickLib.sol
+++ b/lib/core/TickLib.sol
@@ -94,7 +94,7 @@ library TickLib {
   */
   
 
-  /* ### (outbound,inbound) → ratio */
+  /* ### (inbound,outbound) → ratio */
 
   /* `ratioFromVolumes` converts a pair of (inbound,outbound) volumes to a floating-point, normalized ratio.
   * `outboundAmt = 0` has a special meaning and the highest possible price will be returned.
@@ -122,7 +122,7 @@ library TickLib {
     }
   }
 
-  /* ### (outbound,inbound) → ratio */
+  /* ### (inbound,outbound) → ratio */
   function tickFromVolumes(uint inboundAmt, uint outboundAmt) internal pure returns (Tick tick) {
     (uint man, uint exp) = ratioFromVolumes(inboundAmt, outboundAmt);
     return tickFromNormalizedRatio(man,exp);

--- a/lib/core/TickTreeLib.sol
+++ b/lib/core/TickTreeLib.sol
@@ -149,7 +149,7 @@ library LeafLib {
 
   Explanation:
   Note that unlike in fields, have their low bin on the most significant bits.
-  `pos` is initially 1 if `leaf` has some nonzero bit in its MSB half, 0 otherwise. Then `pos` is `A | B`, where `A` is `1<<iszero(ret)`, so `A` is 0 if leaf has some nonzero bit in its MSB half, 2 otherwise. And `B` is 0 if `leaf >> (pos << 7)` has some nonzero bit in its most significant 192 bits, 0 otherwise.
+  `pos` is initially 1 if `leaf` has some nonzero bit in its MSB half, 0 otherwise. Then `pos` is `A | B`, where `A` is `iszero(ret)<<1`, so `A` is 0 if leaf has some nonzero bit in its MSB half, 2 otherwise. And `B` is 0 if `leaf >> (pos << 7)` has some nonzero bit in its most significant 192 bits, 0 otherwise.
   */
   function bestNonEmptyBinPos(Leaf leaf) internal pure returns (uint pos) {
     assembly("memory-safe") {

--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -24,7 +24,9 @@
 
    ## Ratio and price
 
-   In the comments, we use the word 'price' to refer to the ratio between the amount promised by an offer and the amount of requests in return. In the code however, we use the generic word `ratio` to avoid confusion with notions of price based on concepts such as 'quote' and 'base' tokens,etc.
+   In the comments, we use the word 'price' to refer to the ratio between the amount promised by an offer and the amount it requests in return. In the code however, we use the generic word `ratio` to avoid confusion with notions of price based on concepts such as 'quote' and 'base' tokens, etc.
+
+   The unit of price (and `ratio`) is `inbound_tkn`/`outbound_tkn`.
 
    ## `tickSpacing`
 

--- a/src/AUDIT_TRAIL_2.md
+++ b/src/AUDIT_TRAIL_2.md
@@ -24,24 +24,24 @@ Contract inheritance:
                                         │
                                     MgvCommon
                                         │
-                       ┌────────────────┴──────────┐
-                       │                           │
-                 MgvHasOffers                      │
-                       │                           │
-           ┌───────────┴──────────┐                │
-           │                      │                │
-    MgvOfferTaking         MgvOfferMaking          │
-           │                      │                │
-           │                      │                │
-MgvOfferTakingWithPermit          │                │
-           │                      │                │
-           └───────────┬──────────┘                │
-                       │                           │
-                       │                           │
-                AbstractMangrove                   │
-                       │                           │
-                       ▼                           ▼
-                    Mangrove                  MgvAppendix
+                       ┌────────────────┴──────────────────┐
+                       │                                   │
+                 MgvHasOffers                              │
+                       │                                   │
+           ┌───────────┴──────────┐                 ┌──────┴──────┐
+           │                      │                 │             │
+    MgvOfferTaking         MgvOfferMaking     MgvGovernable    MgvView
+           │                      │                 │             │
+           │                      │                 └──────┬──────┘
+MgvOfferTakingWithPermit          │                        │
+           │                      │                        │
+           └───────────┬──────────┘                        │
+                       │                                   │
+                       │                                   │
+                AbstractMangrove                           │
+                       │                                   │
+                       ▼                                   ▼
+                    Mangrove                          MgvAppendix
 ```
 
 Overview of the changes between v1 and v2:

--- a/src/IMangrove.sol
+++ b/src/IMangrove.sol
@@ -17,15 +17,15 @@ interface IMangrove is HasMgvEvents {
   ///@return The permit type hash.
   function PERMIT_TYPEHASH() external pure returns (bytes32);
 
-  ///@notice approves the spender to spend the amount of tokens on behalf of the caller.
+  ///@notice Approves the spender to spend the amount of tokens on behalf of the caller.
   ///@param outbound_tkn The address of the (maker) outbound token.
   ///@param inbound_tkn The address of the (maker) inbound token.
   ///@param spender The address of the spender.
   ///@param value The amount of tokens to approve.
-  ///@return true if the approval succeeded; always true.
+  ///@return true If the approval succeeded; always true.
   function approve(address outbound_tkn, address inbound_tkn, address spender, uint value) external returns (bool);
 
-  ///@notice returns the allowance of the spender to spend tokens on behalf of the owner.
+  ///@notice Returns the allowance of the spender to spend tokens on behalf of the owner.
   ///@param outbound_tkn The address of the (maker) outbound token.
   ///@param inbound_tkn The address of the (maker) inbound token.
   ///@param owner The address of the owner.
@@ -67,12 +67,12 @@ interface IMangrove is HasMgvEvents {
 
   ///@notice Performs a market order on a specified offer list taking offers up to a limit price.
   ///@param olKey The offer list key given by (maker) `outbound_tkn`, (maker) `inbound_tkn`, and `tickSpacing`.
-  ///@param maxTick Must be `>= MIN_TICK` and `<= MAX_TICK`. The log of limit price the taker is ready to pay (meaning: the log base 1.0001 of the ratio of inbound tokens over outbound tokens)
+  ///@param maxTick Must be `>= MIN_TICK` and `<= MAX_TICK`. The log of the limit price the taker is ready to pay (meaning: the log base 1.0001 of the ratio of inbound tokens over outbound tokens).
   ///@param fillVolume Must be `<= MAX_SAFE_VOLUME`. If `fillWants` is true, the amount of `olKey.outbound_tkn` the taker wants to buy; otherwise, the amount of `olKey.inbound_tkn` the taker wants to sell.
-  ///@param fillWants if true, the matching engine tries to get the taker all they want; otherwise, the matching engine tries to sell all that the taker gives. In both cases subject to the price limit.
+  ///@param fillWants If true, the matching engine tries to get the taker all they want; otherwise, the matching engine tries to sell all that the taker gives. In both cases subject to the price limit.
   ///@return takerGot The amount of `olKey.outbound_tkn` the taker got.
   ///@return takerGave The amount of `olKey.inbound_tkn` the taker gave.
-  ///@return bounty The amount of native token the taker got as a bounty due to failing offers (in wei)
+  ///@return bounty The amount of native token the taker got as a bounty due to failing offers (in wei).
   ///@return feePaid The amount of `olKey.outbound_tkn` the taker paid as a fee to Mangrove.
   ///@dev The market order stops when there are no more offers at or below `maxTick`, when the end of the book has been reached, or:
   ///@dev - If `fillWants` is true, the market order stops when `fillVolume` units of `olKey.outbound_tkn` have been obtained. To buy a specific volume of `olKey.outbound_tkn` at any price, set `fillWants` to true, set `fillVolume` to the volume you want to buy, and set `maxTick` to the `MAX_TICK` constant.
@@ -85,11 +85,11 @@ interface IMangrove is HasMgvEvents {
   ///@param olKey The offer list key given by (maker) `outbound_tkn`, (maker) `inbound_tkn`, and `tickSpacing`.
   ///@param maxTick Must be `>= MIN_TICK` and `<= MAX_TICK`. The log of the limit price the taker is ready to pay (meaning: the log base 1.0001 of the ratio of inbound tokens over outbound tokens).
   ///@param fillVolume Must be `<= MAX_SAFE_VOLUME`. If `fillWants` is true, the amount of `olKey.outbound_tkn` the taker wants to buy; otherwise, the amount of `olKey.inbound_tkn` the taker wants to sell.
-  ///@param fillWants if true, the matching engine tries to get the taker all they want; otherwise, the matching engine tries to sell all that the taker gives. In both cases subject to the price limit.
+  ///@param fillWants If true, the matching engine tries to get the taker all they want; otherwise, the matching engine tries to sell all that the taker gives. In both cases subject to the price limit.
   ///@param maxGasreqForFailingOffers The maximum allowed gas required for failing offers (in wei).
   ///@return takerGot The amount of `olKey.outbound_tkn` the taker got.
   ///@return takerGave The amount of `olKey.inbound_tkn` the taker gave.
-  ///@return bounty The amount of native token the taker got as a bounty due to failing offers (in wei)
+  ///@return bounty The amount of native token the taker got as a bounty due to failing offers (in wei).
   ///@return feePaid The amount of `olKey.outbound_tkn` the taker paid as a fee to Mangrove.
   ///@dev Mangrove stops a market order after it has gone through failing offers such that their cumulative `gasreq` is greater than the global `maxGasreqForFailingOffers` parameter. This function can be used by the taker to override the default `maxGasreqForFailingOffers` parameter.
   function marketOrderByTickCustom(
@@ -104,10 +104,10 @@ interface IMangrove is HasMgvEvents {
   ///@param olKey The offer list key given by (maker) `outbound_tkn`, (maker) `inbound_tkn`, and `tickSpacing`.
   ///@param takerWants Must be `<= MAX_SAFE_VOLUME`. The amount the taker wants. This is used along with `takerGives` to derive a max price (`maxTick`) which is the lowest allowed tick in the offer list such that `log_1.0001(takerGives/takerWants) <= maxTick`.
   ///@param takerGives Must be `<= MAX_SAFE_VOLUME`. The amount the taker gives. This is used along with `takerWants` to derive a max price (`maxTick`) which is the lowest allowed tick in the offer list such that `log_1.0001(takerGives/takerWants) <= maxTick`.
-  ///@param fillWants if true, the matching engine tries to get the taker all they want; otherwise, the matching engine tries to sell all that the taker gives. In both cases subject to the price limit.
+  ///@param fillWants If true, the matching engine tries to get the taker all they want; otherwise, the matching engine tries to sell all that the taker gives. In both cases subject to the price limit.
   ///@return takerGot The amount of `olKey.outbound_tkn` the taker got.
   ///@return takerGave The amount of `olKey.inbound_tkn` the taker gave.
-  ///@return bounty The amount of native token the taker got as a bounty due to failing offers (in wei)
+  ///@return bounty The amount of native token the taker got as a bounty due to failing offers (in wei).
   ///@return feePaid The amount of `olKey.outbound_tkn` the taker paid as a fee to Mangrove.
   ///@dev This function is just a wrapper for `marketOrderByTick`, see that function for details.
   ///@dev When deriving the tick, then `takerWants = 0` has a special meaning and the tick for the highest possible ratio between wants and gives will be used,
@@ -120,13 +120,13 @@ interface IMangrove is HasMgvEvents {
   ///@param olKey The offer list key given by (maker) `outbound_tkn`, (maker) `inbound_tkn`, and `tickSpacing`.
   ///@param maxTick Must be `>= MIN_TICK` and `<= MAX_TICK`. The log of the limit price the taker is ready to pay (meaning: the log base 1.0001 of the ratio of inbound tokens over outbound tokens).
   ///@param fillVolume Must be `<= MAX_SAFE_VOLUME`. If `fillWants` is true, the amount of `olKey.outbound_tkn` the taker wants to buy; otherwise, the amount of `olKey.inbound_tkn` the taker wants to sell.
-  ///@param fillWants if true, the matching engine tries to get the taker all they want; otherwise, the matching engine tries to sell all that the taker gives. In both cases subject to the price limit.
+  ///@param fillWants If true, the matching engine tries to get the taker all they want; otherwise, the matching engine tries to sell all that the taker gives. In both cases subject to the price limit.
   ///@param taker The taker from which amounts will be transferred from and to. If the `msg.sender`'s allowance for the given `olKey.outbound_tkn`,`olKey.inbound_tkn` is strictly less than the total amount eventually spent by `taker`, the call will fail.
   ///@return takerGot The amount of `olKey.outbound_tkn` the taker got.
   ///@return takerGave The amount of `olKey.inbound_tkn` the taker gave.
-  ///@return bounty The amount of native token the taker got as a bounty due to failing offers (in wei)
+  ///@return bounty The amount of native token the taker got as a bounty due to failing offers (in wei).
   ///@return feePaid The amount of `olKey.outbound_tkn` the taker paid as a fee to Mangrove.
-  ///@dev The `bounty` will be send to `msg.sender` but transfers will be for `taker`. Requires prior permission.
+  ///@dev The `bounty` will be sent to `msg.sender` but transfers will be for `taker`. Requires prior permission.
   ///@dev See also `marketOrderByTick`.
   function marketOrderForByTick(OLKey memory olKey, Tick maxTick, uint fillVolume, bool fillWants, address taker)
     external
@@ -136,12 +136,12 @@ interface IMangrove is HasMgvEvents {
   ///@param olKey The offer list key given by (maker) `outbound_tkn`, (maker) `inbound_tkn`, and `tickSpacing`.
   ///@param takerWants Must be `<= MAX_SAFE_VOLUME`. The amount the taker wants. This is used along with `takerGives` to derive a max price (`maxTick`) which is the lowest allowed tick in the offer list such that `log_1.0001(takerGives/takerWants) <= maxTick`.
   ///@param takerGives Must be `<= MAX_SAFE_VOLUME`. The amount the taker gives. This is used along with `takerGives` to derive a max price (`maxTick`) which is the lowest allowed tick in the offer list such that `log_1.0001(takerGives/takerWants) <= maxTick`.
-  ///@param fillWants if true, the matching engine tries to get the taker all they want; otherwise, the matching engine tries to sell all that the taker gives. In both cases subject to the price limit.
+  ///@param fillWants If true, the matching engine tries to get the taker all they want; otherwise, the matching engine tries to sell all that the taker gives. In both cases subject to the price limit.
   ///@param taker The taker from which amounts will be transferred from and to the. If the `msg.sender`'s allowance for the given `olKey.outbound_tkn`,`olKey.inbound_tkn` are strictly less than the total amount eventually spent by `taker`, the call will fail.
   ///@return takerGot The amount of `olKey.outbound_tkn` the taker got.
   ///@return takerGave The amount of `olKey.inbound_tkn` the taker gave.
-  ///@return bounty The amount of native token the taker got as a bounty due to failing offers (in wei)
-  ///@return feePaid The amount of native token the taker paid as a fee (in wei of `olKey.outbound_tkn`)
+  ///@return bounty The amount of native token the taker got as a bounty due to failing offers (in wei).
+  ///@return feePaid The amount of native token the taker paid as a fee (in wei of `olKey.outbound_tkn`).
   ///@dev The `bounty` will be send to `msg.sender` but transfers will be for `taker`. Requires prior permission.
   ///@dev See also `marketOrderByVolume`.
   function marketOrderForByVolume(OLKey memory olKey, uint takerWants, uint takerGives, bool fillWants, address taker)
@@ -151,14 +151,14 @@ interface IMangrove is HasMgvEvents {
   // # Cleaning functions
 
   /* # Cleaning */
-  ///@notice Cleans multiple offers, i.e. executes them and remove them from the book if they fail, transferring the failure penalty as bounty to the caller.
+  ///@notice Cleans multiple offers, i.e. executes them and removes them from the book if they fail, transferring the failure penalty as bounty to the caller.
   ///@param olKey The offer list key given by (maker) `outbound_tkn`, (maker) `inbound_tkn`, and `tickSpacing`.
   ///@param targets The offers to clean, identified by their (`offerId, tick, gasreq, takerWants`) that will make them fail.
   ///@param taker The taker used for transfers (should be able to deliver token amounts).
   ///@return successes The number of successfully cleaned offers.
   ///@return bounty The total bounty received by the caller.
   ///@dev If an offer succeeds, the execution of that offer is reverted, it stays in the book, and no bounty is paid; The `cleanByImpersonation` function itself will not revert.
-  ///@dev Note that Mangrove won't attempt to execute an offer if the values in a target don't match its offer. To distinguish between a non-executed clean and a fail clean (due to the offer itself not failing), you must inspect the log (see `MgvLib.sol`) or check the received bounty.
+  ///@dev Note that Mangrove won't attempt to execute an offer if the values in a target don't match its offer. To distinguish between a non-executed clean and a failed clean (due to the offer itself not failing), you must inspect the log (see `MgvLib.sol`) or check the received bounty.
   ///@dev Any `taker` can be impersonated when cleaning because:
   ///@dev - The function reverts if the offer succeeds, reverting any token transfers.
   ///@dev - After a `clean` where the offer has failed, all ERC20 token transfers have also been reverted -- but the sender will still have received the bounty of the failing offers. */
@@ -169,18 +169,18 @@ interface IMangrove is HasMgvEvents {
   // # Maker functions
 
   ///@notice Adds funds to Mangrove for the caller (the maker) to use for provisioning offers.
-  function fund() external payable;
+  receive() external payable;
 
   ///@notice Adds funds to Mangrove for the caller (the maker) to use for provisioning offers.
-  receive() external payable;
+  function fund() external payable;
 
   ///@notice Adds funds to Mangrove for the maker to use for provisioning offers.
   ///@param maker The maker to add funds for.
   function fund(address maker) external payable;
 
   ///@notice Withdraws the caller's (the maker's) free native tokens (funds for provisioning offers not locked by an offer) by transferring them to the caller.
-  ///@param amount the amount to withdraw.
-  ///@return noRevert whether the transfer succeeded.
+  ///@param amount The amount to withdraw.
+  ///@return noRevert Whether the transfer succeeded.
   function withdraw(uint amount) external returns (bool noRevert);
 
   ///@notice Gets the maker's free balance of native tokens (funds for provisioning offers not locked by an offer).
@@ -194,7 +194,7 @@ interface IMangrove is HasMgvEvents {
   ///@param gives Must be `<= MAX_SAFE_VOLUME`. The amount of `olKey.outbound_tkn` the maker gives.
   ///@param gasreq The amount of gas required to execute the offer logic in the maker's `IMaker` implementation. This will limit the gas available, and the offer will fail if it spends more.
   ///@param gasprice The maximum gas price the maker is willing to pay a penalty for due to failing execution.
-  ///@return offerId the id of the offer on Mangrove. Can be used to retract or update the offer (even to reuse a taken offer).
+  ///@return offerId The id of the offer on Mangrove. Can be used to retract or update the offer (even to reuse a taken offer).
   ///@dev The gasreq and gasprice are used to derive the provision which will be used to pay a penalty if the offer fails.
   ///@dev This function is payable to enable delivery of the provision along with the offer creation.
   function newOfferByTick(OLKey memory olKey, Tick tick, uint gives, uint gasreq, uint gasprice)
@@ -208,7 +208,7 @@ interface IMangrove is HasMgvEvents {
   ///@param gives Must be less than MAX_SAFE_VOLUME. The amount of `olKey.outbound_tkn` the maker gives. This is used along with `wants` to derive a tick (price). which is the lowest allowed tick in the offer list such that `log_1.0001(takerGives/takerWants) <= maxTick`. Must be less than MAX_SAFE_VOLUME.
   ///@param gasreq The amount of gas required to execute the offer logic in the maker's `IMaker` implementation. This will limit the gas available, and the offer will fail if it spends more.
   ///@param gasprice The maximum gas price the maker is willing to pay a penalty for due to failing execution.
-  ///@return offerId the id of the offer on Mangrove. Can be used to retract or update the offer (even to reuse a taken offer).
+  ///@return offerId The id of the offer on Mangrove. Can be used to retract or update the offer (even to reuse a taken offer).
   ///@dev This function is just a wrapper for `newOfferByTick`, see that function for details.
   function newOfferByVolume(OLKey memory olKey, uint wants, uint gives, uint gasreq, uint gasprice)
     external
@@ -217,7 +217,7 @@ interface IMangrove is HasMgvEvents {
 
   ///@notice Updates an existing offer on Mangrove, where the caller is the maker.
   ///@param olKey The offer list key given by (maker) `outbound_tkn`, (maker) `inbound_tkn`, and `tickSpacing`.
-  ///@param tick Must be `>= MIN_TICK` and `<= MAX_TICK`. The `tick` induces a price which is `1.0001^tick`.
+  ///@param tick Must be `>= MIN_TICK` and `<= MAX_TICK`. The `tick` induces a price which is `1.0001^tick`. The actual tick of the offer will be the smallest tick `offerTick > tick` that satisfies `offerTick % tickSpacing == 0`.
   ///@param gives The amount of `olKey.outbound_tkn` the maker gives. Must be less than MAX_SAFE_VOLUME.
   ///@param gasreq The amount of gas required to execute the offer logic in the maker's `IMaker` implementation.
   ///@param gasprice The maximum gas price the maker is willing to pay a penalty for due to failing execution.
@@ -269,7 +269,7 @@ interface IMangrove is HasMgvEvents {
 
   ///@notice Determines whether the reentrancy lock is in effect for the offer list.
   ///@param olKey The offer list key given by (maker) `outbound_tkn`, (maker) `inbound_tkn`, and `tickSpacing`.
-  ///@return true if locked; otherwise, false.
+  ///@return true If locked; otherwise, false.
   ///@dev The lock protects modifying or inspecting the offer list while an order is in progress.
   function locked(OLKey memory olKey) external view returns (bool);
 
@@ -279,8 +279,8 @@ interface IMangrove is HasMgvEvents {
   function best(OLKey memory olKey) external view returns (uint offerId);
 
   ///@notice Gets the offer list key with the given hash (if the offer list key has been activated at least once).
-  ///@param olKeyHash the hash of the offer list key.
-  ///@return olKey the olKey.
+  ///@param olKeyHash The hash of the offer list key.
+  ///@return olKey The olKey.
   function olKeys(bytes32 olKeyHash) external view returns (OLKey memory olKey);
 
   // # Offer view functions
@@ -307,12 +307,12 @@ interface IMangrove is HasMgvEvents {
   // # Governance functions
 
   ///@notice Gets the governance address.
-  ///@return the governance address.
+  ///@return The governance address.
   function governance() external view returns (address);
 
   ///@notice Activates an offer list.
   ///@param olKey The offer list key given by (maker) `outbound_tkn`, (maker) `inbound_tkn`, and `tickSpacing`.
-  ///@param fee in basis points, of `olKey.outbound_tkn` given to the taker. This fee is sent to Mangrove. Fee is capped to ~2.5%.
+  ///@param fee In basis points, of `olKey.outbound_tkn` given to the taker. This fee is sent to Mangrove. Fee is capped to ~2.5%.
   ///@param density96X32 The density of the offer list used to define a minimum offer volume. See `setDensity96X32`.
   ///@param offer_gasbase The gasbase of the offer list used to define a minimum provision necessary for offers. See `setGasbase`.
   ///@dev If the flipped offer list is active then the offer lists are expected to have the same `tickSpacing`.
@@ -327,13 +327,13 @@ interface IMangrove is HasMgvEvents {
 
   ///@notice Sets the density.
   ///@param olKey The offer list key given by (maker) `outbound_tkn`, (maker) `inbound_tkn`, and `tickSpacing`.
-  ///@param density96X32 is given as a 96.32 fixed point number. It will be stored as a 9-bit float and be approximated towards 0. The maximum error is 20%. See `DensityLib` for more information.
+  ///@param density96X32 Is given as a 96.32 fixed point number. It will be stored as a 9-bit float and be approximated towards 0. The maximum error is 20%. See `DensityLib` for more information.
   ///@dev Useless if `global.useOracle != 0` and oracle returns a valid density.
   function setDensity96X32(OLKey memory olKey, uint density96X32) external;
 
   ///@notice Sets the fee for the offer list.
   ///@param olKey The offer list key given by (maker) `outbound_tkn`, (maker) `inbound_tkn`, and `tickSpacing`.
-  ///@param fee in basis points, of `olKey.outbound_tkn` given to the taker. This fee is sent to Mangrove. Fee is capped to ~2.5%.
+  ///@param fee In basis points, of `olKey.outbound_tkn` given to the taker. This fee is sent to Mangrove. Fee is capped to ~2.5%.
   function setFee(OLKey memory olKey, uint fee) external;
 
   ///@notice Sets the gasbase for the offer list.
@@ -353,8 +353,8 @@ interface IMangrove is HasMgvEvents {
   ///@param maxGasreqForFailingOffers The maximum cumulative `gasreq` for failing offers during a market order before doing a partial fill. 32 bits.
   function setMaxGasreqForFailingOffers(uint maxGasreqForFailingOffers) external;
 
-  ///@notice Sets the gasprice (in Mwei, 26 bits)
-  ///@param gasprice The gasprice (in Mwei, 26 bits)
+  ///@notice Sets the gasprice (in Mwei, 26 bits).
+  ///@param gasprice The gasprice (in Mwei, 26 bits).
   function setGasprice(uint gasprice) external;
 
   ///@notice Sets a new governance address.
@@ -365,8 +365,8 @@ interface IMangrove is HasMgvEvents {
   ///@param monitor The new monitor/oracle address.
   function setMonitor(address monitor) external;
 
-  ///@notice Sets whether Mangrove notifies the Monitor when and offer is taken
-  ///@param notify Whether Mangrove notifies the Monitor when and offer is taken
+  ///@notice Sets whether Mangrove notifies the Monitor when and offer is taken.
+  ///@param notify Whether Mangrove notifies the Monitor when and offer is taken.
   function setNotify(bool notify) external;
 
   ///@notice Sets whether Mangrove uses the monitor as oracle for `gasprice` and `density` values.
@@ -380,54 +380,54 @@ interface IMangrove is HasMgvEvents {
 
   // # Tick tree view functions
 
-  ///@notice Gets a leaf
+  ///@notice Gets a leaf.
   ///@param olKey The offer list key given by (maker) `outbound_tkn`, (maker) `inbound_tkn`, and `tickSpacing`.
   ///@param index The index.
-  ///@return the leaf.
+  ///@return The leaf.
   function leafs(OLKey memory olKey, int index) external view returns (Leaf);
 
-  ///@notice Gets a level 3 field
+  ///@notice Gets a level 3 field.
   ///@param olKey The offer list key given by (maker) `outbound_tkn`, (maker) `inbound_tkn`, and `tickSpacing`.
   ///@param index The index.
-  ///@return the field
+  ///@return The field.
   function level3s(OLKey memory olKey, int index) external view returns (Field);
 
-  ///@notice Gets a level 2 field
+  ///@notice Gets a level 2 field.
   ///@param olKey The offer list key given by (maker) `outbound_tkn`, (maker) `inbound_tkn`, and `tickSpacing`.
   ///@param index The index.
-  ///@return the field
+  ///@return The field.
   function level2s(OLKey memory olKey, int index) external view returns (Field);
 
-  ///@notice Gets a level 1 field
+  ///@notice Gets a level 1 field.
   ///@param olKey The offer list key given by (maker) `outbound_tkn`, (maker) `inbound_tkn`, and `tickSpacing`.
   ///@param index The index.
-  ///@return the field
+  ///@return Yhe field.
   function level1s(OLKey memory olKey, int index) external view returns (Field);
 
   ///@notice Gets the root from local.
   ///@param olKey The offer list key given by (maker) `outbound_tkn`, (maker) `inbound_tkn`, and `tickSpacing`.
-  ///@return the root
+  ///@return The root.
   function root(OLKey memory olKey) external view returns (Field);
 
   // # Internal functions
 
-  ///@notice internal function used to flashloan tokens from taker to maker, for maker to source the promised liquidity.
-  ///@param sor data about an order-offer match.
-  ///@param taker the taker.
-  ///@return gasused the amount of gas used for `makerExecute`.
-  ///@return makerData the data returned by `makerExecute`.
-  ///@dev not to be called externally - only external to be able to revert.
+  ///@notice Internal function used to flashloan tokens from taker to maker, for maker to source the promised liquidity.
+  ///@param sor Data about an order-offer match.
+  ///@param taker The taker.
+  ///@return gasused The amount of gas used for `makerExecute`.
+  ///@return makerData The data returned by `makerExecute`.
+  ///@dev Not to be called externally - only external to be able to revert.
   function flashloan(MgvLib.SingleOrder memory sor, address taker) external returns (uint gasused, bytes32 makerData);
 
-  ///@notice internal function used to clean failing offers.
-  ///@param olKey The offer list key given by (maker) `outbound_tkn`, (maker) `inbound_tkn`, and `tickSpacing`
+  ///@notice Internal function used to clean failing offers.
+  ///@param olKey The offer list key given by (maker) `outbound_tkn`, (maker) `inbound_tkn`, and `tickSpacing`.
   ///@param offerId The id of the offer on Mangrove.
-  ///@param tick Must be `>= MIN_TICK` and `<= MAX_TICK`. The tick.
+  ///@param tick Must be `>= MIN_TICK` and `<= MAX_TICK`. The `tick` induces a price which is `1.0001^tick`. The actual tick of the offer will be the smallest tick `offerTick > tick` that satisfies `offerTick % tickSpacing == 0`.
   ///@param gasreq The gas required for the offer.
   ///@param takerWants Must be `<= MAX_SAFE_VOLUME`. The amount of `olKey.outbound_tkn` the taker wants.
   ///@param taker The taker used for transfers (should be able to deliver token amounts).
-  ///@return bounty the bounty paid.
-  ///@dev not to be called externally - only external to be able to revert.
+  ///@return bounty The bounty paid.
+  ///@dev Not to be called externally - only external to be able to revert.
   function internalCleanByImpersonation(
     OLKey memory olKey,
     uint offerId,
@@ -437,8 +437,8 @@ interface IMangrove is HasMgvEvents {
     address taker
   ) external returns (uint bounty);
 
-  ///@notice Fall back function (forwards calls to `MgvAppendix`)
+  ///@notice Fall back function (forwards calls to `MgvAppendix`).
   ///@param callData The call data.
-  ///@return the result.
+  ///@return The result.
   fallback(bytes calldata callData) external returns (bytes memory);
 }

--- a/src/IMangrove.sol
+++ b/src/IMangrove.sol
@@ -190,7 +190,7 @@ interface IMangrove is HasMgvEvents {
 
   ///@notice Creates a new offer on Mangrove, where the caller is the maker. The maker can implement the `IMaker` interface to be called during offer execution.
   ///@param olKey The offer list key given by (maker) `outbound_tkn`, (maker) `inbound_tkn`, and `tickSpacing`.
-  ///@param tick Must be `>= MIN_TICK` and `<= MAX_TICK`. The tick (which is a power of 1.0001 and induces a price). The actual tick of the offer will be the smallest tick offerTick > tick that satisfies offerTick % tickSpacing == 0.
+  ///@param tick Must be `>= MIN_TICK` and `<= MAX_TICK`. The `tick` induces a price which is `1.0001^tick`. The actual tick of the offer will be the smallest tick `offerTick > tick` that satisfies `offerTick % tickSpacing == 0`.
   ///@param gives Must be `<= MAX_SAFE_VOLUME`. The amount of `olKey.outbound_tkn` the maker gives.
   ///@param gasreq The amount of gas required to execute the offer logic in the maker's `IMaker` implementation. This will limit the gas available, and the offer will fail if it spends more.
   ///@param gasprice The maximum gas price the maker is willing to pay a penalty for due to failing execution.
@@ -217,7 +217,7 @@ interface IMangrove is HasMgvEvents {
 
   ///@notice Updates an existing offer on Mangrove, where the caller is the maker.
   ///@param olKey The offer list key given by (maker) `outbound_tkn`, (maker) `inbound_tkn`, and `tickSpacing`.
-  ///@param tick Must be `>= MIN_TICK` and `<= MAX_TICK`. The tick (which is a power of 1.0001 and induces a price).
+  ///@param tick Must be `>= MIN_TICK` and `<= MAX_TICK`. The `tick` induces a price which is `1.0001^tick`.
   ///@param gives The amount of `olKey.outbound_tkn` the maker gives. Must be less than MAX_SAFE_VOLUME.
   ///@param gasreq The amount of gas required to execute the offer logic in the maker's `IMaker` implementation.
   ///@param gasprice The maximum gas price the maker is willing to pay a penalty for due to failing execution.

--- a/src/core/MgvCommon.sol
+++ b/src/core/MgvCommon.sol
@@ -13,7 +13,7 @@ contract MgvCommon is HasMgvEvents {
   //+clear+
 
   /* The `governance` address. Governance is the only address that can configure parameters. */
-  address public governance;
+  address internal _governance;
 
   /* Global mgv configuration, encoded in a 256 bits word. The information encoded is detailed in [`structs.js`](#structs.js). */
   Global internal internal_global;

--- a/src/core/MgvGovernable.sol
+++ b/src/core/MgvGovernable.sol
@@ -16,7 +16,7 @@ contract MgvGovernable is MgvCommon {
 
   /* ## Transfer ERC20 tokens to governance.
 
-    If this function is called while an order is executing, the reentrancy may prevent a taker from receiving their tokens. This is fine as the order execution will then fail, and the tx will revert. So the most a malicious governance can do is render Mangrove unusable.
+    If this function is called while an order is executing, the reentrancy may prevent a taker from receiving their tokens. This is fine as the order execution will then fail and the tx will revert. So the most a malicious governance can do is render Mangrove unusable.
   */
   function withdrawERC20(address tokenAddress, uint value) external {
     authOnly();
@@ -86,7 +86,7 @@ contract MgvGovernable is MgvCommon {
   function setGasbase(OLKey memory olKey, uint offer_gasbase) public {
     unchecked {
       authOnly();
-      /* Checking the size of `offer_gasbase` is necessary to prevent a) data loss when copied to an `OfferDetail` struct, and b) overflow when used in calculations. */
+      /* Checking the size of `offer_gasbase` is necessary to prevent a) data loss when copied to an `OfferDetail` struct and b) overflow when used in calculations. */
       require(LocalLib.kilo_offer_gasbase_check(offer_gasbase / 1e3), LocalLib.kilo_offer_gasbase_size_error);
       // require(uint24(offer_gasbase) == offer_gasbase, "mgv/config/offer_gasbase/24bits");
       //+clear+

--- a/src/core/MgvGovernable.sol
+++ b/src/core/MgvGovernable.sol
@@ -10,7 +10,7 @@ contract MgvGovernable is MgvCommon {
 
   function authOnly() internal view {
     unchecked {
-      require(msg.sender == governance || msg.sender == address(this) || governance == address(0), "mgv/unauthorized");
+      require(msg.sender == _governance || msg.sender == address(this) || _governance == address(0), "mgv/unauthorized");
     }
   }
 
@@ -20,7 +20,7 @@ contract MgvGovernable is MgvCommon {
   */
   function withdrawERC20(address tokenAddress, uint value) external {
     authOnly();
-    require(transferToken(tokenAddress, governance, value), "mgv/withdrawERC20Fail");
+    require(transferToken(tokenAddress, _governance, value), "mgv/withdrawERC20Fail");
   }
 
   /* # Set configuration and Mangrove state */
@@ -160,7 +160,7 @@ contract MgvGovernable is MgvCommon {
     unchecked {
       authOnly();
       require(governanceAddress != address(0), "mgv/config/gov/not0");
-      governance = governanceAddress;
+      _governance = governanceAddress;
       emit SetGovernance(governanceAddress);
     }
   }

--- a/src/core/MgvHasOffers.sol
+++ b/src/core/MgvHasOffers.sol
@@ -62,7 +62,7 @@ contract MgvHasOffers is MgvCommon {
             - If the root is now empty, return
   - Once we are done marking leaves/fields as empty, if the removed offer was the best there is at least one remaining offer, and if the caller requested it by setting `shouldUpdateBranch=true`, go down the tree and find the new best offer.
 
-  Each step must take into account the fact that the branch of the best offer is cached in `local`, and that loading a new best offer requires caching a different branch in `local`.
+  Each step must take into account the fact that the branch of the best offer is cached in `local` and that loading a new best offer requires caching a different branch in `local`.
 
   The reason why the caller might set `shouldUpdateBranch=false` is that it is itself about to insert an offer better than the current best offer. In that case, it will take care of caching the branch of the new best offer after calling `dislodgeOffer`.
 

--- a/src/core/MgvLib.sol
+++ b/src/core/MgvLib.sol
@@ -72,7 +72,7 @@ library MgvLib {
     Local local;
   }
 
-  /* <a id="MgvLib/OrderResult"></a> `OrderResult` holds additional data for the maker and is given to them _after_ they fulfilled an offer. It gives them their own returned data from the previous call, and an `mgvData` specifying whether Mangrove encountered an error. */
+  /* <a id="MgvLib/OrderResult"></a> `OrderResult` holds additional data for the maker and is given to them _after_ they fulfilled an offer. It gives them their own returned data from the previous call and an `mgvData` specifying whether Mangrove encountered an error. */
 
   struct OrderResult {
     /* `makerData` holds a message that was either returned by the maker or passed as revert message at the end of the trade execution*/

--- a/src/core/MgvOfferMaking.sol
+++ b/src/core/MgvOfferMaking.sol
@@ -26,7 +26,7 @@ contract MgvOfferMaking is MgvHasOffers {
     Offer oldOffer;
   }
 
-  /* The function `newOffer` is for market makers only; no match with the existing offer list is done. The maker specifies how much `olKey.outbound_tkn` token it `gives`, and at which `tick` (which induces the price `1.0001^tick`). The actual tick of the offer will be the smallest tick offerTick > tick that satisfies offerTick % tickSpacing == 0.
+  /* The function `newOffer` is for market makers only; no match with the existing offer list is done. The maker specifies how much `olKey.outbound_tkn` token it `gives` and at which `tick` (which induces the price `1.0001^tick`). The actual tick of the offer will be the smallest tick offerTick > tick that satisfies offerTick % tickSpacing == 0.
 
      It also specify with `gasreq` how much gas should be given when executing their offer.
 
@@ -219,7 +219,7 @@ contract MgvOfferMaking is MgvHasOffers {
   /* Used by `updateOfferBy*` and `newOfferBy*`, this function optionally removes an offer then (re)inserts it in the tick tree. The `update` argument indicates whether the call comes from `updateOfferBy*` or `newOfferBy*`. */
   function writeOffer(OfferList storage offerList, OfferPack memory ofp, Tick insertionTick, bool update) internal {
     unchecked {
-      /* `gasprice`'s floor is Mangrove's own gasprice estimate, `ofp.global.gasprice`. We first check that gasprice fits in 26 bits. Otherwise it could be that `uint26(gasprice) < global_gasprice < gasprice`, and the actual value we store is `uint26(gasprice)` (using pseudocode here since the type uint26 does not exist). */
+      /* `gasprice`'s floor is Mangrove's own gasprice estimate, `ofp.global.gasprice`. We first check that gasprice fits in 26 bits. Otherwise it could be that `uint26(gasprice) < global_gasprice < gasprice` and the actual value we store is `uint26(gasprice)` (using pseudocode here since the type uint26 does not exist). */
       require(GlobalLib.gasprice_check(ofp.gasprice), "mgv/writeOffer/gasprice/tooBig");
 
       if (ofp.gasprice < ofp.global.gasprice()) {
@@ -423,7 +423,7 @@ contract MgvOfferMaking is MgvHasOffers {
         }
       }
 
-      /* Now that we are done checking the current state of the leaf, we can update it. By reading the last id of the written offer's bin in the offer's leaf, we can check if the bin is currently empty or not (as an invariant, an empty bin has both `firstId` and `lastId` equal to 0, and a nonempty bin has both ids different from 0. 
+      /* Now that we are done checking the current state of the leaf, we can update it. By reading the last id of the written offer's bin in the offer's leaf, we can check if the bin is currently empty or not (as an invariant, an empty bin has both `firstId` and `lastId` equal to 0, and a nonempty bin has both ids different from 0). 
 
       Note that offers are always inserted at the end of their bin, so that earlier offer are taken first during market orders.
       */

--- a/src/core/MgvOfferMaking.sol
+++ b/src/core/MgvOfferMaking.sol
@@ -26,7 +26,7 @@ contract MgvOfferMaking is MgvHasOffers {
     Offer oldOffer;
   }
 
-  /* The function `newOffer` is for market makers only; no match with the existing offer list is done. The maker specifies how much `olKey.outbound_tkn` token it `gives`, and at which `tick` (which is a power of 1.0001 and induces a price). The actual tick of the offer will be the smallest tick offerTick > tick that satisfies offerTick % tickSpacing == 0.
+  /* The function `newOffer` is for market makers only; no match with the existing offer list is done. The maker specifies how much `olKey.outbound_tkn` token it `gives`, and at which `tick` (which induces the price `1.0001^tick`). The actual tick of the offer will be the smallest tick offerTick > tick that satisfies offerTick % tickSpacing == 0.
 
      It also specify with `gasreq` how much gas should be given when executing their offer.
 

--- a/src/core/MgvOfferMaking.sol
+++ b/src/core/MgvOfferMaking.sol
@@ -209,6 +209,7 @@ contract MgvOfferMaking is MgvHasOffers {
       /* Since we only ever send money to the caller, we do not need to provide any particular amount of gas, the caller should manage this herself. */
       debitWei(msg.sender, amount);
       (noRevert,) = msg.sender.call{value: amount}("");
+      require(noRevert, "mgv/withdrawCallRevert");
     }
   }
 

--- a/src/core/MgvOfferTaking.sol
+++ b/src/core/MgvOfferTaking.sol
@@ -52,7 +52,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
     }
   }
 
-  /* There is a `ByVolume` variant where the taker specifies a desired total amount of `olKey.outbound_tkn` tokens (`takerWants`), and an available total amount of `olKey.inbound_tkn` (`takerGives`). Volumes should fit on 127 bits. */
+  /* There is a `ByVolume` variant where the taker specifies a desired total amount of `olKey.outbound_tkn` tokens (`takerWants`) and an available total amount of `olKey.inbound_tkn` (`takerGives`). Volumes should fit on 127 bits. */
   function marketOrderByVolume(OLKey memory olKey, uint takerWants, uint takerGives, bool fillWants)
     public
     returns (uint takerGot, uint takerGave, uint bounty, uint feePaid)
@@ -228,7 +228,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
       /* Throughout the market order, `fillVolume` represents the amount left to buy (if `fillWants`) or sell (if `!fillWants`). */
       mor.fillVolume = fillVolume;
 
-      /* For the market order to start, the offer list needs to be both active, and not currently protected from reentrancy. */
+      /* For the market order to start, the offer list needs to be both active and not currently protected from reentrancy. */
       activeOfferListOnly(sor.global, sor.local);
       unlockedOfferListOnly(sor.local);
 
@@ -350,7 +350,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
         /* <a id="internalMarketOrder/liftReentrancy"></a>Now that the market order is over, we can lift the lock on the book. In the same operation we
 
-      * lift the reentrancy lock, and
+      * lift the reentrancy lock and
       * update the storage
 
       so we are free from out of order storage writes.
@@ -471,7 +471,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
         /* <a id="internalCleans/liftReentrancy"></a> Now that the current clean is over, we can lift the lock on the book. In the same operation we
 
-        * lift the reentrancy lock, and
+        * lift the reentrancy lock and
         * update the storage
 
         so we are free from out of order storage writes.
@@ -531,7 +531,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
       }
       /* The flashloan is executed by call to `flashloan`. If the call reverts, it means the maker failed to send back `sor.takerWants` units of `olKey.outbound_tkn` to the taker. Notes :
        * `msg.sender` is Mangrove itself in those calls -- all operations related to the actual caller should be done outside of this call.
-       * any spurious exception due to an error in Mangrove code will be falsely blamed on the Maker, and its provision for the offer will be unfairly taken away.
+       * any spurious exception due to an error in Mangrove code will be falsely blamed on the Maker and its provision for the offer will be unfairly taken away.
        */
       bool success;
       bytes memory retdata;
@@ -554,7 +554,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
       /* `success` is true: trade is complete */
       if (success) {
-        /* In case of success, `retdata` encodes the gas used by the offer, and an arbitrary 256 bits word sent by the maker.  */
+        /* In case of success, `retdata` encodes the gas used by the offer and an arbitrary 256 bits word sent by the maker.  */
         (gasused, makerData) = abi.decode(retdata, (uint, bytes32));
         /* `internalMgvData` indicates trade success */
         internalMgvData = bytes32("mgv/tradeSuccess");

--- a/src/core/MgvOfferTaking.sol
+++ b/src/core/MgvOfferTaking.sol
@@ -767,7 +767,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
   /*
      Penalty application summary:
 
-   * If the transaction was a success, we entirely refund the maker and send nothing to the taker.
+   * `applyPenalty` is not called if the offer executes successfully, so the offer remains provisioned. The maker can move the provision from the offer to its internal balance by calling `retractOffer(olKey,offerId,true)`.
    * Otherwise, the maker loses the cost of `gasused + offer_gasbase` gas. The gas price is estimated by `gasprice`.
    * To create the offer, the maker had to provision for `gasreq + offer_gasbase` gas at a price of `offerDetail.gasprice`.
    * We do not consider the tx.gasprice.

--- a/src/core/MgvOfferTaking.sol
+++ b/src/core/MgvOfferTaking.sol
@@ -568,7 +568,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
         mor.totalGot += sor.takerWants;
         require(mor.totalGot >= sor.takerWants, "mgv/totalGot/overflow");
         mor.totalGave += sor.takerGives;
-        require(mor.totalGave >= sor.takerGives, "mgv/totalGot/overflow");
+        require(mor.totalGave >= sor.takerGives, "mgv/totalGave/overflow");
       } else {
         /* In case of failure, `retdata` encodes an [internal status code](#MgvOfferTaking/internalStatusCodes), the gas used by the offer, and an arbitrary 256 bits word sent by the maker.  */
         (internalMgvData, gasused, makerData) = innerDecode(retdata);

--- a/src/core/MgvOfferTaking.sol
+++ b/src/core/MgvOfferTaking.sol
@@ -238,7 +238,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
        * not set `prev`/`next` pointers to their correct locations at each offer taken (this is an optimization enabled by forbidding reentrancy).
        * after consuming a segment of offers, will update the current `best` offer to be the best remaining offer on the book. */
 
-      /* We start be enabling the reentrancy lock for this (`olKey.outbound_tkn`,`olKey.inbound_tkn`, `olKey.tickSpacing`) offer list. */
+      /* We start by enabling the reentrancy lock for this (`olKey.outbound_tkn`,`olKey.inbound_tkn`, `olKey.tickSpacing`) offer list. */
       sor.local = sor.local.lock(true);
       offerList.local = sor.local;
 

--- a/src/core/MgvOfferTakingWithPermit.sol
+++ b/src/core/MgvOfferTakingWithPermit.sol
@@ -71,8 +71,6 @@ abstract contract MgvOfferTakingWithPermit is MgvOfferTaking {
     returns (uint takerGot, uint takerGave, uint bounty, uint feePaid)
   {
     unchecked {
-      require(uint160(takerWants) == takerWants, "mgv/mOrder/takerWants/160bits");
-      require(uint160(takerGives) == takerGives, "mgv/mOrder/takerGives/160bits");
       uint fillVolume = fillWants ? takerWants : takerGives;
       Tick tick = TickLib.tickFromVolumes(takerGives, takerWants);
       return marketOrderForByTick(olKey, tick, fillVolume, fillWants, taker);

--- a/src/core/MgvOfferTakingWithPermit.sol
+++ b/src/core/MgvOfferTakingWithPermit.sol
@@ -90,7 +90,7 @@ abstract contract MgvOfferTakingWithPermit is MgvOfferTaking {
 
   /* # Misc. low-level functions */
 
-  /* Used by `*For` functions, it both checks that `msg.sender` was allowed to use the taker's funds, and decreases the former's allowance. */
+  /* Used by `*For` functions, it both checks that `msg.sender` was allowed to use the taker's funds and decreases the former's allowance. */
   function deductSenderAllowance(address outbound_tkn, address inbound_tkn, address owner, uint amount) internal {
     unchecked {
       mapping(address => uint) storage curriedAllow = _allowance[outbound_tkn][inbound_tkn][owner];

--- a/src/core/MgvView.sol
+++ b/src/core/MgvView.sol
@@ -7,6 +7,11 @@ import "@mgv/src/core/MgvCommon.sol";
 /* Contains view functions, to reduce Mangrove contract size */
 contract MgvView is MgvCommon {
   /* # Configuration Reads */
+  /* Get the address of Mangrove's governance. Only governance can successfully call functions of `MgvGovernable`. */
+  function governance() external view returns (address) {
+    return _governance;
+  }
+
   /* Reading the configuration for an offer list involves reading the config global to all offer lists and the local one. In addition, a global parameter (`gasprice`) and a local one (`density`) may be read from the oracle. */
   function config(OLKey memory olKey) external view returns (Global _global, Local _local) {
     unchecked {

--- a/test/core/MakerOperations.t.sol
+++ b/test/core/MakerOperations.t.sol
@@ -195,6 +195,14 @@ contract MakerOperationsTest is MangroveTest, IMaker {
     mkr.withdrawMgv(amt1 + 1);
   }
 
+  function test_withdraw_to_reverting_contract_fails(uint64 amt) public {
+    vm.assume(amt > 0);
+    mkr.provisionMgv(amt);
+    vm.mockCallRevert(address(mkr), amt, bytes.concat(""), bytes(""));
+    vm.expectRevert("mgv/withdrawCallRevert");
+    mkr.withdrawMgv(amt);
+  }
+
   function test_newOffer_without_mgv_balance_fails() public {
     vm.expectRevert("mgv/insufficientProvision");
     mkr.newOfferByVolume(1 ether, 1 ether, 0, 0);

--- a/test/core/MakerPosthook.t.sol
+++ b/test/core/MakerPosthook.t.sol
@@ -302,9 +302,9 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     expectFrom($(mgv));
     // FIXME use vulcan's approach to checking events after the fact
     // https://github.com/nomoixyz/vulcan/blob/25788a482552ff7a3c2c1c7e148b323ce848182d/src/_modules/Expect.sol#L602
-    emit Credit($(this), 19191492440000000);
+    emit Credit($(this), 19191493320000000);
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), $(tkr), ofr, 1 ether, 1 ether, 8507560000000, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), $(tkr), ofr, 1 ether, 1 ether, 8506680000000, "mgv/makerRevert");
     bool success = tkr.marketOrderWithSuccess(2 ether);
     assertTrue(!success, "market order should fail");
     assertTrue(called, "PostHook not called");
@@ -391,9 +391,9 @@ contract MakerPosthookTest is MangroveTest, IMaker {
     expectFrom($(mgv));
     emit OfferRetract(olKey.hash(), $(this), ofr, true);
     expectFrom($(mgv));
-    emit Credit($(this), 19191492440000000);
+    emit Credit($(this), 19191493320000000);
     expectFrom($(mgv));
-    emit OfferFail(olKey.hash(), $(tkr), ofr, 1 ether, 1 ether, 8507560000000, "mgv/makerRevert");
+    emit OfferFail(olKey.hash(), $(tkr), ofr, 1 ether, 1 ether, 8506680000000, "mgv/makerRevert");
     bool success = tkr.marketOrderWithSuccess(2 ether);
     assertTrue(called, "PostHook not called");
 


### PR DESCRIPTION
## To do
- [x] Ask ChainSec to use the new logo, both in the report and on their website. I put a copy of the logo in the Google Drive folder with the draft report
	- Done on Telegram
- [x] Ask ChainSec to reference their latest Mangrove audit report in section 2.2
	- In section 2.2 they link to a previous report from May 2022
		- https://web.archive.org/web/20221230124638/https://chainsecurity.com/wp-content/uploads/2022/03/ChainSecurity_Giry_Mangrove_audit_220511.pdf
		- The most recent one is from March 21, 2023
			- https://chainsecurity.com/security-audit/mangrove-smart-contract/
	- Noted in the response document
- [x] Fix issues from Section 5 and 6
	- Besides fixing the issues are there any files we need to update?
		- eg AUDIT_TRAIL and CHANGELOG?
		- Nope
	- Section 5
		- [x] 5.1 Incorrect Comments
			- [x] 5.1.1 `TickTreeLib.bestNonEmptyBinPos` comment
				- ChainSec thinks    `iszero(pos)<<1`   should be changed to   `1<<iszero(ret)`
				  - Fixed
			- [x] 5.1.2 `Bitlib.fls` comment
			  - Deleted
			- [x] 5.1.3 `MgvOfferTaking` typo: `be`  ->  `by`
				- Fixed
			- [x] 5.1.4 `MgvOfferTaking.applyPenalty()` comment
			  - Fixed
		- [x] 5.2 Redundant Input Validation
			- Redundant validation removed
		- [x] 5.3 Withdraw Does Not Revert
			- Fixed
	- Section 6
		- [x] 6.1 Inconsistent Variable Naming
		  - Do nothing, but use the opportunity to make `governance` internal.
		- [x] 6.2 Permit Does Not Specify Price and Lasts Forever
			- This is intended and should not be changed
		- [x] 6.3 Typo in Error String
			- Fixed
- [x] Fill out response template in Google Drive
	- Espen: Added notes re. Section 2 + draft responses to findings.
- [x] Other things:
   - [x] @espendk  I remember noticing some weird phrasings in the IMangrove comments which @lnist  said came from the comments of the functions themselves: I think this is one such instance: https://github.com/mangrovedao/mangrove-core/pull/603#discussion_r1342915459
   - [x] @espendk We should review the occurrences of “, and” as some have been observed in the past to be inappropriate (maybe a “use Oxford comma everywhere” search-replace gone wrong?).
   	 - Done
   - [x] Outbound, inbound inconsistencies - from Lasse:
       ```
			/* ### (outbound,inbound) → ratio */
			function tickFromVolumes(uint inboundAmt, uint outboundAmt) internal pure returns (Tick tick) {
       ```
		- We normally have outbound,inbound (so the comment is right) but the function takes inbound,outbound. There are multiple occurrences in ticklib of this reversal.
		- Espen: This occurs in functions (`ratioFromVolumes`, `tickFromVolumes`) that convert `inbound amount`, `outbound amount` to a ratio, ie they calculate `inbound amount / outbound amount`. From this perspective, the parameter ordering makes sense as it matches the order of the operands in the primary calculation the functions compute. So not sure this should be changed?
		- Solution: Updated the comments to match the parameter ordering
	- [x] @espendk  Ratio should be defined as inbound/outbound
		- Done