### PR TITLE
feat(script): Default to MgvGovernance as chief in Mangrove deployers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next version
 
-- Upgrade to @mangrovedao/context-addresses v1.3.2 (contains Blast mainnet accounts)
+- Upgrade to @mangrovedao/context-addresses v1.3.4 (contains Blast mainnet addresses)
+- Upgrade to @mangrovedao/mangrove-deployments v2.2.2
 
 # 2.1.1
 

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "gas-measurement.sh"
   ],
   "devDependencies": {
-    "@mangrovedao/context-addresses": "^1.3.2",
-    "@mangrovedao/mangrove-deployments": "^2.1.1",
+    "@mangrovedao/context-addresses": "^1.3.4",
+    "@mangrovedao/mangrove-deployments": "^2.2.2",
     "@types/node": "^20.11.5",
     "bn.js": "^5.2.1",
     "husky": "^8.0.3",

--- a/script/core/deployers/BlastMangroveDeployer.s.sol
+++ b/script/core/deployers/BlastMangroveDeployer.s.sol
@@ -28,7 +28,7 @@ contract BlastMangroveDeployer is MangroveDeployer, StdCheats {
     blastPointsOperator = envAddressOrName("BLAST_POINTS_OPERATOR", "BlastPointsOperator");
 
     innerRun({
-      chief: envAddressOrName("CHIEF", broadcaster()),
+      chief: envAddressOrName("CHIEF", "MgvGovernance"),
       gasprice: envHas("GASPRICE") ? vm.envUint("GASPRICE") : 1,
       gasmax: envHas("GASMAX") ? vm.envUint("GASMAX") : 2_000_000,
       gasbot: envAddressOrName("GASBOT", "Gasbot"),

--- a/script/core/deployers/MangroveDeployer.s.sol
+++ b/script/core/deployers/MangroveDeployer.s.sol
@@ -15,7 +15,7 @@ contract MangroveDeployer is Deployer {
 
   function run() public virtual {
     innerRun({
-      chief: envAddressOrName("CHIEF", broadcaster()),
+      chief: envAddressOrName("CHIEF", "MgvGovernance"),
       gasprice: envHas("GASPRICE") ? vm.envUint("GASPRICE") : 1,
       gasmax: envHas("GASMAX") ? vm.envUint("GASMAX") : 2_000_000,
       gasbot: envAddressOrName("GASBOT", "Gasbot")

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,15 +104,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mangrovedao/context-addresses@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "@mangrovedao/context-addresses@npm:1.1.4"
-  dependencies:
-    semver: ^7.5.4
-  checksum: 358c1dda7d3453a748e91aa1b9bfbe3f8db9364495dc1a98e0d0f4e172db229fb9c17b12a102976935c5ef2886da3f943a86a0136498b69cd07ead34712d2930
-  languageName: node
-  linkType: hard
-
 "@mangrovedao/context-addresses@npm:^1.3.2":
   version: 1.3.2
   resolution: "@mangrovedao/context-addresses@npm:1.3.2"
@@ -122,12 +113,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mangrovedao/context-addresses@npm:^1.3.4":
+  version: 1.3.4
+  resolution: "@mangrovedao/context-addresses@npm:1.3.4"
+  dependencies:
+    semver: ^7.5.4
+  checksum: bbe6cd76dfdb4aa75f8502f58ef3edd841ccc3650f26be7fde887060070ef0968a457221e5640c8dbad9af6b9205d708a47e10a2e88b1372b1baa8708eb74435
+  languageName: node
+  linkType: hard
+
 "@mangrovedao/mangrove-core@workspace:.":
   version: 0.0.0-use.local
   resolution: "@mangrovedao/mangrove-core@workspace:."
   dependencies:
-    "@mangrovedao/context-addresses": ^1.3.2
-    "@mangrovedao/mangrove-deployments": ^2.1.1
+    "@mangrovedao/context-addresses": ^1.3.4
+    "@mangrovedao/mangrove-deployments": ^2.2.2
     "@types/node": ^20.11.5
     bn.js: ^5.2.1
     husky: ^8.0.3
@@ -146,13 +146,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@mangrovedao/mangrove-deployments@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "@mangrovedao/mangrove-deployments@npm:2.1.1"
+"@mangrovedao/mangrove-deployments@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "@mangrovedao/mangrove-deployments@npm:2.2.2"
   dependencies:
-    "@mangrovedao/context-addresses": ^1.1.4
+    "@mangrovedao/context-addresses": ^1.3.2
     semver: ^7.5.4
-  checksum: 0d97701d7f7f9b13f76e752474479544f5496eed01610c30c700c0f2710745fa1be5eb7fc4882bc5154091e6548a7b88198f23aa45de59c9823b1ed8caa3daf6
+  checksum: 1091750ff29aa741474804da48c1870ad601bfd4a34e4f901fc6a9d160ac47149b1fe05103dd239630fd3e93d281aaca28dd11b0c44bf268b697738b12a2dd45
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Previously, `tx.origin` would be used as chief, but this is inconsistent with the use of the named `MgvGovernance` address. Also, if the `CHIEF` env var was mistyped (we've seen this happen)  the script would still succeed, but use an unexpected address as governance.

Also update `context-addresses` and `mangrove-deployments` to the latest versions.