### PR TITLE
docs(license): Update licenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Next version
 
+- Update licenses:
+  - Change license of Contants.sol and TickLib.sol from BUSL-1.1 to MIT
+  - Replace Unlicense and BSD-2-Clause with MIT
+  - Replace AGPL-3.0 with AGPL-3.0-or-later
+  - Consistently use AGPL-3.0-or-later for tools, scripts, and tests
+  - Restore MIT license for OpenZeppelin code
+
 # 2.0.0
 
 - New tick-based API with constant-gas insert, update, and retract of offers (the volume-based API is still available)

--- a/LICENSE
+++ b/LICENSE
@@ -3,9 +3,8 @@ Copyright (c)-2023 ADDMA (Mangrove Association). All rights reserved.
 The files in this repo are covered by different licenses:
 
 * Mangrove Core contracts are licensed under Business Source License 1.1.
-* Contract interfaces (ABIs) are licensed under Unlicense (i.e. they are public domain).
-* Tools and other pieces of code are licensed under BSD 2-Clause License
-    or GNU AFFERO GENERAL PUBLIC LICENSE v3.
+* Contract interfaces (ABIs) are licensed under MIT License.
+* Tools and other pieces of code are licensed under GNU AFFERO GENERAL PUBLIC LICENSE v3.
 
 Each file header contains the SPDX license identifier of the license for that file.
 For more information about SPDX, please refer to <https://spdx.dev/>.
@@ -780,44 +779,12 @@ For more information on this, and how to apply and follow the GNU AGPL, see
 
 -------------------------------------------------------------------------------
 
-BSD 2-Clause License
+MIT License
 
-Copyright (c), ADDMA (Mangrove Association)
-All rights reserved.
+Copyright (c) 2023 ADDMA (Mangrove Association)
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
+The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
 
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-
--------------------------------------------------------------------------------
-
-The Unlicense
-
-This is free and unencumbered software released into the public domain.
-
-Anyone is free to copy, modify, publish, use, compile, sell, or distribute this software, either in source code form or as a compiled binary, for any purpose, commercial or non-commercial, and by any means.
-
-In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain. We make this dedication for the benefit of the public at large and to the detriment of our heirs and successors. We intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-For more information, please refer to <https://unlicense.org/>
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,8 @@ The files in this repo are covered by different licenses:
 
 * Mangrove Core contracts are licensed under Business Source License 1.1.
 * Contract interfaces (ABIs) are licensed under MIT License.
-* Tools and other pieces of code are licensed under GNU AFFERO GENERAL PUBLIC LICENSE v3.
+* Tools and other pieces of code are licensed under GNU AFFERO GENERAL PUBLIC LICENSE v3
+    or any later version.
 
 Each file header contains the SPDX license identifier of the license for that file.
 For more information about SPDX, please refer to <https://spdx.dev/>.

--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,8 @@ Copyright (c)-2023 ADDMA (Mangrove Association). All rights reserved.
 The files in this repo are covered by different licenses:
 
 * Mangrove Core contracts are licensed under Business Source License 1.1.
-* Contract interfaces (ABIs) are licensed under MIT License.
+* Contract interfaces (ABIs) and libraries useful for integrating with Mangrove
+    are licensed under MIT License.
 * Tools and other pieces of code are licensed under GNU AFFERO GENERAL PUBLIC LICENSE v3
     or any later version.
 

--- a/LICENSE
+++ b/LICENSE
@@ -5,8 +5,8 @@ The files in this repo are covered by different licenses:
 * Mangrove Core contracts are licensed under Business Source License 1.1.
 * Contract interfaces (ABIs) and libraries useful for integrating with Mangrove
     are licensed under MIT License.
-* Tools and other pieces of code are licensed under GNU AFFERO GENERAL PUBLIC LICENSE v3
-    or any later version.
+* Tools, scripts, tests, and other pieces of code are licensed under
+    GNU AFFERO GENERAL PUBLIC LICENSE v3 or any later version.
 * OpenZeppelin code in ERC20.sol and ERC20Lib.sol is covered by the original
     MIT License (text included below).
 

--- a/LICENSE
+++ b/LICENSE
@@ -7,6 +7,8 @@ The files in this repo are covered by different licenses:
     are licensed under MIT License.
 * Tools and other pieces of code are licensed under GNU AFFERO GENERAL PUBLIC LICENSE v3
     or any later version.
+* OpenZeppelin code in ERC20.sol and ERC20Lib.sol is covered by the original
+    MIT License (text included below).
 
 Each file header contains the SPDX license identifier of the license for that file.
 For more information about SPDX, please refer to <https://spdx.dev/>.
@@ -790,3 +792,30 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+-------------------------------------------------------------------------------
+OpenZeppelin MIT License
+-------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2016-2023 zOS Global Limited and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/Debug.sol
+++ b/lib/Debug.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.13;
 

--- a/lib/IERC20.sol
+++ b/lib/IERC20.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.6.2;
 
 interface IERC20 {

--- a/lib/Script2.sol
+++ b/lib/Script2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-2.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {Script} from "@mgv/forge-std/Script.sol";

--- a/lib/Test2.sol
+++ b/lib/Test2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {Test, console2} from "@mgv/forge-std/Test.sol";

--- a/lib/ToyENS.sol
+++ b/lib/ToyENS.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
 /* Onchain contract registry with the following features:

--- a/lib/TransferLib.sol
+++ b/lib/TransferLib.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	BSD-2-Clause
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.10;
 
 import "@mgv/src/core/MgvLib.sol";

--- a/lib/core/Constants.sol
+++ b/lib/core/Constants.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
 /* The constants below are written as literals to optimize gas. For all the relevant constants here, the non-literal expression that computes them is checked in `Constants.t.sol`. */

--- a/lib/core/LocalExtra.sol
+++ b/lib/core/LocalExtra.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
 import {Bin,TickTreeLib,Field} from "@mgv/lib/core/TickTreeLib.sol";

--- a/lib/core/OfferDetailExtra.sol
+++ b/lib/core/OfferDetailExtra.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
 import {OfferDetail,OfferDetailUnpacked} from "@mgv/src/preprocessed/OfferDetail.post.sol";

--- a/lib/core/OfferExtra.sol
+++ b/lib/core/OfferExtra.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
 import "@mgv/lib/core/TickTreeLib.sol";

--- a/lib/core/TickLib.sol
+++ b/lib/core/TickLib.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
 import {Bin} from "@mgv/lib/core/TickTreeLib.sol";

--- a/lib/preprocessed/ToString.post.sol
+++ b/lib/preprocessed/ToString.post.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.13;
 

--- a/preprocessing/Struct.pre.sol.ts
+++ b/preprocessing/Struct.pre.sol.ts
@@ -1,7 +1,7 @@
 import { format, tabulate } from "./lib/format";
 
 export const template = ({ preamble, struct_utilities, struct: s }) => {
-  return format`// SPDX-License-Identifier: Unlicense
+  return format`// SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.13;
 

--- a/preprocessing/Struct.pre.sol.ts
+++ b/preprocessing/Struct.pre.sol.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 import { format, tabulate } from "./lib/format";
 
 export const template = ({ preamble, struct_utilities, struct: s }) => {

--- a/preprocessing/StructTest.pre.sol.ts
+++ b/preprocessing/StructTest.pre.sol.ts
@@ -1,7 +1,7 @@
 import { format, tabulate } from "./lib/format";
 
 export const template = ({ preamble, struct_utilities, struct: s }) => {
-  return format`// SPDX-License-Identifier:	AGPL-3.0
+  return format`// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.13;
 

--- a/preprocessing/StructTest.pre.sol.ts
+++ b/preprocessing/StructTest.pre.sol.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 import { format, tabulate } from "./lib/format";
 
 export const template = ({ preamble, struct_utilities, struct: s }) => {

--- a/preprocessing/Structs.pre.sol.ts
+++ b/preprocessing/Structs.pre.sol.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 import { format } from "./lib/format";
 
 export const template = ({ preamble, structs }) => {

--- a/preprocessing/Structs.pre.sol.ts
+++ b/preprocessing/Structs.pre.sol.ts
@@ -1,7 +1,7 @@
 import { format } from "./lib/format";
 
 export const template = ({ preamble, structs }) => {
-  return format`// SPDX-License-Identifier: Unlicense
+  return format`// SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.13;
 

--- a/preprocessing/ToString.pre.sol.ts
+++ b/preprocessing/ToString.pre.sol.ts
@@ -2,7 +2,7 @@ import { format } from "./lib/format";
 
 
 export const template = ({ preamble, structs }) => {
-  return format`// SPDX-License-Identifier: Unlicense
+  return format`// SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.13;
 

--- a/preprocessing/ToString.pre.sol.ts
+++ b/preprocessing/ToString.pre.sol.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 import { format } from "./lib/format";
 
 

--- a/preprocessing/lib/format.ts
+++ b/preprocessing/lib/format.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 // template tag that converts array to separate lines but keeps the current
 // indent level
 export const format = (strings: TemplateStringsArray, ...nuggets: any[]) => {

--- a/preprocessing/lib/preproc.ts
+++ b/preprocessing/lib/preproc.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 import * as util from "util";
 
 /*

--- a/preprocessing/run.ts
+++ b/preprocessing/run.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 import * as fs from "fs";
 
 import struct_defs from "./structs";

--- a/preprocessing/structs.ts
+++ b/preprocessing/structs.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 /* # Mangrove Summary
    * Mangrove holds offer lists for `outbound_tkn`,`inbound_tkn` pairs with a given `tickSpacing`.
    * Offers are sorted in a tree (the "tick tree") where each available price point (a `bin`) holds a doubly linked list of offers.

--- a/script/README.md
+++ b/script/README.md
@@ -5,7 +5,7 @@ This directory contains scripts (`*.s.sol`) for deploying, configuring, and gove
 This is a script example:
 
 ```solidity
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 // This script is SmallMgvReaderDeployer.s.sol
 pragma solidity ^0.8.13;
 

--- a/script/core/ActivateMarket.s.sol
+++ b/script/core/ActivateMarket.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {Deployer} from "@mgv/script/lib/Deployer.sol";

--- a/script/core/ActivateSemibook.s.sol
+++ b/script/core/ActivateSemibook.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {Deployer} from "@mgv/script/lib/Deployer.sol";

--- a/script/core/DeactivateMarket.s.sol
+++ b/script/core/DeactivateMarket.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {Deployer} from "@mgv/script/lib/Deployer.sol";

--- a/script/core/UseOracle.s.sol
+++ b/script/core/UseOracle.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {Deployer} from "@mgv/script/lib/Deployer.sol";

--- a/script/core/deployers/ArbitrumMangroveDeployer.s.sol
+++ b/script/core/deployers/ArbitrumMangroveDeployer.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {ToyENS} from "@mgv/lib/ToyENS.sol";

--- a/script/core/deployers/MangroveDeployer.s.sol
+++ b/script/core/deployers/MangroveDeployer.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
 import {Mangrove} from "@mgv/src/core/Mangrove.sol";

--- a/script/core/deployers/MangroveDeployer.s.sol
+++ b/script/core/deployers/MangroveDeployer.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {Mangrove} from "@mgv/src/core/Mangrove.sol";

--- a/script/core/deployers/MumbaiMangroveDeployer.s.sol
+++ b/script/core/deployers/MumbaiMangroveDeployer.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {ToyENS} from "@mgv/lib/ToyENS.sol";

--- a/script/core/deployers/PolygonMangroveDeployer.s.sol
+++ b/script/core/deployers/PolygonMangroveDeployer.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {ToyENS} from "@mgv/lib/ToyENS.sol";

--- a/script/core/monitors/EvalSnipeOffer.s.sol
+++ b/script/core/monitors/EvalSnipeOffer.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {Deployer} from "@mgv/script/lib/Deployer.sol";

--- a/script/core/monitors/MarketHealth.s.sol
+++ b/script/core/monitors/MarketHealth.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {Deployer} from "@mgv/script/lib/Deployer.sol";

--- a/script/lib/Deployer.sol
+++ b/script/lib/Deployer.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {Script2} from "@mgv/lib/Script2.sol";

--- a/script/lib/GetTokenDealSlot.sol
+++ b/script/lib/GetTokenDealSlot.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {Deployer} from "@mgv/script/lib/Deployer.sol";

--- a/script/periphery/CopyOpenSemibooks.s.sol
+++ b/script/periphery/CopyOpenSemibooks.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "@mgv/src/periphery/MgvReader.sol";

--- a/script/periphery/UpdateMarket.s.sol
+++ b/script/periphery/UpdateMarket.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "@mgv/src/periphery/MgvReader.sol";

--- a/script/periphery/deployers/MgvReaderDeployer.s.sol
+++ b/script/periphery/deployers/MgvReaderDeployer.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
 import {Script, console} from "@mgv/forge-std/Script.sol";

--- a/script/periphery/deployers/MgvReaderDeployer.s.sol
+++ b/script/periphery/deployers/MgvReaderDeployer.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {Script, console} from "@mgv/forge-std/Script.sol";

--- a/script/toy/deployers/ERC20Deployer.sol
+++ b/script/toy/deployers/ERC20Deployer.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "@mgv/src/core/MgvLib.sol";

--- a/script/toy/deployers/PixieMATICDeployer.s.sol
+++ b/script/toy/deployers/PixieMATICDeployer.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
 import {Script, console} from "@mgv/forge-std/Script.sol";

--- a/script/toy/deployers/PixieMATICDeployer.s.sol
+++ b/script/toy/deployers/PixieMATICDeployer.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {Script, console} from "@mgv/forge-std/Script.sol";

--- a/script/toy/deployers/PixieUSDCDeployer.s.sol
+++ b/script/toy/deployers/PixieUSDCDeployer.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
 import {Script, console} from "@mgv/forge-std/Script.sol";

--- a/script/toy/deployers/PixieUSDCDeployer.s.sol
+++ b/script/toy/deployers/PixieUSDCDeployer.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {Script, console} from "@mgv/forge-std/Script.sol";

--- a/src/IMangrove.sol
+++ b/src/IMangrove.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 // This file must be kept up-to-date with the actual Mangrove interface.
 
 pragma solidity >=0.7.0 <0.9.0;

--- a/src/core/MgvLib.sol
+++ b/src/core/MgvLib.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 
 /* `MgvLib` contains data structures returned by external calls to Mangrove and the interfaces it uses for its own external calls. */
 

--- a/src/preprocessed/Global.post.sol
+++ b/src/preprocessed/Global.post.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.13;
 

--- a/src/preprocessed/Local.post.sol
+++ b/src/preprocessed/Local.post.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.13;
 

--- a/src/preprocessed/Offer.post.sol
+++ b/src/preprocessed/Offer.post.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.13;
 

--- a/src/preprocessed/OfferDetail.post.sol
+++ b/src/preprocessed/OfferDetail.post.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.13;
 

--- a/src/preprocessed/Structs.post.sol
+++ b/src/preprocessed/Structs.post.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.13;
 

--- a/src/toy/ERC20.sol
+++ b/src/toy/ERC20.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: AGPL-3.0-only
+// SPDX-License-Identifier: MIT
+// Code adapted from OpenZeppelin Contracts
 pragma solidity >=0.8.0;
 
 import {IERC20} from "@mgv/lib/IERC20.sol";

--- a/src/toy/ERC20BL.sol
+++ b/src/toy/ERC20BL.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import "./ERC20.sol";

--- a/src/toy/ERC20Lib.sol
+++ b/src/toy/ERC20Lib.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: AGPL-3.0-only
+// SPDX-License-Identifier: MIT
+// Code adapted from OpenZeppelin Contracts
 pragma solidity >=0.8.0;
 
 /**

--- a/src/toy/MintableERC20BLWithDecimals.sol
+++ b/src/toy/MintableERC20BLWithDecimals.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import "./ERC20BL.sol";

--- a/src/toy/PixieMATIC.sol
+++ b/src/toy/PixieMATIC.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {MintableERC20BLWithDecimals} from "./MintableERC20BLWithDecimals.sol";

--- a/src/toy/PixieMATIC.sol
+++ b/src/toy/PixieMATIC.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
 import {MintableERC20BLWithDecimals} from "./MintableERC20BLWithDecimals.sol";

--- a/src/toy/PixieUSDC.sol
+++ b/src/toy/PixieUSDC.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {MintableERC20BLWithDecimals} from "./MintableERC20BLWithDecimals.sol";

--- a/src/toy/PixieUSDC.sol
+++ b/src/toy/PixieUSDC.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
 import {MintableERC20BLWithDecimals} from "./MintableERC20BLWithDecimals.sol";

--- a/test-ratios/TickRatioConversion.sol
+++ b/test-ratios/TickRatioConversion.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.10;
 

--- a/test/core/BasicMakerOperations.t.sol
+++ b/test/core/BasicMakerOperations.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.10;
 

--- a/test/core/Constants.t.sol
+++ b/test/core/Constants.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.10;
 

--- a/test/core/Density.t.sol
+++ b/test/core/Density.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 // those tests should be run with -vv so correct gas estimates are shown
 

--- a/test/core/DynamicTicks.t.sol
+++ b/test/core/DynamicTicks.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.10;
 

--- a/test/core/Field.t.sol
+++ b/test/core/Field.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.10;
 

--- a/test/core/Gatekeeping.t.sol
+++ b/test/core/Gatekeeping.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.10;
 

--- a/test/core/IMangroveAbi.t.sol
+++ b/test/core/IMangroveAbi.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {Test2} from "@mgv/lib/Test2.sol";

--- a/test/core/Leaf.t.sol
+++ b/test/core/Leaf.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.10;
 

--- a/test/core/MakerOperations.t.sol
+++ b/test/core/MakerOperations.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.10;
 

--- a/test/core/MakerPosthook.t.sol
+++ b/test/core/MakerPosthook.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import "@mgv/test/lib/MangroveTest.sol";

--- a/test/core/Monitor.t.sol
+++ b/test/core/Monitor.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.10;
 

--- a/test/core/Permit.t.sol
+++ b/test/core/Permit.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.10;
 

--- a/test/core/Scenarii.t.sol
+++ b/test/core/Scenarii.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.10;
 

--- a/test/core/TakerOperations.t.sol
+++ b/test/core/TakerOperations.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.10;
 

--- a/test/core/TheClog.t.sol
+++ b/test/core/TheClog.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {MangroveTest} from "@mgv/test/lib/MangroveTest.sol";

--- a/test/core/TickAndBin.t.sol
+++ b/test/core/TickAndBin.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.10;
 

--- a/test/core/gas/CleanOtherOfferList.t.sol
+++ b/test/core/gas/CleanOtherOfferList.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.18;
 

--- a/test/core/gas/MarketOrderOtherOfferList.t.sol
+++ b/test/core/gas/MarketOrderOtherOfferList.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.18;
 

--- a/test/core/gas/NewOfferOtherOfferList.t.sol
+++ b/test/core/gas/NewOfferOtherOfferList.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.18;
 

--- a/test/core/gas/NewOfferSameOfferList.t.sol
+++ b/test/core/gas/NewOfferSameOfferList.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.18;
 

--- a/test/core/gas/OfferGasBase.t.sol
+++ b/test/core/gas/OfferGasBase.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {OfferGasBaseBaseTest} from "@mgv/test/lib/gas/OfferGasBaseBase.t.sol";

--- a/test/core/gas/RetractOfferOtherOfferList.t.sol
+++ b/test/core/gas/RetractOfferOtherOfferList.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.18;
 

--- a/test/core/gas/RetractOfferSameOfferList.t.sol
+++ b/test/core/gas/RetractOfferSameOfferList.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.18;
 

--- a/test/core/gas/TickTreeBoundariesGasTest.t.sol
+++ b/test/core/gas/TickTreeBoundariesGasTest.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.18;
 

--- a/test/core/gas/UpdateOfferOtherOfferList.t.sol
+++ b/test/core/gas/UpdateOfferOtherOfferList.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.18;
 

--- a/test/core/gas/UpdateOfferOtherOfferListDetails.t.sol
+++ b/test/core/gas/UpdateOfferOtherOfferListDetails.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.18;
 

--- a/test/core/gas/UpdateOfferSameOfferList.t.sol
+++ b/test/core/gas/UpdateOfferSameOfferList.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.18;
 

--- a/test/core/ticktree/TickTreeCleanOffer.t.sol
+++ b/test/core/ticktree/TickTreeCleanOffer.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:  AGPL-3.0
+// SPDX-License-Identifier:  AGPL-3.0-or-later
 
 pragma solidity ^0.8.18;
 

--- a/test/core/ticktree/TickTreeMarketOrder.t.sol
+++ b/test/core/ticktree/TickTreeMarketOrder.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:  AGPL-3.0
+// SPDX-License-Identifier:  AGPL-3.0-or-later
 
 pragma solidity ^0.8.18;
 

--- a/test/core/ticktree/TickTreeNewOffer.t.sol
+++ b/test/core/ticktree/TickTreeNewOffer.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.18;
 

--- a/test/core/ticktree/TickTreeRetractOffer.t.sol
+++ b/test/core/ticktree/TickTreeRetractOffer.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:  AGPL-3.0
+// SPDX-License-Identifier:  AGPL-3.0-or-later
 
 pragma solidity ^0.8.18;
 

--- a/test/core/ticktree/TickTreeTest.t.sol
+++ b/test/core/ticktree/TickTreeTest.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.18;
 

--- a/test/core/ticktree/TickTreeTestAssumptions.t.sol
+++ b/test/core/ticktree/TickTreeTestAssumptions.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.18;
 

--- a/test/core/ticktree/TickTreeUpdateOffer.t.sol
+++ b/test/core/ticktree/TickTreeUpdateOffer.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:  AGPL-3.0
+// SPDX-License-Identifier:  AGPL-3.0-or-later
 
 pragma solidity ^0.8.18;
 

--- a/test/lib/AllMethodIdentifiersTest.sol
+++ b/test/lib/AllMethodIdentifiersTest.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {stdJson} from "@mgv/forge-std/StdJson.sol";

--- a/test/lib/MangroveTest.sol
+++ b/test/lib/MangroveTest.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {Test2, toFixed, Test, console, toString, vm} from "@mgv/lib/Test2.sol";

--- a/test/lib/TestTickTree.sol
+++ b/test/lib/TestTickTree.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.18;
 

--- a/test/lib/agents/MakerDeployer.sol
+++ b/test/lib/agents/MakerDeployer.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.10;
 

--- a/test/lib/agents/TestMaker.sol
+++ b/test/lib/agents/TestMaker.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "@mgv/src/IMangrove.sol";

--- a/test/lib/agents/TestMoriartyMaker.sol
+++ b/test/lib/agents/TestMoriartyMaker.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {IMangrove} from "@mgv/src/IMangrove.sol";

--- a/test/lib/agents/TestSender.sol
+++ b/test/lib/agents/TestSender.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.10;
 

--- a/test/lib/agents/TestTaker.sol
+++ b/test/lib/agents/TestTaker.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.10;
 

--- a/test/lib/forks/Arbitrum.sol
+++ b/test/lib/forks/Arbitrum.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {GenericFork} from "./Generic.sol";

--- a/test/lib/forks/Ethereum.sol
+++ b/test/lib/forks/Ethereum.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {GenericFork} from "./Generic.sol";

--- a/test/lib/forks/Generic.sol
+++ b/test/lib/forks/Generic.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {Script, console, stdJson} from "@mgv/forge-std/Script.sol";

--- a/test/lib/forks/Goerli.sol
+++ b/test/lib/forks/Goerli.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {GenericFork} from "./Generic.sol";

--- a/test/lib/forks/Local.sol
+++ b/test/lib/forks/Local.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {GenericFork} from "./Generic.sol";

--- a/test/lib/forks/Mumbai.sol
+++ b/test/lib/forks/Mumbai.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {GenericFork} from "./Generic.sol";

--- a/test/lib/forks/Polygon.sol
+++ b/test/lib/forks/Polygon.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {GenericFork} from "./Generic.sol";

--- a/test/lib/forks/TestnetZkevm.sol
+++ b/test/lib/forks/TestnetZkevm.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {GenericFork} from "./Generic.sol";

--- a/test/lib/forks/Zkevm.sol
+++ b/test/lib/forks/Zkevm.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {GenericFork} from "./Generic.sol";

--- a/test/lib/gas/GasTestBase.t.sol
+++ b/test/lib/gas/GasTestBase.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.18;
 

--- a/test/lib/gas/MangroveMeasureGasused.sol
+++ b/test/lib/gas/MangroveMeasureGasused.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {Mangrove} from "@mgv/src/core/Mangrove.sol";

--- a/test/lib/gas/OfferGasBaseBase.t.sol
+++ b/test/lib/gas/OfferGasBaseBase.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {console} from "@mgv/test/lib/MangroveTest.sol";

--- a/test/lib/gas/OfferGasReqBase.t.sol
+++ b/test/lib/gas/OfferGasReqBase.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {MangroveTest, MgvReader, TestTaker} from "@mgv/test/lib/MangroveTest.sol";

--- a/test/lib/gas/OfferPosthookFailGasDelta.t.sol
+++ b/test/lib/gas/OfferPosthookFailGasDelta.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {MangroveTest, MgvReader, TestMaker, TestTaker, TestSender, console} from "@mgv/test/lib/MangroveTest.sol";

--- a/test/lib/tokens/TestToken.sol
+++ b/test/lib/tokens/TestToken.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 // !!! Warning !!!
 // This is a faucet token contract with freely mintable token intended for testing purpose.
 // Do not use for value bearing tokens!

--- a/test/periphery/MgvOracle.t.sol
+++ b/test/periphery/MgvOracle.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 // pragma experimental ABIEncoderV2;

--- a/test/periphery/MgvReader.t.sol
+++ b/test/periphery/MgvReader.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.10;
 

--- a/test/preprocessed/GlobalTest.post.sol
+++ b/test/preprocessed/GlobalTest.post.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.13;
 

--- a/test/preprocessed/LocalTest.post.sol
+++ b/test/preprocessed/LocalTest.post.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.13;
 

--- a/test/preprocessed/MgvGlobalTest.post.sol
+++ b/test/preprocessed/MgvGlobalTest.post.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.13;
 

--- a/test/preprocessed/MgvLocalTest.post.sol
+++ b/test/preprocessed/MgvLocalTest.post.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.13;
 

--- a/test/preprocessed/MgvOfferDetailTest.post.sol
+++ b/test/preprocessed/MgvOfferDetailTest.post.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.13;
 

--- a/test/preprocessed/MgvOfferTest.post.sol
+++ b/test/preprocessed/MgvOfferTest.post.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.13;
 

--- a/test/preprocessed/OfferDetailTest.post.sol
+++ b/test/preprocessed/OfferDetailTest.post.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.13;
 

--- a/test/preprocessed/OfferTest.post.sol
+++ b/test/preprocessed/OfferTest.post.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.13;
 

--- a/test/script/core/DeactivateMarket.t.sol
+++ b/test/script/core/DeactivateMarket.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {Deployer} from "@mgv/script/lib/Deployer.sol";

--- a/test/script/core/UpdateMarket.t.sol
+++ b/test/script/core/UpdateMarket.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {Deployer} from "@mgv/script/lib/Deployer.sol";

--- a/test/script/core/deployers/BaseMangroveDeployer.t.sol
+++ b/test/script/core/deployers/BaseMangroveDeployer.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {Deployer} from "@mgv/script/lib/Deployer.sol";

--- a/test/script/core/deployers/MangroveDeployer.t.sol
+++ b/test/script/core/deployers/MangroveDeployer.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {Deployer} from "@mgv/script/lib/Deployer.sol";

--- a/test/script/core/deployers/MumbaiMangroveDeployer.t.sol
+++ b/test/script/core/deployers/MumbaiMangroveDeployer.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {Deployer} from "@mgv/script/lib/Deployer.sol";

--- a/test/script/core/deployers/PolygonMangroveDeployer.t.sol
+++ b/test/script/core/deployers/PolygonMangroveDeployer.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {Deployer} from "@mgv/script/lib/Deployer.sol";

--- a/test/script/periphery/CopyOpenSemibooks.t.sol
+++ b/test/script/periphery/CopyOpenSemibooks.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import {Deployer} from "@mgv/script/lib/Deployer.sol";

--- a/test/self/BitLib.t.sol
+++ b/test/self/BitLib.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.10;
 

--- a/test/self/Script2.t.sol
+++ b/test/self/Script2.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 pragma solidity ^0.8.10;
 

--- a/test/toy_strategies/TestToken.t.sol
+++ b/test/toy_strategies/TestToken.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.10;
 
 import "@mgv/test/lib/MangroveTest.sol";


### PR DESCRIPTION
- Change license of Contants.sol and TickLib.sol from BUSL-1.1 to MIT
- Replace Unlicense and BSD-2-Clause with MIT
- Replace AGPL-3.0 with AGPL-3.0-or-later
- Consistently use AGPL-3.0-or-later for tools, scripts, and tests
- Restore MIT license for OpenZeppelin code